### PR TITLE
fix: unblock workspace websocket proxy when vmIp is null

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -130,20 +130,19 @@ app.use('*', async (c, next) => {
     return c.json({ error: 'INVALID_WORKSPACE', message: 'Invalid workspace subdomain' }, 400);
   }
 
-  // Look up the VM IP from D1
+  // Look up workspace routing metadata from D1.
   const db = drizzle(c.env.DATABASE, { schema });
   const workspace = await db
     .select({
       nodeId: schema.workspaces.nodeId,
-      vmIp: schema.workspaces.vmIp,
       status: schema.workspaces.status,
     })
     .from(schema.workspaces)
     .where(eq(schema.workspaces.id, workspaceId))
     .get();
 
-  if (!workspace || !workspace.vmIp) {
-    return c.json({ error: 'NOT_FOUND', message: 'Workspace not found or has no VM IP' }, 404);
+  if (!workspace) {
+    return c.json({ error: 'NOT_FOUND', message: 'Workspace not found' }, 404);
   }
 
   if (workspace.status !== 'running') {

--- a/apps/api/tests/unit/ws-proxy.test.ts
+++ b/apps/api/tests/unit/ws-proxy.test.ts
@@ -10,6 +10,11 @@ describe('ws proxy source contract', () => {
     expect(file).toContain('workspace.nodeId || workspaceId');
   });
 
+  it('does not block proxying when workspace vmIp is null', () => {
+    expect(file).not.toContain('!workspace || !workspace.vmIp');
+    expect(file).toContain("return c.json({ error: 'NOT_FOUND', message: 'Workspace not found' }, 404);");
+  });
+
   it('strips spoofed routing headers and injects trusted values', () => {
     expect(file).toContain("headers.delete('x-sam-node-id')");
     expect(file).toContain("headers.delete('x-sam-workspace-id')");


### PR DESCRIPTION
## Summary
- Fix workspace subdomain proxy middleware to no longer require `workspaces.vmIp` for routing.
- Keep routing via `vm-{nodeId}.{BASE_DOMAIN}` and preserve running-state gating.
- Add regression test to prevent reintroducing `vmIp` dependency in ws proxy.

## Validation
- [x] `pnpm --filter @simple-agent-manager/api test -- --run tests/unit/ws-proxy.test.ts`
- [x] `pnpm --filter @simple-agent-manager/api test -- --run tests/unit/routes/workspaces.test.ts`
- [x] `pnpm --filter @simple-agent-manager/api lint`
- [x] `pnpm --filter @simple-agent-manager/api typecheck`

## UI Compliance Checklist (Required for UI changes)
- [ ] Mobile-first layout verified
- [ ] Accessibility checks completed
- [ ] Shared UI components used or exception documented

## Exceptions (If any)
- N/A: no UI changes in this PR.

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [ ] cross-component-change
- [x] business-logic-change
- [ ] public-surface-change
- [ ] docs-sync-change
- [ ] security-sensitive-change
- [ ] ui-change
- [ ] infra-change

### External References

- N/A: no external API contract changes.

### Codebase Impact Analysis

- `apps/api/src/index.ts`: workspace subdomain proxy now checks only workspace existence + running status before routing to node hostname.
- `apps/api/tests/unit/ws-proxy.test.ts`: regression assertion added to block reintroduction of vmIp gating.

### Documentation & Specs

- N/A: no user-facing contract or documented behavior changed.

### Constitution & Risk Check

- Principle XI checked: no hardcoded URL/timeout/limit additions; proxy hostname still derives from `BASE_DOMAIN` and workspace/node IDs.
- Risk: low; scoped to ws proxy guard condition for workspace lookup.

<!-- AGENT_PREFLIGHT_END -->
