### PR TITLE
fix: retry /request-shutdown + heartbeat fallback shutdown

### DIFF
--- a/.claude/rules/06-technical-patterns.md
+++ b/.claude/rules/06-technical-patterns.md
@@ -78,6 +78,33 @@ export const WorkspaceCard: FC<Props> = ({ workspace }) => {
 };
 ```
 
+## VM Agent Lifecycle Pattern
+
+When the VM agent needs to make critical HTTP calls to the control plane (e.g., `/request-shutdown`):
+
+1. **Make the call BEFORE local shutdown** — `srv.Stop()` tears down the HTTP server, PTY sessions, and idle detector. Network calls after this may fail due to timeouts or connection issues.
+2. **Always use retry logic with backoff** — A single HTTP call is never reliable enough for critical operations. Use 3 attempts with 5-second delays.
+3. **Log response bodies on failure** — Status codes alone are insufficient for debugging. Always read and log `resp.Body` on non-2xx responses.
+4. **Never rely solely on the VM to clean itself up** — The control plane MUST have a fallback mechanism (see below).
+
+### Systemd Restart Gotchas
+
+- `Restart=always` restarts the service whenever it exits, regardless of `systemctl disable` or `systemctl mask`
+- `systemctl disable` only prevents boot-time auto-start, NOT runtime restarts
+- `systemctl mask` requires `daemon-reload` to take effect on a running service
+- **Solution**: Block forever with `select {}` after requesting shutdown. The VM will be deleted externally.
+
+## Defense-in-Depth for Async Operations
+
+When a remote system (VM) is responsible for triggering its own cleanup:
+
+1. **Primary path**: VM calls `/request-shutdown` directly after detecting idle timeout
+2. **Fallback path**: Control plane heartbeat handler checks if the VM reports being past the idle deadline and initiates deletion server-side
+3. **Both paths must use the same deletion logic** — reuse `deleteServer()`, `deleteDNSRecord()`, `cleanupWorkspaceDNSRecords()`
+4. **Guard against duplicate execution** — Use DB status transitions (`running` → `stopping`) as a lock. Only trigger deletion when status is `running`.
+
+This pattern prevents runaway billing when VMs fail to self-delete due to network issues, auth errors, or bugs.
+
 ## Common Tasks
 
 ### Adding a New API Endpoint


### PR DESCRIPTION
## Summary

- **VM Agent**: Moves `/request-shutdown` call BEFORE `srv.Stop()` (so networking is still up) and adds 3-attempt retry logic with 5s backoff
- **Control Plane**: Heartbeat endpoint now initiates VM deletion server-side when VM reports being idle past deadline — safety net for when VM can't self-delete
- **Process Rules**: Documents VM lifecycle patterns and defense-in-depth requirements

<!-- AGENT_PREFLIGHT_START -->
### Agent Preflight Evidence

- [x] **Change Classification**: `cross-component-change`, `business-logic-change`
- [x] **Context Gathered**: Read `main.go`, `workspaces.ts` heartbeat/stop/request-shutdown handlers, `detector.go`, `server.go`, `config.go`
- [x] **Impact Analysis**: VM agent shutdown flow reordered (request before stop); heartbeat handler now has deletion side-effect when idle past deadline
- [x] **Assumptions**: Heartbeat is still being sent by VM agent even after idle detection fires (verified: `sendHeartbeat()` runs on its own ticker, idle detection only closes `shutdownCh`)
- [x] **Cross-component dependencies**: VM agent → API heartbeat endpoint → Hetzner deletion; same deletion pattern as stop endpoint
- [x] **Constitution check**: No hardcoded values; idle timeout from per-workspace DB column; retry count could be made configurable but 3 is a reasonable default
<!-- AGENT_PREFLIGHT_END -->

## Test plan

- [x] Go build passes (`go build ./...`)
- [x] Go tests pass (`go test ./...`)
- [x] TypeScript build passes (`pnpm build`)
- [x] TypeScript tests pass (`pnpm test`)
- [ ] Playwright E2E: create workspace with 5min idle, verify it transitions to stopped

🤖 Generated with [Claude Code](https://claude.ai/code)