### PR TITLE
fix: allow Idempotency-Key in API CORS preflight

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -201,7 +201,7 @@ app.use('*', cors({
     return origin;
   },
   credentials: true,
-  allowHeaders: ['Content-Type', 'Authorization'],
+  allowHeaders: ['Content-Type', 'Authorization', 'Idempotency-Key'],
   allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
 }));
 

--- a/apps/api/tests/unit/cors-config.test.ts
+++ b/apps/api/tests/unit/cors-config.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('cors config source contract', () => {
+  const file = readFileSync(resolve(process.cwd(), 'src/index.ts'), 'utf8');
+
+  it('allows idempotency key request header for cross-origin session creation', () => {
+    expect(file).toContain("allowHeaders: ['Content-Type', 'Authorization', 'Idempotency-Key']");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `Idempotency-Key` to API CORS `allowHeaders` so cross-origin agent session creation is not blocked by browser preflight.
- Add source-contract unit test to keep this header allowlist from regressing.

## Validation
- [x] `pnpm --filter @simple-agent-manager/api test -- --run tests/unit/cors-config.test.ts`
- [x] `pnpm --filter @simple-agent-manager/api test -- --run tests/unit/routes/agent-sessions.test.ts`
- [x] `pnpm --filter @simple-agent-manager/api lint`
- [x] `pnpm --filter @simple-agent-manager/api typecheck`

## UI Compliance Checklist (Required for UI changes)
- [ ] Mobile-first layout verified
- [ ] Accessibility checks completed
- [ ] Shared UI components used or exception documented

## Exceptions (If any)
- N/A: no UI changes in this PR.

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [ ] cross-component-change
- [x] business-logic-change
- [ ] public-surface-change
- [ ] docs-sync-change
- [ ] security-sensitive-change
- [ ] ui-change
- [ ] infra-change

### External References

- N/A: no external API contract changes.

### Codebase Impact Analysis

- `apps/api/src/index.ts`: CORS allowHeaders now includes `Idempotency-Key`.
- `apps/api/tests/unit/cors-config.test.ts`: regression test for CORS allowlist.

### Documentation & Specs

- N/A: no user-facing docs/spec behavior changes.

### Constitution & Risk Check

- Principle XI checked: no hardcoded deployment URLs/timeouts/limits introduced.
- Risk: low; scoped to OPTIONS preflight allow-header list.

<!-- AGENT_PREFLIGHT_END -->
