### PR TITLE
fix: raise mobile workspace action touch targets

### DIFF
--- a/apps/web/src/components/WorkspaceCard.tsx
+++ b/apps/web/src/components/WorkspaceCard.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { StatusBadge } from './StatusBadge';
 import { Card } from '@simple-agent-manager/ui';
 import type { WorkspaceResponse } from '@simple-agent-manager/shared';
+import { useIsMobile } from '../hooks/useIsMobile';
 
 interface WorkspaceCardProps {
   workspace: WorkspaceResponse;
@@ -26,6 +27,7 @@ const actionButtonStyle: React.CSSProperties = {
  */
 export function WorkspaceCard({ workspace, onStop, onRestart, onDelete }: WorkspaceCardProps) {
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
 
   const handleOpen = () => {
     // Open the control plane workspace page (not the ws-* subdomain directly).
@@ -46,6 +48,15 @@ export function WorkspaceCard({ workspace, onStop, onRestart, onDelete }: Worksp
     // Pop-up blocker fallback
     navigate(path);
   };
+
+  const buttonStyle = {
+    ...actionButtonStyle,
+    minHeight: isMobile ? '56px' : 'auto',
+    minWidth: isMobile ? '120px' : 'auto',
+    fontSize: isMobile ? '0.875rem' : actionButtonStyle.fontSize,
+    padding: isMobile ? '0 16px' : actionButtonStyle.padding,
+    flex: isMobile ? '1 1 0%' : '0 0 auto',
+  } satisfies React.CSSProperties;
 
   return (
     <Card style={{ padding: 'var(--sam-space-4)', transition: 'border-color 0.15s' }}>
@@ -106,8 +117,10 @@ export function WorkspaceCard({ workspace, onStop, onRestart, onDelete }: Worksp
       <div style={{
         marginTop: 'var(--sam-space-4)',
         display: 'flex',
-        alignItems: 'center',
+        flexDirection: isMobile ? 'column' : 'row',
+        alignItems: isMobile ? 'stretch' : 'center',
         justifyContent: 'space-between',
+        gap: isMobile ? 'var(--sam-space-3)' : 'var(--sam-space-2)',
       }}>
         <div style={{ fontSize: '0.75rem', color: 'var(--sam-color-fg-muted)', opacity: 0.7 }}>
           {workspace.lastActivityAt
@@ -115,12 +128,12 @@ export function WorkspaceCard({ workspace, onStop, onRestart, onDelete }: Worksp
             : `Created: ${new Date(workspace.createdAt).toLocaleString()}`}
         </div>
 
-        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--sam-space-2)' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--sam-space-2)', width: isMobile ? '100%' : 'auto' }}>
           {workspace.status === 'running' && (
             <>
               <button
                 onClick={handleOpen}
-                style={{ ...actionButtonStyle, color: 'var(--sam-color-accent-primary)' }}
+                style={{ ...buttonStyle, color: 'var(--sam-color-accent-primary)' }}
                 onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'rgba(22, 163, 74, 0.1)'; }}
                 onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
               >
@@ -129,7 +142,7 @@ export function WorkspaceCard({ workspace, onStop, onRestart, onDelete }: Worksp
               {onStop && (
                 <button
                   onClick={() => onStop(workspace.id)}
-                  style={{ ...actionButtonStyle, color: 'var(--sam-color-warning)' }}
+                  style={{ ...buttonStyle, color: 'var(--sam-color-warning)' }}
                   onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'rgba(245, 158, 11, 0.1)'; }}
                   onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
                 >
@@ -143,7 +156,7 @@ export function WorkspaceCard({ workspace, onStop, onRestart, onDelete }: Worksp
               {onRestart && (
                 <button
                   onClick={() => onRestart(workspace.id)}
-                  style={{ ...actionButtonStyle, color: 'var(--sam-color-success)' }}
+                  style={{ ...buttonStyle, color: 'var(--sam-color-success)' }}
                   onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'rgba(34, 197, 94, 0.1)'; }}
                   onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
                 >
@@ -153,7 +166,7 @@ export function WorkspaceCard({ workspace, onStop, onRestart, onDelete }: Worksp
               {onDelete && (
                 <button
                   onClick={() => onDelete(workspace.id)}
-                  style={{ ...actionButtonStyle, color: 'var(--sam-color-danger)' }}
+                  style={{ ...buttonStyle, color: 'var(--sam-color-danger)' }}
                   onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'rgba(239, 68, 68, 0.1)'; }}
                   onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
                 >
@@ -165,7 +178,7 @@ export function WorkspaceCard({ workspace, onStop, onRestart, onDelete }: Worksp
           {workspace.status === 'error' && onDelete && (
             <button
               onClick={() => onDelete(workspace.id)}
-              style={{ ...actionButtonStyle, color: 'var(--sam-color-danger)' }}
+              style={{ ...buttonStyle, color: 'var(--sam-color-danger)' }}
               onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'rgba(239, 68, 68, 0.1)'; }}
               onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
             >

--- a/apps/web/tests/unit/components/workspace-card.test.tsx
+++ b/apps/web/tests/unit/components/workspace-card.test.tsx
@@ -3,7 +3,12 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { WorkspaceCard } from '../../../src/components/WorkspaceCard';
+import { useIsMobile } from '../../../src/hooks/useIsMobile';
 import type { WorkspaceResponse } from '@simple-agent-manager/shared';
+
+vi.mock('../../../src/hooks/useIsMobile', () => ({
+  useIsMobile: vi.fn(),
+}));
 
 const workspace: WorkspaceResponse = {
   id: '01KTESTWORKSPACEID0000000000000',
@@ -22,9 +27,12 @@ const workspace: WorkspaceResponse = {
   url: 'https://ws-01ktestworkspaceid0000000000000.simple-agent-manager.org',
 };
 
+const mockUseIsMobile = vi.mocked(useIsMobile);
+
 describe('WorkspaceCard', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockUseIsMobile.mockReturnValue(false);
   });
 
   it('opens the control plane workspace page (not the ws-* URL)', async () => {
@@ -60,5 +68,24 @@ describe('WorkspaceCard', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Open' }));
 
     expect(screen.getByText('Workspace page')).toBeInTheDocument();
+  });
+
+  it('uses 56px touch targets for mobile actions', () => {
+    mockUseIsMobile.mockReturnValue(true);
+
+    render(
+      <MemoryRouter>
+        <WorkspaceCard workspace={workspace} onStop={() => undefined} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('button', { name: 'Open' })).toHaveStyle({
+      minHeight: '56px',
+      minWidth: '120px',
+    });
+    expect(screen.getByRole('button', { name: 'Stop' })).toHaveStyle({
+      minHeight: '56px',
+      minWidth: '120px',
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Increase workspace-card action button touch targets on mobile to comply with the 56px minimum target requirement.
- Keep desktop sizing/layout behavior compact while making mobile actions easier to tap.
- Add a unit test that guards the mobile sizing contract.

## Validation

- [x] `pnpm lint` (ran: `pnpm --filter @simple-agent-manager/web lint`)
- [x] `pnpm typecheck` (ran: `pnpm --filter @simple-agent-manager/web typecheck`)
- [x] `pnpm test` (ran: `pnpm --filter @simple-agent-manager/web test -- --run tests/unit/components/workspace-card.test.tsx`)
- [x] Additional validation run (if applicable)
- [x] Mobile and desktop verification notes added for UI changes

Additional validation:
- Production Playwright measurement before fix: dashboard `Open`/`Stop` controls were ~22px height at 390px viewport.
- Post-merge validation planned for same viewport to confirm >=56px target.

## UI Compliance Checklist (Required for UI changes)

- [x] Mobile-first layout verified
- [x] Accessibility checks completed
- [x] Shared UI components used or exception documented

Exception documented:
- Existing `WorkspaceCard` uses inline button styling for status-color variants; this change preserves that pattern while enforcing touch-target sizing.

## Exceptions (If any)

- Scope: Keep desktop compact sizing unchanged.
- Rationale: Avoid regressing desktop card density while fixing mobile usability.
- Expiration: N/A

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [ ] cross-component-change
- [ ] business-logic-change
- [ ] public-surface-change
- [ ] docs-sync-change
- [ ] security-sensitive-change
- [x] ui-change
- [ ] infra-change

### External References

N/A: internal UI behavior change only.

### Codebase Impact Analysis

- `apps/web/src/components/WorkspaceCard.tsx`
- `apps/web/tests/unit/components/workspace-card.test.tsx`

### Documentation & Specs

N/A: no docs/spec content describes workspace card action control dimensions.

### Constitution & Risk Check

- Checked Constitution Principle XI (No Hardcoded Values): no business logic/config values added; only a UI touch-target sizing rule aligned with existing mobile UX requirements.
- Risk/tradeoff: mobile buttons are larger; mitigated by keeping desktop sizing and by test coverage for mobile sizing behavior.

<!-- AGENT_PREFLIGHT_END -->
