### PR TITLE
fix: block forever after idle shutdown to prevent systemd restart loop

### DIFF
--- a/packages/vm-agent/main.go
+++ b/packages/vm-agent/main.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"os/exec"
 	"os/signal"
 	"syscall"
 	"time"
@@ -78,18 +77,6 @@ func main() {
 	// If this was an idle shutdown, request deletion from control plane
 	// This ensures proper cleanup of Hetzner resources and DNS records
 	if idleShutdown && cfg.ControlPlaneURL != "" && cfg.WorkspaceID != "" && cfg.CallbackToken != "" {
-		// Mask the systemd service to prevent ALL restarts (including Restart=always).
-		// "systemctl disable" only prevents boot-time auto-start but does NOT
-		// prevent runtime restarts from Restart=always. "systemctl mask" creates
-		// a symlink to /dev/null that blocks the service from starting by any
-		// mechanism. Unlike "disable --now", mask does not send SIGTERM to the
-		// running process, so we can finish our cleanup below.
-		if out, err := exec.Command("systemctl", "mask", "vm-agent").CombinedOutput(); err != nil {
-			log.Printf("Warning: failed to mask vm-agent service: %v: %s", err, string(out))
-		} else {
-			log.Println("Masked vm-agent systemd service to prevent restart after idle shutdown")
-		}
-
 		log.Println("Requesting VM deletion from control plane due to idle timeout...")
 
 		payload := map[string]interface{}{
@@ -123,9 +110,14 @@ func main() {
 			}
 		}
 
-		// Give the control plane time to process the deletion request
-		// This helps ensure logs are captured before the VM is deleted
-		time.Sleep(5 * time.Second)
+		// Block forever after requesting shutdown. If we exit, systemd's
+		// Restart=always will restart the agent, which calls /ready and
+		// resets lastActivityAt — creating an infinite shutdown loop.
+		// Neither `systemctl disable` nor `systemctl mask` reliably prevent
+		// runtime restarts without daemon-reload. Since the VM will be
+		// deleted by the control plane, there's no reason to exit.
+		log.Println("Shutdown requested — blocking until VM is deleted")
+		select {}
 	}
 
 	log.Println("VM Agent stopped")


### PR DESCRIPTION
## Summary

Final fix for the systemd restart loop that prevents VMs from shutting down on idle.

**Root cause**: After the agent detects idle timeout and sends `/request-shutdown`, it exits. Systemd's `Restart=always` restarts the agent, which calls `/ready` and resets `lastActivityAt`. This creates an infinite cycle where the agent never stays down.

**Previous attempts** (PRs #19, #20, #21):
- `systemctl disable --now` — kills the running process before it can call `/request-shutdown`
- `systemctl disable` — only prevents boot-time auto-start, not runtime `Restart=always`
- `systemctl mask` — requires `daemon-reload` to affect the running service

**This fix**: After sending `/request-shutdown`, block forever with `select {}`. The VM will be deleted by the control plane — there's no reason for the process to exit.

Live Playwright testing confirmed all three previous approaches failed: activity timestamp was reset at the exact deadline time every 5 minutes, proving systemd restarted the agent.

## Validation

- [x] `go build ./...` and `go test ./...`
- [x] Playwright live test confirmed the bug with `systemctl mask`

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [x] business-logic-change

### External References

N/A: Verified via live Playwright testing that systemctl disable/mask don't prevent runtime Restart=always.

### Codebase Impact Analysis

- `packages/vm-agent/main.go` — Replace systemctl mask + sleep with `select {}` (block forever)

### Documentation & Specs

N/A: No interface changes.

### Constitution & Risk Check

- **Principle XI**: Removed hardcoded `time.Sleep(5 * time.Second)` and `systemctl mask` command.
- **Risk**: None — the VM is being deleted by the control plane anyway. Blocking is the safest option.

<!-- AGENT_PREFLIGHT_END -->