### PR TITLE
fix: use systemctl mask to prevent agent restart after idle shutdown

### DIFF
--- a/packages/vm-agent/main.go
+++ b/packages/vm-agent/main.go
@@ -78,17 +78,16 @@ func main() {
 	// If this was an idle shutdown, request deletion from control plane
 	// This ensures proper cleanup of Hetzner resources and DNS records
 	if idleShutdown && cfg.ControlPlaneURL != "" && cfg.WorkspaceID != "" && cfg.CallbackToken != "" {
-		// Disable systemd restart so that systemd does not restart the agent
-		// after this process exits. Without this, systemd's Restart=always
-		// policy would restart the agent, which calls /ready (resetting
-		// lastActivityAt) and creates an infinite shutdown loop.
-		// NOTE: We use "disable" WITHOUT "--now" because --now would send
-		// SIGTERM to our own process, killing us before we can call
-		// /request-shutdown below.
-		if out, err := exec.Command("systemctl", "disable", "vm-agent").CombinedOutput(); err != nil {
-			log.Printf("Warning: failed to disable vm-agent service: %v: %s", err, string(out))
+		// Mask the systemd service to prevent ALL restarts (including Restart=always).
+		// "systemctl disable" only prevents boot-time auto-start but does NOT
+		// prevent runtime restarts from Restart=always. "systemctl mask" creates
+		// a symlink to /dev/null that blocks the service from starting by any
+		// mechanism. Unlike "disable --now", mask does not send SIGTERM to the
+		// running process, so we can finish our cleanup below.
+		if out, err := exec.Command("systemctl", "mask", "vm-agent").CombinedOutput(); err != nil {
+			log.Printf("Warning: failed to mask vm-agent service: %v: %s", err, string(out))
 		} else {
-			log.Println("Disabled vm-agent systemd service to prevent restart after idle shutdown")
+			log.Println("Masked vm-agent systemd service to prevent restart after idle shutdown")
 		}
 
 		log.Println("Requesting VM deletion from control plane due to idle timeout...")


### PR DESCRIPTION
## Summary

Follow-up to PR #20. `systemctl disable` only prevents boot-time auto-start but does NOT prevent runtime restarts from `Restart=always`. Live Playwright testing confirmed the agent was still being restarted after idle shutdown — activity timestamp was reset at the exact moment the idle deadline passed.

Changed from `systemctl disable vm-agent` to `systemctl mask vm-agent`, which creates a symlink to `/dev/null` that blocks the service from starting by ANY mechanism, including `Restart=always`. Unlike `disable --now`, mask does not SIGTERM the running process.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `go build ./...` and `go test ./...`
- [x] Live Playwright test confirmed the bug (activity reset at deadline time)

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [x] business-logic-change

### External References

N/A: systemd behavior verified from live test observation.

### Codebase Impact Analysis

- `packages/vm-agent/main.go` — `systemctl disable vm-agent` → `systemctl mask vm-agent`

### Documentation & Specs

N/A: No interface changes.

### Constitution & Risk Check

- **Principle XI**: No new hardcoded values.
- **Risk**: Minimal — `mask` is strictly more preventive than `disable`.

<!-- AGENT_PREFLIGHT_END -->