### PR TITLE
fix: don't kill agent during idle shutdown, use per-workspace timeout

### DIFF
--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -603,7 +603,7 @@ workspacesRoutes.post('/:id/heartbeat', async (c) => {
   const body = await c.req.json<HeartbeatRequest>();
   const db = drizzle(c.env.DATABASE, { schema });
   const now = new Date().toISOString();
-  const idleTimeoutSeconds = getIdleTimeoutSeconds(c.env);
+  const globalIdleTimeoutSeconds = getIdleTimeoutSeconds(c.env);
 
   const workspaces = await db
     .select()
@@ -615,6 +615,9 @@ workspacesRoutes.post('/:id/heartbeat', async (c) => {
   if (!wsHeartbeat) {
     throw errors.notFound('Workspace');
   }
+
+  // Use per-workspace idle timeout if set, otherwise fall back to global default
+  const idleTimeoutSeconds = wsHeartbeat.idleTimeoutSeconds ?? globalIdleTimeoutSeconds;
 
   // Use the VM's reported lastActivityAt (authoritative) to update the control plane's view.
   // The VM agent tracks actual user input activity locally and reports it here.


### PR DESCRIPTION
## Summary

Two bugs prevented VMs from shutting down on idle timeout:

1. **`systemctl disable --now` kills the running agent**: PR #19 added `systemctl disable --now vm-agent` to prevent restart loops, but `--now` sends SIGTERM to the running process - killing the agent before it can call `/request-shutdown`. Fixed by removing `--now` so we only disable the service (prevent restart) without stopping it.

2. **Heartbeat uses global timeout instead of per-workspace**: The heartbeat endpoint compared idle time against `getIdleTimeoutSeconds(c.env)` (global 1800s default) instead of the workspace's `idle_timeout_seconds`. Workspaces with custom short timeouts (e.g., 300s) never received `action: "shutdown"` from the control plane.

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (38 TS tests + 5 Go test packages pass)
- [x] `go build ./...` and `go test ./...` pass
- [ ] Additional validation run (if applicable)
- [x] Mobile and desktop verification notes added for UI changes — N/A, no UI changes

## Exceptions (If any)

- Scope: N/A
- Rationale: N/A
- Expiration: N/A

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [x] cross-component-change
- [x] business-logic-change
- [ ] public-surface-change
- [ ] docs-sync-change
- [ ] security-sensitive-change
- [ ] ui-change
- [ ] infra-change

### External References

N/A: Bug fix based on live testing observation. Created a workspace with 5-minute idle timeout using Playwright, observed VM stayed running 10+ minutes past deadline. Root cause identified by tracing `systemctl disable --now` behavior (sends SIGTERM) and heartbeat endpoint code path.

### Codebase Impact Analysis

- `packages/vm-agent/main.go` — Changed `systemctl disable --now vm-agent` to `systemctl disable vm-agent` (remove --now flag that kills our own process)
- `apps/api/src/routes/workspaces.ts` — Heartbeat endpoint now reads `wsHeartbeat.idleTimeoutSeconds` (per-workspace) instead of only using global `getIdleTimeoutSeconds(c.env)`

### Documentation & Specs

N/A: No behavior changes to documented interfaces. The idle timeout was already documented as per-workspace configurable; this fix makes the heartbeat endpoint honor that setting.

### Constitution & Risk Check

- **Principle XI (No Hardcoded Values)**: Verified - uses per-workspace DB value with global env var fallback, no new hardcoded values introduced.
- **Risk**: Minimal - only changes shutdown flow timing (disable vs disable+stop) and uses existing DB column for timeout comparison.

<!-- AGENT_PREFLIGHT_END -->

🤖 Generated with [Claude Code](https://claude.ai/code)