### PR TITLE
fix: only count user input as activity for idle detection

### DIFF
--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -595,27 +595,26 @@ workspacesRoutes.post('/:id/heartbeat', async (c) => {
     throw errors.notFound('Workspace');
   }
 
-  // Update last activity if there's activity
-  if (body.hasActivity) {
+  // Use the VM's reported lastActivityAt (authoritative) to update the control plane's view.
+  // The VM agent tracks actual user input activity locally and reports it here.
+  if (body.lastActivityAt) {
     await db
       .update(schema.workspaces)
-      .set({ lastActivityAt: now, updatedAt: now })
+      .set({
+        lastActivityAt: body.lastActivityAt,
+        shutdownDeadline: body.shutdownDeadline ?? null,
+        updatedAt: now,
+      })
       .where(eq(schema.workspaces.id, workspaceId));
   }
 
-  // Check if idle timeout reached
-  // NOTE: VMs self-terminate based on local idle detection. The 'shutdown' action
-  // here is informational/suggestive. VMs don't depend on the control plane being
-  // available to shut down when idle.
-  const lastActivity = wsHeartbeat.lastActivityAt
-    ? new Date(wsHeartbeat.lastActivityAt)
-    : new Date(wsHeartbeat.createdAt);
-  const idleSeconds = (Date.now() - lastActivity.getTime()) / 1000;
+  // Use VM-reported idle time (authoritative) for the response
+  const idleSeconds = body.idleSeconds ?? 0;
   const shouldShutdown = idleSeconds >= idleTimeoutSeconds;
 
-  // Calculate shutdown deadline (when idle timeout will be reached)
-  const remainingSeconds = Math.max(0, idleTimeoutSeconds - idleSeconds);
-  const shutdownDeadline = new Date(Date.now() + remainingSeconds * 1000).toISOString();
+  // Use VM-reported deadline, or compute a fallback
+  const shutdownDeadline = body.shutdownDeadline
+    ?? new Date(Date.now() + Math.max(0, idleTimeoutSeconds - idleSeconds) * 1000).toISOString();
 
   const response: HeartbeatResponse = {
     action: shouldShutdown ? 'shutdown' : 'continue',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -165,7 +165,7 @@ export interface HeartbeatRequest {
   idleSeconds: number;
   idle: boolean;
   lastActivityAt: string;
-  hasActivity?: boolean; // If there was activity since last heartbeat
+  shutdownDeadline?: string;
 }
 
 export interface HeartbeatResponse {

--- a/packages/vm-agent/internal/server/websocket.go
+++ b/packages/vm-agent/internal/server/websocket.go
@@ -195,7 +195,8 @@ func (s *Server) handleTerminalWS(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			if n > 0 {
-				s.idleDetector.RecordActivity()
+				// Don't record PTY output as activity - background processes
+				// and shell prompts would prevent idle shutdown
 				outputData, _ := json.Marshal(map[string]string{"data": string(buf[:n])})
 				writeMu.Lock()
 				err = conn.WriteJSON(wsMessage{Type: "output", Data: outputData})
@@ -246,7 +247,8 @@ func (s *Server) handleTerminalWS(w http.ResponseWriter, r *http.Request) {
 			}
 
 		case "ping":
-			s.idleDetector.RecordActivity()
+			// Don't record activity for pings - they're automatic heartbeats
+			// sent every 30s regardless of user interaction
 			writeMu.Lock()
 			_ = conn.WriteJSON(wsMessage{Type: "pong"})
 			writeMu.Unlock()
@@ -344,7 +346,8 @@ func (s *Server) handleMultiTerminalWS(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 					if n > 0 {
-						s.idleDetector.RecordActivity()
+						// Don't record PTY output as activity - background processes
+						// and shell prompts would prevent idle shutdown
 						outputData, _ := json.Marshal(map[string]string{"data": string(buf[:n])})
 						writeMu.Lock()
 						err = conn.WriteJSON(wsMessage{
@@ -536,7 +539,8 @@ func (s *Server) handleMultiTerminalWS(w http.ResponseWriter, r *http.Request) {
 			writeMu.Unlock()
 
 		case "ping":
-			s.idleDetector.RecordActivity()
+			// Don't record activity for pings - they're automatic heartbeats
+			// sent every 30s regardless of user interaction
 			writeMu.Lock()
 			_ = conn.WriteJSON(wsMessage{Type: "pong", SessionID: msg.SessionID})
 			writeMu.Unlock()


### PR DESCRIPTION
## Summary

Workspaces were never shutting down on idle because automatic ping heartbeats (every 30s) and PTY output from background processes were both resetting the idle timer. A workspace set to 5 minutes would stay alive indefinitely.

**Root cause**: The VM agent treated three types of events as "activity":
1. **User input** (typing in terminal) - correct
2. **Ping messages** (automatic 30s browser heartbeats) - WRONG
3. **PTY output** (any shell output including prompts, cron, logs) - WRONG

Now only explicit user terminal input and ACP agent messages count as activity.

Also fixes the heartbeat endpoint to use the VM's authoritative `lastActivityAt` and `shutdownDeadline` instead of computing stale values on the control plane side.

## Validation
- [x] `pnpm lint` (no new warnings)
- [x] `pnpm typecheck`
- [x] `pnpm test` (all pass)
- [x] `go build ./...` (compiles)
- [x] `go test ./...` (all pass)

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [x] cross-component-change
- [x] business-logic-change
- [ ] public-surface-change
- [ ] docs-sync-change
- [ ] security-sensitive-change
- [ ] ui-change
- [ ] infra-change

### External References

N/A: Bug fix based on observed production behavior (workspace not shutting down after 25 minutes with 5-minute timeout)

### Codebase Impact Analysis

- `packages/vm-agent/internal/server/websocket.go` - Removed RecordActivity() from ping handlers and PTY output readers in both single-terminal and multi-terminal WebSocket handlers
- `apps/api/src/routes/workspaces.ts` - Heartbeat endpoint now uses VM-reported lastActivityAt/shutdownDeadline instead of computing locally
- `packages/shared/src/types.ts` - Replaced unused `hasActivity` field with `shutdownDeadline` in HeartbeatRequest

### Documentation & Specs

N/A: No interface changes - internal behavior fix only

### Constitution & Risk Check

- Principle XI: No hardcoded values affected - idle timeout remains configurable
- Risk: With only user input as activity, a long-running process with no user interaction will trigger idle shutdown. This is the correct behavior - users who need long-running processes should set a longer timeout or disable it.

<!-- AGENT_PREFLIGHT_END -->

## Test plan
- [x] Go code compiles and tests pass
- [x] TypeScript builds and tests pass
- [ ] Deploy and test: create workspace with 5-min timeout, close tab, verify it shuts down after 5 minutes
- [ ] Verify typing in terminal resets the idle timer correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)