### PR TITLE
docs: add multi-agent support research and pre-spec (006)

### DIFF
--- a/specs/006-multi-agent-support/research.md
+++ b/specs/006-multi-agent-support/research.md
@@ -1,0 +1,494 @@
+# Research: Multi-Agent Support via ACP
+
+**Feature Branch**: `006-multi-agent-support`
+**Created**: 2026-02-05
+**Status**: Research / Pre-Spec
+
+## Problem Statement
+
+SAM currently supports only Claude Code as its coding agent. Users who prefer OpenAI Codex, Google Gemini CLI, or other coding agents cannot use the platform. To broaden SAM's appeal and avoid vendor lock-in, we need a multi-agent architecture that lets users choose which AI coding agent runs in their workspace — while keeping a single, unified web UI.
+
+## Prior Art: Happy Coder CLI
+
+Happy Coder (`happy-coder`, MIT License, by slopus) solves a related problem — wrapping multiple coding agents behind a single mobile/web interface. It currently supports Claude Code, OpenAI Codex, and Google Gemini CLI using **three different integration strategies**:
+
+### Happy Coder's Agent Integration Approaches
+
+| Agent | Integration Strategy | Protocol | How It Works |
+|-------|---------------------|----------|--------------|
+| **Claude Code** | Direct process spawn + file scanning | Custom (inherited stdio + JSONL log parsing) | Spawns `claude` as child process. In "local mode" stdio is inherited (user types directly). In "remote mode" uses `--print` / `--input-format stream-json` for programmatic control. Captures output by watching Claude's JSONL session log files on disk. |
+| **OpenAI Codex** | MCP client | Model Context Protocol (stdio transport) | Communicates with Codex via `CodexMcpClient` using MCP's JSON-RPC over stdio. Maps permission modes to Codex-specific sandbox/approval policies. |
+| **Google Gemini** | ACP backend | Agent Client Protocol (JSON-RPC/NDJSON over stdio) | Spawns `gemini --experimental-acp` which speaks ACP natively. Uses `@agentclientprotocol/sdk`'s `ClientSideConnection` for structured bidirectional communication. |
+
+### Happy Coder's Abstraction Layers
+
+Happy Coder uses a clean three-layer abstraction to normalize all agents:
+
+**Layer 1 — AgentBackend Interface** (universal contract):
+```typescript
+interface AgentBackend {
+    startSession(initialPrompt?: string): Promise<StartSessionResult>;
+    sendPrompt(sessionId, prompt): Promise<void>;
+    cancel(sessionId): Promise<void>;
+    onMessage(handler: AgentMessageHandler): void;
+    respondToPermission?(requestId, approved): Promise<void>;
+    dispose(): Promise<void>;
+}
+```
+
+**Layer 2 — TransportHandler** (agent-specific quirks):
+Handles stdout filtering, stderr parsing, tool name resolution, timeout tuning per agent.
+
+**Layer 3 — MessageAdapter** (normalization for the UI):
+Transforms internal `AgentMessage` into a common `MobileAgentMessage` format.
+
+### Happy Coder's Limitations for SAM
+
+- **Mobile-first relay architecture** — designed for encrypted bridge to phone, not web workspace management
+- **No orchestration** — sessions are independent; doesn't coordinate multiple agents
+- **Local-only** — agents run on the user's desktop, not in cloud VMs/devcontainers
+- **Terminal wrapping** — Claude integration relies on inherited stdio and file system watching, which works for a local CLI but doesn't map cleanly to a remote VM architecture
+
+---
+
+## Agent Client Protocol (ACP) Deep Dive
+
+ACP is the most promising standardization effort for our use case. Created by **Zed Industries** with **Google**, it's designed to be "LSP for AI coding agents."
+
+### Protocol Overview
+
+- **Transport**: JSON-RPC 2.0 over NDJSON (newline-delimited JSON) via stdio
+- **Version**: Protocol version `1` (stable core, pre-1.0 SDK at 0.14.x)
+- **License**: Apache 2.0
+
+### Key Protocol Methods
+
+**Client → Agent:**
+| Method | Purpose |
+|--------|---------|
+| `initialize` | Negotiate protocol version + capabilities |
+| `authenticate` | Auth flow (if agent requires it) |
+| `session/new` | Create conversation session |
+| `session/load` | Resume previous session |
+| `session/prompt` | Send user message |
+| `session/cancel` | Cancel ongoing turn |
+| `session/set_mode` | Switch mode (ask/architect/code) |
+
+**Agent → Client (notifications):**
+| Update Type | Purpose |
+|-------------|---------|
+| `agent_message_chunk` | Streaming text response |
+| `agent_thought_chunk` | Internal reasoning (extended thinking) |
+| `tool_call` | Tool execution started |
+| `tool_call_update` | Tool execution progress/result |
+| `usage_update` | Token usage |
+| `plan` | Agent's execution plan |
+
+**Agent → Client (requests):**
+| Method | Purpose |
+|--------|---------|
+| `session/request_permission` | Ask user to approve tool execution |
+| `fs/read_text_file` | Read file from client's filesystem |
+| `fs/write_text_file` | Write file to client's filesystem |
+| `terminal/create` | Execute command in terminal |
+| `terminal/output` | Get terminal output |
+
+### ACP Adoption (as of 2026-02)
+
+**Agents with ACP support:**
+- Claude Code (via ACP adapter)
+- Gemini CLI (native, `--experimental-acp`)
+- Codex CLI (via ACP adapter)
+- GitHub Copilot
+- Augment Code (Auggie CLI)
+- Mistral Vibe
+- OpenCode
+- Qwen Code
+- 30+ community agents
+
+**Editors with ACP client support:**
+- Zed (native)
+- JetBrains IDEs
+- Neovim (via plugins)
+- Emacs
+
+### ACP Maturity Assessment
+
+**Stable**: initialization, sessions, prompts, tool calls, permissions, file system access, terminal management, slash commands, modes, config options, extensions.
+
+**Unstable/Experimental**: session forking, session listing, session resuming, model selection, token usage tracking, request cancellation.
+
+**Missing for our use case**: Remote agent transport (HTTP/WebSocket) is explicitly listed as work-in-progress. The current spec assumes local subprocess stdio. We need to bridge this gap.
+
+---
+
+## SAM's Current Architecture (Relevant to Multi-Agent)
+
+### How Claude Code Currently Runs in SAM
+
+```
+Browser → Cloudflare → VM (Caddy reverse proxy)
+                          ├── VM Agent (Go, port 8080)
+                          │   ├── WebSocket terminal handler
+                          │   ├── PTY session manager
+                          │   ├── JWT auth + session cookies
+                          │   └── Idle detection + heartbeat
+                          │
+                          ├── CloudCLI UI (port 3001) [optional]
+                          │
+                          └── Devcontainer (Docker)
+                              ├── User's repo at /workspace
+                              └── Claude Code CLI (installed via devcontainer feature)
+```
+
+Key observations:
+1. **VM Agent is agent-agnostic** — it provides PTY access to a shell. It doesn't know about Claude Code.
+2. **Claude Code is installed in the devcontainer** via a devcontainer feature, not by the VM Agent.
+3. **The terminal component** (`packages/terminal`) renders raw PTY output via xterm.js + WebSocket. It has no understanding of agent-specific structured output.
+4. **The web UI** (`apps/web`) shows a generic terminal view. No agent-aware UI elements (tool call cards, permission dialogs, thinking indicators, etc.).
+
+### What We Gain from ACP
+
+If we move from "raw PTY terminal" to "ACP-aware UI", we can render:
+- **Structured agent responses** with markdown formatting
+- **Tool call cards** showing what the agent is doing (reading files, editing, running commands)
+- **Permission dialogs** allowing users to approve/reject tool executions
+- **Thinking indicators** showing the agent's reasoning process
+- **File diffs** inline when the agent edits code
+- **Token usage** tracking per session
+- **Agent mode switching** (ask/architect/code)
+
+This is a dramatically better UX than a raw terminal.
+
+---
+
+## Architecture Options
+
+### Option A: ACP-Native (Recommended)
+
+Run ACP as the primary protocol between the web UI and coding agents. The VM Agent becomes an ACP gateway.
+
+```
+┌────────────────────────────────────────────────┐
+│  Browser (SAM Web UI)                          │
+│  ┌──────────────────────────────────────────┐  │
+│  │  ACP Web Client                          │  │
+│  │  (React components for structured agent  │  │
+│  │   output, tool calls, permissions, etc.) │  │
+│  └──────────────┬───────────────────────────┘  │
+└─────────────────┼──────────────────────────────┘
+                  │ WebSocket (ACP-over-WS)
+                  │
+┌─────────────────┼──────────────────────────────┐
+│  VM (Host)      │                              │
+│  ┌──────────────┴───────────────────────────┐  │
+│  │  VM Agent (Go)                           │  │
+│  │  ┌────────────────────────────────────┐  │  │
+│  │  │  ACP WebSocket Gateway             │  │  │
+│  │  │  - Accepts WS from browser         │  │  │
+│  │  │  - Translates WS ↔ stdio NDJSON    │  │  │
+│  │  │  - Manages agent child process     │  │  │
+│  │  └────────────┬───────────────────────┘  │  │
+│  │               │ stdio (NDJSON)           │  │
+│  │  ┌────────────┴───────────────────────┐  │  │
+│  │  │  Agent Process (in devcontainer)   │  │  │
+│  │  │  - claude --acp                    │  │  │
+│  │  │  - gemini --experimental-acp       │  │  │
+│  │  │  - codex --acp                     │  │  │
+│  │  └────────────────────────────────────┘  │  │
+│  └──────────────────────────────────────────┘  │
+└────────────────────────────────────────────────┘
+```
+
+**Pros:**
+- Clean, standardized protocol end-to-end
+- Rich structured UI for all agents
+- As ACP matures, all agents automatically improve
+- Permission model built into protocol
+- File diffs, tool calls, thinking all come for free
+
+**Cons:**
+- Requires building ACP WebSocket transport (not yet in spec)
+- Agents that don't fully support ACP need adapter work
+- More complex VM Agent changes (Go ACP gateway)
+- ACP is still pre-1.0; breaking changes possible
+
+### Option B: PTY + Structured Sideband
+
+Keep the current PTY/terminal approach but add a structured sideband channel for agent metadata.
+
+```
+┌────────────────────────────────────────────────┐
+│  Browser                                       │
+│  ┌─────────────────┐  ┌────────────────────┐  │
+│  │  xterm.js        │  │  Agent Panel       │  │
+│  │  (raw terminal)  │  │  (tool calls,      │  │
+│  │                  │  │   permissions,     │  │
+│  │                  │  │   thinking, etc.)  │  │
+│  └────────┬─────────┘  └────────┬───────────┘  │
+└───────────┼─────────────────────┼──────────────┘
+            │ WS (terminal)       │ WS (sideband)
+            │                     │
+┌───────────┼─────────────────────┼──────────────┐
+│  VM Agent │                     │              │
+│  ┌────────┴──────┐  ┌──────────┴───────────┐  │
+│  │ PTY Manager   │  │ Agent Monitor        │  │
+│  │ (existing)    │  │ (watches logs,       │  │
+│  │               │  │  parses output,      │  │
+│  │               │  │  emits structured    │  │
+│  │               │  │  events)             │  │
+│  └───────────────┘  └──────────────────────┘  │
+└────────────────────────────────────────────────┘
+```
+
+**Pros:**
+- Simpler to implement incrementally
+- PTY terminal always works as fallback
+- Doesn't depend on ACP maturity
+- Can parse Claude's JSONL logs (like Happy Coder)
+
+**Cons:**
+- Agent-specific log parsing is fragile and breaks with updates
+- Two parallel channels (PTY + sideband) add complexity
+- Permission model must be custom-built per agent
+- Each new agent requires new parsing code
+
+### Option C: Hybrid (Recommended Starting Point)
+
+Start with ACP as the primary protocol, but keep PTY as a fallback for agents that don't speak ACP or when ACP breaks.
+
+```
+┌────────────────────────────────────────────────────────┐
+│  Browser (SAM Web UI)                                  │
+│  ┌──────────────────────────────────────────────────┐  │
+│  │  Workspace View                                  │  │
+│  │  ┌────────────────────┐ ┌─────────────────────┐  │  │
+│  │  │  ACP Agent Panel   │ │  Fallback Terminal  │  │  │
+│  │  │  (structured UI    │ │  (xterm.js PTY,     │  │  │
+│  │  │   when ACP works)  │ │   always available) │  │  │
+│  │  └────────┬───────────┘ └──────────┬──────────┘  │  │
+│  └───────────┼────────────────────────┼─────────────┘  │
+└──────────────┼────────────────────────┼────────────────┘
+               │ WS (ACP)              │ WS (PTY)
+               │                       │
+┌──────────────┼───────────────────────┼─────────────────┐
+│  VM Agent    │                       │                 │
+│  ┌───────────┴────────────┐  ┌───────┴──────────────┐  │
+│  │  ACP Gateway           │  │  PTY Manager         │  │
+│  │  - WS ↔ stdio bridge   │  │  (existing, unchanged│  │
+│  │  - Agent lifecycle     │  │   from current impl) │  │
+│  │  - Transport handler   │  │                      │  │
+│  │    per agent           │  │                      │  │
+│  └───────────┬────────────┘  └──────────────────────┘  │
+│              │ stdio (NDJSON)                           │
+│  ┌───────────┴────────────────────────────────────┐    │
+│  │  Devcontainer                                  │    │
+│  │  ┌──────────────┐                              │    │
+│  │  │ Agent Process │  claude --acp               │    │
+│  │  │              │  gemini --experimental-acp   │    │
+│  │  │              │  codex --acp                 │    │
+│  │  └──────────────┘                              │    │
+│  └────────────────────────────────────────────────┘    │
+└────────────────────────────────────────────────────────┘
+```
+
+**Pros:**
+- ACP provides the rich UI when available
+- PTY fallback ensures nothing breaks
+- Incremental migration path
+- Users can toggle between views
+
+**Cons:**
+- Two code paths to maintain (but PTY path already exists)
+- Slightly more complex VM Agent
+
+---
+
+## Key Technical Challenges
+
+### 1. ACP over WebSocket (Not Yet Standardized)
+
+ACP currently specifies stdio (NDJSON) as its transport. We need a WebSocket bridge. Two options:
+
+**a) VM Agent bridges WS ↔ stdio** (recommended):
+The Go VM Agent accepts WebSocket connections from the browser, spawns the agent process with piped stdio, and forwards NDJSON messages bidirectionally. This keeps the agent process unchanged.
+
+**b) Direct WS transport in agent**:
+Wait for ACP to standardize WebSocket transport. This is listed as work-in-progress and may land before we ship.
+
+### 2. Agent Process Lifecycle in Devcontainers
+
+Agents run inside the devcontainer (Docker), but the VM Agent runs on the host. We need to spawn and manage agent processes across this boundary:
+
+```bash
+# From VM Agent (host), execute in devcontainer:
+docker exec -it <container-id> claude --acp
+```
+
+Or use `devcontainer exec`:
+```bash
+devcontainer exec --workspace-folder /workspace -- claude --acp
+```
+
+This is how the current architecture would work — the VM Agent needs to spawn the agent process inside the devcontainer and pipe its stdio.
+
+### 3. Agent Installation
+
+Each agent needs to be available inside the devcontainer. Options:
+
+**a) Devcontainer features** (current approach for Claude):
+```json
+{
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
+    "ghcr.io/google/devcontainer-features/gemini-cli:1.0": {},
+    "ghcr.io/openai/devcontainer-features/codex:1.0": {}
+  }
+}
+```
+
+**b) Cloud-init post-install** (install after devcontainer up):
+```bash
+devcontainer exec -- npm install -g @anthropic-ai/claude-code
+devcontainer exec -- npm install -g @openai/codex
+devcontainer exec -- npm install -g @google/gemini-cli
+```
+
+**c) Only install the selected agent** (based on workspace config):
+Install only the agent the user chose when creating the workspace.
+
+Option (c) is most efficient — no point installing agents the user won't use.
+
+### 4. Agent Authentication / API Keys
+
+Each agent needs its own API key:
+- Claude Code → `ANTHROPIC_API_KEY`
+- Codex → `OPENAI_API_KEY`
+- Gemini CLI → Google auth (OAuth or `GEMINI_API_KEY`)
+
+These are user-provided credentials that should be:
+1. Stored encrypted per-user in the database (like Hetzner tokens currently)
+2. Injected into the devcontainer environment at startup
+3. Never exposed to the VM Agent or control plane
+
+### 5. Permission Model Differences
+
+ACP standardizes the permission flow, but agents have different permission semantics:
+
+| Agent | Permission Model |
+|-------|-----------------|
+| Claude Code | Tool-level approval (read/edit/execute), auto-approve rules |
+| Codex | Sandbox levels (workspace-write, full-access) + approval policies |
+| Gemini | Tool-level approval via ACP `request_permission` |
+
+ACP normalizes this to: `request_permission` → user chooses from `allow_once`, `reject_once`, etc. But the agent's behavior after approval may differ.
+
+### 6. Fallback Terminal for Non-ACP Agents
+
+Some agents may never support ACP, or users may want raw terminal access. The existing PTY/xterm.js infrastructure should remain available as a fallback — either as the primary view or as a secondary panel.
+
+---
+
+## Data Model Implications
+
+### Workspace Table Changes
+
+```sql
+ALTER TABLE workspaces ADD COLUMN agent_type TEXT NOT NULL DEFAULT 'claude-code';
+-- Values: 'claude-code', 'openai-codex', 'google-gemini', etc.
+
+ALTER TABLE workspaces ADD COLUMN agent_mode TEXT DEFAULT 'acp';
+-- Values: 'acp' (structured UI), 'pty' (raw terminal)
+```
+
+### Credentials Table Changes
+
+Currently stores Hetzner tokens. Needs to support agent API keys:
+
+```sql
+-- Existing: provider credentials (Hetzner)
+-- New: agent credentials
+ALTER TABLE credentials ADD COLUMN credential_type TEXT NOT NULL DEFAULT 'cloud-provider';
+-- Values: 'cloud-provider', 'agent-api-key'
+
+ALTER TABLE credentials ADD COLUMN agent_type TEXT;
+-- Values: 'claude-code', 'openai-codex', 'google-gemini'
+-- NULL for cloud-provider credentials
+```
+
+### Agent Registry (Configuration)
+
+```typescript
+interface AgentDefinition {
+  id: string;                    // 'claude-code'
+  name: string;                  // 'Claude Code'
+  acpCommand: string;            // 'claude'
+  acpArgs: string[];             // ['--acp']
+  devcontainerFeature?: string;  // 'ghcr.io/anthropics/devcontainer-features/claude-code:1.0'
+  installCommand?: string;       // 'npm install -g @anthropic-ai/claude-code'
+  envVarName: string;            // 'ANTHROPIC_API_KEY'
+  supportsAcp: boolean;          // true
+  transportQuirks?: {            // Agent-specific ACP behavior
+    initTimeout: number;         // Gemini needs 120s vs 30s default
+    stdoutFilter?: RegExp;       // Filter non-JSON output
+  };
+}
+```
+
+---
+
+## Scope for Spec
+
+Based on this research, the spec should cover:
+
+### Phase 1: ACP Gateway in VM Agent
+- Add ACP WebSocket endpoint to VM Agent (alongside existing PTY endpoint)
+- Implement stdio ↔ WebSocket bridge for ACP NDJSON
+- Agent process lifecycle management (spawn inside devcontainer, monitor, restart)
+- Transport handler abstraction for agent-specific quirks
+
+### Phase 2: ACP Web Client Components
+- React components for rendering ACP session updates
+- Structured message display (markdown, code blocks)
+- Tool call cards with status indicators
+- Permission request dialogs
+- Thinking/reasoning display
+- File diff viewer
+- Token usage display
+
+### Phase 3: Multi-Agent Workspace Configuration
+- Agent selection in workspace creation flow
+- Agent API key management in Settings
+- Per-agent devcontainer feature installation
+- Cloud-init template updates for agent-specific setup
+
+### Phase 4: Fallback & Resilience
+- PTY fallback when ACP fails or agent doesn't support it
+- Toggle between ACP view and raw terminal
+- Graceful degradation for unstable ACP features
+
+---
+
+## Open Questions
+
+1. **Should we support running multiple agents in the same workspace?** (e.g., Claude + Codex side by side) — Probably not for MVP, but the architecture shouldn't prevent it.
+
+2. **Should ACP be the only interface, or always paired with PTY?** — Recommend always keeping PTY available. ACP is pre-1.0 and agents may have bugs.
+
+3. **How do we handle agent updates?** — Agents are installed in the devcontainer. Users can rebuild to get updates, or we can auto-update on workspace restart.
+
+4. **Should we contribute to ACP's WebSocket transport spec?** — If we build a clean WS transport, contributing it upstream would benefit the ecosystem and ensure our implementation stays compatible.
+
+5. **Do we need agent-specific UI beyond what ACP provides?** — ACP is generic by design. Some agents have unique features (Claude's artifacts, Gemini's grounding) that ACP may not surface.
+
+---
+
+## References
+
+- [Agent Client Protocol (ACP)](https://agentclientprotocol.com) — Official website
+- [ACP GitHub](https://github.com/agentclientprotocol/agent-client-protocol) — Spec + SDKs
+- [@agentclientprotocol/sdk](https://www.npmjs.com/package/@agentclientprotocol/sdk) — TypeScript SDK
+- [Happy Coder CLI](https://github.com/slopus/happy-cli) — MIT-licensed multi-agent wrapper
+- [Happy Coder Mobile App](https://github.com/slopus/happy) — MIT-licensed companion app
+- [claude-squad](https://github.com/smtg-ai/claude-squad) — Multi-agent terminal manager
+- [Zed ACP Integration](https://zed.dev/acp) — Reference ACP client implementation

--- a/specs/006-multi-agent-support/spec.md
+++ b/specs/006-multi-agent-support/spec.md
@@ -1,0 +1,582 @@
+# Feature Specification: Multi-Agent Support via ACP
+
+**Feature Branch**: `006-multi-agent-support`
+**Created**: 2026-02-05
+**Status**: Draft (Pre-Spec)
+**Input**: Support multiple AI coding agents (Claude Code, OpenAI Codex, Google Gemini CLI) via the Agent Client Protocol, with agent-specific wrappers running inside devcontainers and a structured web UI.
+
+## Overview
+
+Extend SAM to support multiple AI coding agents — not just Claude Code — by adopting the Agent Client Protocol (ACP) as the communication standard between the web UI and agent processes. Users select their preferred agent when creating a workspace, provide their own API key, and get a rich structured UI (tool calls, permissions, thinking indicators, file diffs) instead of a raw terminal.
+
+**Key Design Principles**:
+1. **ACP-first, PTY-fallback** — Use ACP for structured agent communication; keep raw terminal as fallback
+2. **Agent runs in devcontainer** — Agent processes live inside Docker, managed by VM Agent on the host
+3. **VM Agent as ACP gateway** — Bridges WebSocket (browser) ↔ stdio NDJSON (agent process)
+4. **BYOK (Bring Your Own Key)** — Users provide their own API keys for each agent, stored encrypted
+5. **Incremental adoption** — Can ship ACP for one agent first, expand to others
+
+---
+
+## User Scenarios & Testing
+
+### User Story 1 — Choose an Agent When Creating a Workspace (Priority: P1)
+
+An authenticated user creates a workspace and selects which AI coding agent to use. The platform provisions the workspace with only the selected agent installed.
+
+**Why this priority**: Agent selection is the foundational UX change. Everything else builds on the user's choice of agent.
+
+**Independent Test**: User can see a list of supported agents in the workspace creation form, select one, and see the workspace created with that agent.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user on the Create Workspace page, **When** they view the agent selector, **Then** they see available agents (Claude Code, Codex, Gemini) with descriptions and icons
+2. **Given** a user selects "Google Gemini", **When** the workspace is provisioned, **Then** only the Gemini CLI is installed in the devcontainer (not Claude or Codex)
+3. **Given** a user has not configured an API key for the selected agent, **When** they try to create the workspace, **Then** they are prompted to add the required API key in Settings first
+4. **Given** a workspace is created with a specific agent, **When** the user views the workspace, **Then** the agent type is displayed in the workspace metadata
+
+---
+
+### User Story 2 — Manage Agent API Keys (Priority: P2)
+
+A user navigates to Settings and configures API keys for one or more coding agents. Keys are encrypted and stored per-user.
+
+**Why this priority**: Without API keys, agents cannot authenticate with their respective providers. This extends the existing BYOC credential model to agent credentials.
+
+**Independent Test**: User can add, view (masked), update, and remove API keys for each supported agent.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user on the Settings page, **When** they view the "Agent API Keys" section, **Then** they see a card for each supported agent with its connection status
+2. **Given** a user enters a valid Anthropic API key, **When** they click "Save", **Then** the key is encrypted and stored, and the card shows "Connected"
+3. **Given** a user has a saved API key, **When** they view it, **Then** only the last 4 characters are visible (e.g., `sk-ant-...7x9Q`)
+4. **Given** a user removes an API key, **When** they have running workspaces using that agent, **Then** they see a warning that those workspaces will lose agent access on restart
+
+---
+
+### User Story 3 — Structured Agent UI via ACP (Priority: P3)
+
+A user opens a running workspace and sees a rich, structured interface showing the agent's responses, tool calls, permission requests, and thinking process — instead of a raw terminal.
+
+**Why this priority**: This is the core UX improvement that ACP enables. A structured UI is dramatically better than watching raw terminal output.
+
+**Independent Test**: User can send a prompt, see streaming markdown response, see tool call cards, approve/reject tool permissions, and view file diffs — all in the browser.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running workspace with ACP-enabled agent, **When** the user opens the workspace, **Then** they see a chat-like interface with a prompt input and message history
+2. **Given** the user sends "read the README and summarize it", **When** the agent responds, **Then** the response streams in as formatted markdown with syntax-highlighted code blocks
+3. **Given** the agent wants to edit a file, **When** it requests permission, **Then** the user sees a permission dialog with the tool name, file path, and approve/reject buttons
+4. **Given** the agent edits a file, **When** the tool call completes, **Then** the user sees a diff view showing the changes made
+5. **Given** the agent is thinking, **When** extended thinking chunks arrive, **Then** a collapsible "Thinking..." section shows the agent's reasoning
+6. **Given** the agent runs a terminal command, **When** the command executes, **Then** the output appears in an embedded terminal block within the conversation
+
+---
+
+### User Story 4 — PTY Fallback Terminal (Priority: P4)
+
+A user can toggle between the structured ACP view and a raw PTY terminal at any time. If ACP fails to connect, the PTY terminal is shown automatically.
+
+**Why this priority**: ACP is pre-1.0 and agents may have bugs. Users need escape hatch to raw terminal access.
+
+**Independent Test**: User can switch between ACP view and PTY terminal, and if ACP connection drops, the terminal appears automatically.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user in the ACP view, **When** they click "Switch to Terminal", **Then** they see the familiar xterm.js terminal with a shell prompt
+2. **Given** the ACP connection fails during initialization, **When** the workspace loads, **Then** the PTY terminal is shown automatically with a banner: "Structured view unavailable — using terminal mode"
+3. **Given** a user in the PTY terminal, **When** they click "Switch to Agent View", **Then** they return to the structured ACP interface (session state is preserved on the agent side)
+4. **Given** an agent that does not support ACP, **When** the workspace opens, **Then** only the PTY terminal is available (no toggle shown)
+
+---
+
+### User Story 5 — Agent-Specific Configuration (Priority: P5)
+
+A user can configure agent-specific settings for their workspace, such as agent mode (ask/architect/code), auto-approve rules, and model selection.
+
+**Why this priority**: Power users need to configure agent behavior. ACP provides this through modes and config options.
+
+**Acceptance Scenarios**:
+
+1. **Given** an ACP-connected agent that supports modes, **When** the user opens the mode selector, **Then** they see available modes (e.g., "Ask", "Code", "Architect") as reported by the agent
+2. **Given** the user selects "Code" mode, **When** the mode changes, **Then** the agent switches behavior and the UI updates the mode indicator
+3. **Given** an agent that supports model selection, **When** the user opens model settings, **Then** they see available models from the agent's capabilities
+
+---
+
+## Technical Architecture
+
+### System Context
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Browser                                                 │
+│  ┌─────────────────────────────────────────────────────┐ │
+│  │  SAM Web UI                                         │ │
+│  │  ┌──────────────────┐  ┌─────────────────────────┐  │ │
+│  │  │  ACP Agent Panel │  │  PTY Terminal (fallback) │  │ │
+│  │  │  - Chat messages │  │  - xterm.js (existing)   │  │ │
+│  │  │  - Tool cards    │  │                          │  │ │
+│  │  │  - Permissions   │  │                          │  │ │
+│  │  │  - Diffs         │  │                          │  │ │
+│  │  │  - Thinking      │  │                          │  │ │
+│  │  └────────┬─────────┘  └────────┬────────────────┘  │ │
+│  └───────────┼─────────────────────┼────────────────────┘ │
+└──────────────┼─────────────────────┼─────────────────────┘
+               │ WS (ACP/JSON-RPC)   │ WS (PTY binary)
+               │                     │
+┌──────────────┼─────────────────────┼─────────────────────┐
+│  VM Host     │                     │                     │
+│  ┌───────────┴─────────────────────┴──────────────────┐  │
+│  │  VM Agent (Go binary)                              │  │
+│  │                                                    │  │
+│  │  ┌──────────────────────┐  ┌────────────────────┐  │  │
+│  │  │  ACP Gateway         │  │  PTY Manager       │  │  │
+│  │  │  - WS ↔ NDJSON      │  │  (existing,        │  │  │
+│  │  │  - Agent lifecycle   │  │   unchanged)       │  │  │
+│  │  │  - Transport handler │  │                    │  │  │
+│  │  └──────────┬───────────┘  └────────────────────┘  │  │
+│  └─────────────┼──────────────────────────────────────┘  │
+│                │ stdio (NDJSON via docker exec)           │
+│  ┌─────────────┼──────────────────────────────────────┐  │
+│  │  Devcontainer (Docker)                             │  │
+│  │  ┌──────────┴───────────────────────────────────┐  │  │
+│  │  │  Agent Process                               │  │  │
+│  │  │  - claude --acp                              │  │  │
+│  │  │  - gemini --experimental-acp                 │  │  │
+│  │  │  - codex --acp                               │  │  │
+│  │  │                                              │  │  │
+│  │  │  Environment:                                │  │  │
+│  │  │  - ANTHROPIC_API_KEY / OPENAI_API_KEY / etc. │  │  │
+│  │  │  - Workspace at /workspace                   │  │  │
+│  │  └──────────────────────────────────────────────┘  │  │
+│  └────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Component Responsibilities
+
+#### 1. ACP Gateway (New — in VM Agent, Go)
+
+The ACP Gateway is a new module in the VM Agent that:
+
+- **Accepts WebSocket connections** at `/agent/ws` (alongside existing `/terminal/ws` for PTY)
+- **Spawns agent processes** inside the devcontainer via `docker exec` with stdio piped
+- **Bridges transports**: reads NDJSON from agent's stdout, writes to WebSocket; reads WebSocket messages, writes NDJSON to agent's stdin
+- **Handles agent lifecycle**: start, monitor health, restart on crash, clean shutdown
+- **Implements transport handlers**: per-agent quirks (stdout filtering, init timeouts, tool name resolution)
+
+```go
+// New package: internal/acp/
+type Gateway struct {
+    agentType       string          // "claude-code", "openai-codex", "google-gemini"
+    agentCmd        string          // "claude"
+    agentArgs       []string        // ["--acp"]
+    containerID     string          // Docker container to exec into
+    process         *AgentProcess   // Running agent with piped stdio
+    idleDetector    *idle.Detector  // Shared with PTY manager
+    transport       TransportHandler // Agent-specific quirks
+}
+
+type TransportHandler interface {
+    InitTimeout() time.Duration
+    FilterStdoutLine(line string) (string, bool)  // Filter non-JSON output
+    HandleStderr(line string) error                // Parse agent errors
+}
+
+type AgentProcess struct {
+    cmd    *exec.Cmd
+    stdin  io.WriteCloser
+    stdout io.ReadCloser
+    stderr io.ReadCloser
+    done   chan struct{}
+}
+```
+
+**WebSocket Message Format**: Raw ACP JSON-RPC messages forwarded as WebSocket text frames. Each line of NDJSON becomes one WebSocket message. The browser's ACP client parses JSON-RPC directly.
+
+#### 2. ACP Web Client (New — React components in packages/acp-client)
+
+A new package providing React components that implement an ACP client in the browser:
+
+```
+packages/acp-client/
+├── src/
+│   ├── AcpProvider.tsx          # Context provider, manages WS connection
+│   ├── useAcpSession.ts         # Hook: initialize, prompt, cancel
+│   ├── useAcpMessages.ts        # Hook: streaming message state
+│   │
+│   ├── components/
+│   │   ├── AgentPanel.tsx        # Main panel (message list + input)
+│   │   ├── MessageBubble.tsx     # Single agent/user message
+│   │   ├── ToolCallCard.tsx      # Tool call with status, diff, output
+│   │   ├── PermissionDialog.tsx  # Approve/reject tool execution
+│   │   ├── ThinkingBlock.tsx     # Collapsible reasoning display
+│   │   ├── FileDiffView.tsx      # Side-by-side or unified diff
+│   │   ├── TerminalBlock.tsx     # Embedded terminal output in chat
+│   │   ├── UsageIndicator.tsx    # Token usage display
+│   │   └── ModeSelector.tsx      # Agent mode switcher
+│   │
+│   ├── transport/
+│   │   ├── websocket.ts          # WebSocket ↔ ACP JSON-RPC bridge
+│   │   └── types.ts              # ACP message types (from SDK schema)
+│   │
+│   └── index.ts
+├── package.json                  # Depends on @agentclientprotocol/sdk
+└── tsconfig.json
+```
+
+**Key Design Decision**: Use `@agentclientprotocol/sdk`'s type definitions but implement our own WebSocket transport (since the SDK only provides stdio transport). The SDK's `ClientSideConnection` expects a `Stream` interface — we implement that interface over WebSocket.
+
+```typescript
+// Custom WebSocket stream adapter for ACP SDK
+import { type Stream, ClientSideConnection } from '@agentclientprotocol/sdk';
+
+function createWebSocketStream(ws: WebSocket): Stream {
+  const readable = new ReadableStream({
+    start(controller) {
+      ws.onmessage = (event) => {
+        const message = JSON.parse(event.data);
+        controller.enqueue(message);
+      };
+      ws.onclose = () => controller.close();
+    }
+  });
+
+  const writable = new WritableStream({
+    write(message) {
+      ws.send(JSON.stringify(message));
+    }
+  });
+
+  return { readable, writable };
+}
+```
+
+#### 3. Agent Registry (New — in API + shared types)
+
+A configurable registry of supported agents:
+
+```typescript
+// packages/shared/src/agents.ts
+export interface AgentDefinition {
+  id: AgentType;
+  name: string;
+  description: string;
+  icon: string;                     // URL or icon identifier
+
+  // ACP integration
+  acpCommand: string;               // Binary name inside devcontainer
+  acpArgs: string[];                // Args to enable ACP mode
+  supportsAcp: boolean;
+
+  // Installation
+  devcontainerFeature?: string;     // Feature URI for devcontainer.json
+  installCommand?: string;          // Fallback: npm install command
+
+  // Credentials
+  envVarName: string;               // e.g., 'ANTHROPIC_API_KEY'
+  credentialLabel: string;          // e.g., 'Anthropic API Key'
+  credentialHelpUrl: string;        // Link to "get an API key" page
+
+  // Agent-specific transport config
+  initTimeoutMs: number;            // ACP init timeout
+  stdoutFilterPatterns?: string[];  // Regex patterns to strip from stdout
+}
+
+export type AgentType = 'claude-code' | 'openai-codex' | 'google-gemini';
+
+export const AGENT_REGISTRY: Record<AgentType, AgentDefinition> = {
+  'claude-code': {
+    id: 'claude-code',
+    name: 'Claude Code',
+    description: 'Anthropic\'s AI coding agent',
+    icon: 'claude',
+    acpCommand: 'claude',
+    acpArgs: ['--acp'],
+    supportsAcp: true,
+    devcontainerFeature: 'ghcr.io/anthropics/devcontainer-features/claude-code:1.0',
+    envVarName: 'ANTHROPIC_API_KEY',
+    credentialLabel: 'Anthropic API Key',
+    credentialHelpUrl: 'https://console.anthropic.com/settings/keys',
+    initTimeoutMs: 30000,
+  },
+  'openai-codex': {
+    id: 'openai-codex',
+    name: 'Codex',
+    description: 'OpenAI\'s coding agent',
+    icon: 'openai',
+    acpCommand: 'codex',
+    acpArgs: ['--acp'],
+    supportsAcp: true,
+    installCommand: 'npm install -g @openai/codex',
+    envVarName: 'OPENAI_API_KEY',
+    credentialLabel: 'OpenAI API Key',
+    credentialHelpUrl: 'https://platform.openai.com/api-keys',
+    initTimeoutMs: 30000,
+  },
+  'google-gemini': {
+    id: 'google-gemini',
+    name: 'Gemini CLI',
+    description: 'Google\'s AI coding agent',
+    icon: 'gemini',
+    acpCommand: 'gemini',
+    acpArgs: ['--experimental-acp'],
+    supportsAcp: true,
+    installCommand: 'npm install -g @google/gemini-cli',
+    envVarName: 'GEMINI_API_KEY',
+    credentialLabel: 'Gemini API Key',
+    credentialHelpUrl: 'https://aistudio.google.com/apikey',
+    initTimeoutMs: 120000,  // Gemini needs longer init
+    stdoutFilterPatterns: ['^(?!\\{)'],  // Filter non-JSON debug output
+  },
+};
+```
+
+#### 4. Cloud-Init & Devcontainer Changes
+
+The cloud-init template needs to:
+1. Accept `agent_type` as a template variable
+2. Install only the selected agent's CLI in the devcontainer
+3. Pass the agent's API key as a container environment variable
+4. Configure the VM Agent with the agent type and ACP command
+
+```yaml
+# Cloud-init additions (template variables)
+# {{ agent_type }}     - 'claude-code', 'openai-codex', 'google-gemini'
+# {{ agent_command }}  - 'claude', 'codex', 'gemini'
+# {{ agent_args }}     - '--acp', '--experimental-acp'
+# {{ agent_api_key }}  - User's encrypted API key (decrypted at boot)
+
+# VM Agent systemd environment additions:
+Environment=AGENT_TYPE={{ agent_type }}
+Environment=AGENT_COMMAND={{ agent_command }}
+Environment=AGENT_ARGS={{ agent_args }}
+```
+
+#### 5. Credential Flow
+
+```
+User saves API key          API encrypts & stores       Workspace created
+in Settings UI        →     in D1 (per-user)      →    with agent_type
+                                                              │
+                                                              ▼
+                                                    Cloud-init fetches
+                                                    encrypted key via
+                                                    bootstrap token
+                                                              │
+                                                              ▼
+                                                    VM Agent decrypts
+                                                    and injects into
+                                                    devcontainer env
+                                                              │
+                                                              ▼
+                                                    Agent process reads
+                                                    ANTHROPIC_API_KEY /
+                                                    OPENAI_API_KEY / etc.
+```
+
+---
+
+## Data Model Changes
+
+### Workspaces Table
+
+```sql
+-- Add agent_type column
+ALTER TABLE workspaces ADD COLUMN agent_type TEXT NOT NULL DEFAULT 'claude-code';
+-- CHECK constraint: agent_type IN ('claude-code', 'openai-codex', 'google-gemini')
+```
+
+### Credentials Table
+
+```sql
+-- Extend to support agent API keys alongside cloud provider tokens
+ALTER TABLE credentials ADD COLUMN credential_type TEXT NOT NULL DEFAULT 'cloud-provider';
+-- Values: 'cloud-provider', 'agent-api-key'
+
+ALTER TABLE credentials ADD COLUMN agent_type TEXT;
+-- NULL for cloud-provider credentials
+-- 'claude-code', 'openai-codex', 'google-gemini' for agent keys
+```
+
+### API Changes
+
+**New/Modified Endpoints:**
+
+| Method | Path | Change |
+|--------|------|--------|
+| `POST /api/workspaces` | Add `agentType` to request body | New field |
+| `GET /api/workspaces/:id` | Include `agentType` in response | New field |
+| `PUT /api/credentials/agent` | Save agent API key | New endpoint |
+| `GET /api/credentials/agent` | List agent API keys (masked) | New endpoint |
+| `DELETE /api/credentials/agent/:agentType` | Remove agent API key | New endpoint |
+| `GET /api/agents` | List supported agents with metadata | New endpoint |
+
+**WebSocket Endpoints (VM Agent):**
+
+| Path | Protocol | Purpose |
+|------|----------|---------|
+| `/terminal/ws` | Binary (PTY) | Existing raw terminal access |
+| `/agent/ws` | Text (ACP JSON-RPC) | New structured agent communication |
+
+---
+
+## ACP Message Flow (Detailed)
+
+### Session Initialization
+
+```
+Browser                    VM Agent                Agent Process
+  │                          │                        │
+  │── WS connect ───────────►│                        │
+  │   /agent/ws?token=JWT    │                        │
+  │                          │── docker exec ────────►│
+  │                          │   claude --acp         │
+  │                          │   (pipes stdio)        │
+  │                          │                        │
+  │── initialize ──────────►│── (NDJSON) ──────────►│
+  │   {protocolVersion: 1,   │                        │
+  │    capabilities: {...}}  │                        │
+  │                          │◄── InitializeResult ───│
+  │◄── InitializeResult ────│   {capabilities,       │
+  │                          │    authMethods}        │
+  │                          │                        │
+  │── session/new ─────────►│── (NDJSON) ──────────►│
+  │   {cwd: "/workspace"}   │                        │
+  │                          │◄── NewSessionResult ───│
+  │◄── NewSessionResult ────│   {sessionId, modes}   │
+```
+
+### Prompt Turn with Tool Call
+
+```
+Browser                    VM Agent                Agent Process
+  │                          │                        │
+  │── session/prompt ──────►│── (NDJSON) ──────────►│
+  │   {prompt: "fix the     │                        │
+  │    bug in main.ts"}     │                        │
+  │                          │                        │
+  │                          │◄── session/update ─────│
+  │◄── session/update ──────│   (agent_thought_chunk) │
+  │   "Let me look at..."   │                        │
+  │                          │                        │
+  │                          │◄── session/update ─────│
+  │◄── session/update ──────│   (tool_call:          │
+  │   📁 Read main.ts       │    kind: "read")       │
+  │                          │                        │
+  │                          │◄── session/update ─────│
+  │◄── session/update ──────│   (tool_call_update:   │
+  │   📁 Read main.ts ✓     │    status: completed)  │
+  │                          │                        │
+  │                          │◄── session/update ─────│
+  │◄── session/update ──────│   (tool_call:          │
+  │   ✏️ Edit main.ts       │    kind: "edit")       │
+  │                          │                        │
+  │                          │◄── request_permission ─│
+  │◄── request_permission ──│   "Allow edit of       │
+  │   [Approve] [Reject]    │    main.ts?"           │
+  │                          │                        │
+  │── permission_response ─►│── (NDJSON) ──────────►│
+  │   {approved: true}      │                        │
+  │                          │                        │
+  │                          │◄── session/update ─────│
+  │◄── session/update ──────│   (tool_call_update:   │
+  │   ✏️ Edit main.ts ✓     │    status: completed,  │
+  │   [diff view]           │    diff: {...})        │
+  │                          │                        │
+  │                          │◄── session/update ─────│
+  │◄── session/update ──────│   (agent_message_chunk)│
+  │   "I fixed the bug..."  │                        │
+  │                          │                        │
+  │                          │◄── PromptResponse ─────│
+  │◄── PromptResponse ──────│   {stopReason:         │
+  │                          │    "end_turn"}         │
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: ACP Gateway in VM Agent
+**Goal**: VM Agent can spawn an ACP agent process and bridge its stdio to a WebSocket.
+
+- Add `internal/acp/` package to VM Agent
+- Implement `Gateway` struct with agent process lifecycle
+- Implement WebSocket endpoint at `/agent/ws`
+- Implement NDJSON ↔ WebSocket message bridging
+- Add `TransportHandler` interface for agent-specific quirks
+- Add `AGENT_TYPE`, `AGENT_COMMAND`, `AGENT_ARGS` env vars to config
+- Implement `docker exec` spawning for devcontainer processes
+- Integration test: spawn Claude with `--acp`, send `initialize`, get response
+
+### Phase 2: ACP Web Client
+**Goal**: Browser can display a structured agent conversation.
+
+- Create `packages/acp-client` package
+- Implement WebSocket ↔ ACP Stream adapter
+- Build `AcpProvider` context with connection management
+- Build `useAcpSession` hook (initialize, prompt, cancel)
+- Build core UI components (AgentPanel, MessageBubble, ToolCallCard)
+- Build PermissionDialog component
+- Build ThinkingBlock component
+- Build FileDiffView component
+- Build TerminalBlock component (for `terminal/create` tool calls)
+- Integration test: full prompt → response → tool call → permission cycle
+
+### Phase 3: Multi-Agent Configuration
+**Goal**: Users can select agents and manage API keys.
+
+- Add `agent_type` column to workspaces table + migration
+- Add agent credential storage (extend credentials table)
+- Build agent selection UI in Create Workspace form
+- Build agent API key management in Settings page
+- Update cloud-init template to accept agent_type
+- Update devcontainer setup to install only selected agent
+- Update credential flow to inject agent API key into devcontainer env
+- Add `GET /api/agents` endpoint returning registry
+
+### Phase 4: PTY Fallback & Polish
+**Goal**: Robust fallback and production readiness.
+
+- Add view toggle (ACP ↔ Terminal) to workspace page
+- Auto-fallback to PTY when ACP connection fails
+- Session persistence across reconnects
+- Token usage display
+- Agent mode selector
+- Error recovery for agent crashes (auto-restart with backoff)
+- Idle detection integration (ACP activity counts as user activity)
+
+---
+
+## Dependencies & Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| ACP protocol breaking changes (pre-1.0) | UI components break | Pin SDK version, abstract behind our own types |
+| Agent doesn't start in ACP mode | Workspace unusable | Auto-fallback to PTY terminal |
+| Agent-specific ACP quirks | Unreliable behavior | TransportHandler abstraction per agent |
+| WebSocket transport not in ACP spec | Non-standard transport | Implement as thin bridge (WS frames = NDJSON lines) |
+| Agent API key security | Key exposure | Same encryption as Hetzner tokens (AES-GCM, per-user) |
+| Docker exec stdio latency | Sluggish UI | Benchmark; consider direct container networking if needed |
+
+---
+
+## Out of Scope (for initial version)
+
+- **Multi-agent orchestration**: Running multiple agents cooperating on the same task
+- **Agent marketplace**: Third-party agents beyond the initial three
+- **Session history persistence**: Saving and resuming ACP sessions across workspace restarts
+- **Voice interaction**: Audio content blocks in ACP
+- **Agent-to-agent communication**: A2A protocol support
+- **Custom agent configurations**: Per-workspace agent settings files (`.claude/settings.json` etc.)
+
+---
+
+## Technologies
+
+- **Protocol**: Agent Client Protocol (ACP) v1, JSON-RPC 2.0 over NDJSON
+- **SDK**: `@agentclientprotocol/sdk` (TypeScript, for types and protocol constants)
+- **VM Agent**: Go 1.22+ (new `internal/acp/` package)
+- **Web Client**: React + TypeScript (new `packages/acp-client/` package)
+- **Transport**: WebSocket (browser ↔ VM Agent) + stdio NDJSON (VM Agent ↔ agent process)


### PR DESCRIPTION
Research Happy Coder CLI's multi-agent wrapper patterns and the Agent
Client Protocol (ACP) to determine how SAM can support Claude Code,
OpenAI Codex, and Google Gemini CLI through a unified web UI.

Key findings:
- ACP (by Zed Industries + Google) is the emerging standard for
  client-agent communication, analogous to LSP for language servers
- Happy Coder uses three integration strategies: process spawning
  (Claude), MCP (Codex), and ACP (Gemini) — normalized via an
  AgentBackend interface
- SAM's VM Agent can act as an ACP gateway, bridging WebSocket
  (browser) to stdio NDJSON (agent process in devcontainer)
- ACP enables rich structured UI: tool call cards, permission
  dialogs, thinking indicators, file diffs — vs raw terminal

The pre-spec proposes a hybrid architecture: ACP-first with PTY
fallback, phased from gateway to web client to multi-agent config.

https://claude.ai/code/session_01BDisbbbQgZ9JrYJQd99fh6