### PR TITLE
fix: update landing cost copy for explicit stop flow

### DIFF
--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -76,7 +76,7 @@ export function Landing() {
             {[
               { label: 'Cloud VMs', sub: 'Powered by Hetzner', color: '#60a5fa' },
               { label: 'Claude Code', sub: 'Pre-installed', color: 'var(--sam-color-success)' },
-              { label: 'Zero Cost', sub: 'When idle', color: '#c084fc' },
+              { label: 'Pay as you go', sub: 'Stop when done', color: '#c084fc' },
             ].map((item) => (
               <div key={item.label} style={{
                 textAlign: 'center',

--- a/apps/web/tests/unit/pages/landing.test.tsx
+++ b/apps/web/tests/unit/pages/landing.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('Landing page source contract', () => {
+  const file = readFileSync(resolve(process.cwd(), 'src/pages/Landing.tsx'), 'utf8');
+
+  it('does not advertise idle-based zero-cost behavior', () => {
+    expect(file).not.toContain('Zero Cost');
+    expect(file).not.toContain('When idle');
+    expect(file).toContain('Pay as you go');
+    expect(file).toContain('Stop when done');
+  });
+});


### PR DESCRIPTION
## Summary
- Replace stale landing marketing copy (`Zero Cost / When idle`) with explicit lifecycle-aligned messaging (`Pay as you go / Stop when done`).
- Add source-contract test to prevent regression to idle-shutdown copy.

## Validation
- [x] `pnpm --filter @simple-agent-manager/web test -- --run tests/unit/pages/landing.test.tsx`
- [x] `pnpm --filter @simple-agent-manager/web lint`
- [x] `pnpm --filter @simple-agent-manager/web typecheck`

## UI Compliance Checklist (Required for UI changes)
- [x] Mobile-first layout verified
- [x] Accessibility checks completed
- [x] Shared UI components used or exception documented

## Exceptions (If any)
- N/A

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [ ] cross-component-change
- [ ] business-logic-change
- [ ] public-surface-change
- [ ] docs-sync-change
- [ ] security-sensitive-change
- [x] ui-change
- [ ] infra-change

### External References

- N/A: no external API changes.

### Codebase Impact Analysis

- `apps/web/src/pages/Landing.tsx`: feature-card copy updated to remove idle-shutdown claim.
- `apps/web/tests/unit/pages/landing.test.tsx`: regression check for copy values.

### Documentation & Specs

- N/A: user-facing behavior unchanged; copy now matches existing lifecycle docs.

### Constitution & Risk Check

- Principle XI checked: no hardcoded deployment URLs/timeouts/limits added.
- Risk: low, text-only UI change with test coverage.

<!-- AGENT_PREFLIGHT_END -->
