### PR TITLE
feat(workspace): unify terminal/chat tabs and fix node callback routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,7 @@ Claude Code now supports dual authentication methods:
 - Cloudflare D1 (SQLite) for app state; Cloudflare KV for bootstrap tokens and boot logs; Cloudflare R2 for Node Agent binaries (014-multi-workspace-nodes)
 
 ## Recent Changes
+- 014-multi-workspace-nodes: Added workspace-scoped callback token flow for Node Agent workspace provisioning/ACP/git credential requests, and unified workspace tab creation UX (`+` menu for terminal/chat sessions with agent-specific chat options when multiple agent keys are configured)
 - 014-multi-workspace-nodes: Added first-class Nodes with multi-workspace hosting, node/workspace event streams, agent sessions, node-scoped routing/auth, and explicit lifecycle control (no idle-triggered shutdown)
 - 014-auth-profile-sync: Resolve and persist the GitHub account primary email at login (via `/user/emails`) and propagate git user name/email into workspace bootstrap so VM agent configures commit identity
 - 013-agent-oauth-support: Dual credential support for Claude Code (API key + OAuth token), credential switching capability, auto-activation behavior

--- a/apps/api/src/services/node-agent.ts
+++ b/apps/api/src/services/node-agent.ts
@@ -42,24 +42,30 @@ async function nodeAgentRequest<T>(
   }
 
   const startedAt = Date.now();
-  recordNodeRoutingMetric({
-    metric: 'node_agent_request',
-    nodeId,
-    workspaceId: options.workspaceId ?? null,
-  }, env);
+  recordNodeRoutingMetric(
+    {
+      metric: 'node_agent_request',
+      nodeId,
+      workspaceId: options.workspaceId ?? null,
+    },
+    env
+  );
 
   const response = await fetch(url, {
     ...options,
     headers,
   });
 
-  recordNodeRoutingMetric({
-    metric: 'node_agent_response',
-    nodeId,
-    workspaceId: options.workspaceId ?? null,
-    statusCode: response.status,
-    durationMs: Date.now() - startedAt,
-  }, env);
+  recordNodeRoutingMetric(
+    {
+      metric: 'node_agent_response',
+      nodeId,
+      workspaceId: options.workspaceId ?? null,
+      statusCode: response.status,
+      durationMs: Date.now() - startedAt,
+    },
+    env
+  );
 
   if (!response.ok) {
     const body = await response.text().catch(() => '');
@@ -81,6 +87,7 @@ export async function createWorkspaceOnNode(
     workspaceId: string;
     repository: string;
     branch: string;
+    callbackToken: string;
   }
 ): Promise<unknown> {
   return nodeAgentRequest(nodeId, env, '/workspaces', {

--- a/apps/api/tests/unit/routes/workspaces.test.ts
+++ b/apps/api/tests/unit/routes/workspaces.test.ts
@@ -5,7 +5,10 @@ import { resolve } from 'node:path';
 describe('workspaces routes source contract', () => {
   const file = readFileSync(resolve(process.cwd(), 'src/routes/workspaces.ts'), 'utf8');
   const schemaFile = readFileSync(resolve(process.cwd(), 'src/db/schema.ts'), 'utf8');
-  const migrationFile = readFileSync(resolve(process.cwd(), 'src/db/migrations/0007_multi_workspace_nodes.sql'), 'utf8');
+  const migrationFile = readFileSync(
+    resolve(process.cwd(), 'src/db/migrations/0007_multi_workspace_nodes.sql'),
+    'utf8'
+  );
 
   it('defines node-scoped workspace list/filter and rename endpoints', () => {
     expect(file).toContain("const nodeId = c.req.query('nodeId')");
@@ -29,11 +32,15 @@ describe('workspaces routes source contract', () => {
   });
 
   it('uses DB-backed node-scoped unique display names for create and rename', () => {
-    expect(file).toContain('const uniqueName = await resolveUniqueWorkspaceDisplayName(db, targetNodeId, body.name)');
+    expect(file).toContain(
+      'const uniqueName = await resolveUniqueWorkspaceDisplayName(db, targetNodeId, body.name)'
+    );
     expect(file).toContain('resolveUniqueWorkspaceDisplayName(');
     expect(file).toContain('nodeScopeId');
     expect(schemaFile).toContain('idx_workspaces_node_display_name_unique');
-    expect(migrationFile).toContain('CREATE UNIQUE INDEX IF NOT EXISTS idx_workspaces_node_display_name_unique');
+    expect(migrationFile).toContain(
+      'CREATE UNIQUE INDEX IF NOT EXISTS idx_workspaces_node_display_name_unique'
+    );
   });
 
   it('keeps rename and create duplicate protection tied to node scope', () => {
@@ -44,5 +51,10 @@ describe('workspaces routes source contract', () => {
 
   it('removes idle-triggered request-shutdown route', () => {
     expect(file).not.toContain('/request-shutdown');
+  });
+
+  it('accepts node-scoped callback tokens for workspace callbacks', () => {
+    expect(file).toContain('payload.workspace === workspace.nodeId');
+    expect(file).toContain("throw errors.forbidden('Token workspace mismatch')");
   });
 });

--- a/docs/guides/multi-terminal.md
+++ b/docs/guides/multi-terminal.md
@@ -9,6 +9,7 @@ Simple Agent Manager now supports multiple terminal sessions within a single bro
 The multi-terminal feature is controlled by a feature flag. To enable it:
 
 1. Set the environment variable in your `.env` file:
+
    ```bash
    VITE_FEATURE_MULTI_TERMINAL=true
    ```
@@ -19,7 +20,8 @@ The multi-terminal feature is controlled by a feature flag. To enable it:
 
 ### Creating New Terminals
 
-- Click the **+** button in the tab bar
+- In the Workspace page, click the top tab bar **+** menu, then choose **New Terminal Session**
+- In embedded/standalone terminal views, click the **+** button in the terminal tab bar
 - Use keyboard shortcut `Ctrl+Shift+T` (or `Cmd+T` on Mac)
 - Maximum of 10 concurrent terminals per workspace (configurable)
 
@@ -47,6 +49,7 @@ The multi-terminal feature is controlled by a feature flag. To enable it:
 ### Tab Overflow
 
 When you have more tabs than can fit in the viewport:
+
 - Scroll arrows appear on the left/right
 - Click the **⋮** menu to see all terminals in a dropdown
 - The tab bar is horizontally scrollable on touch devices
@@ -60,13 +63,13 @@ When you have more tabs than can fit in the viewport:
 
 ## Keyboard Shortcuts
 
-| Action | Windows/Linux | Mac |
-|--------|--------------|-----|
-| New Terminal | `Ctrl+Shift+T` | `Cmd+T` |
-| Close Terminal | `Ctrl+Shift+W` | `Cmd+W` |
-| Next Tab | `Ctrl+Tab` | `Cmd+Shift+]` |
-| Previous Tab | `Ctrl+Shift+Tab` | `Cmd+Shift+[` |
-| Jump to Tab N | `Alt+[1-9]` | `Cmd+[1-9]` |
+| Action         | Windows/Linux    | Mac           |
+| -------------- | ---------------- | ------------- |
+| New Terminal   | `Ctrl+Shift+T`   | `Cmd+T`       |
+| Close Terminal | `Ctrl+Shift+W`   | `Cmd+W`       |
+| Next Tab       | `Ctrl+Tab`       | `Cmd+Shift+]` |
+| Previous Tab   | `Ctrl+Shift+Tab` | `Cmd+Shift+[` |
+| Jump to Tab N  | `Alt+[1-9]`      | `Cmd+[1-9]`   |
 
 ## Configuration
 
@@ -106,6 +109,7 @@ The multi-terminal interface is fully responsive:
 ## Session Independence
 
 Each terminal maintains its own:
+
 - Working directory
 - Environment variables
 - Command history
@@ -124,17 +128,20 @@ Switching between tabs doesn't affect running commands - they continue executing
 ## Troubleshooting
 
 ### Can't Create New Terminal
+
 - Check if you've reached the maximum limit (10 by default)
 - Verify the VM Agent is running and accepting connections
 - Check browser console for WebSocket errors
 
 ### Tab Not Responding
+
 - The terminal session may have been explicitly closed from another tab/window
 - The workspace may have restarted (fresh PTY sessions are created after restart)
 - Try closing and creating a new tab
 - Check the connection status indicator
 
 ### Keyboard Shortcuts Not Working
+
 - Ensure the terminal doesn't have focus (click outside the terminal area)
 - Check for conflicts with browser or OS shortcuts
 - Some shortcuts may differ on macOS
@@ -182,6 +189,7 @@ The multi-terminal system uses an extended WebSocket protocol:
 ## Future Enhancements
 
 Planned features for future releases:
+
 - Terminal splitting/panes within tabs
 - Terminal sharing between users
 - Command history search across all terminals

--- a/packages/terminal/src/MultiTerminal.tsx
+++ b/packages/terminal/src/MultiTerminal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useCallback } from 'react';
+import React, { useEffect, useRef, useState, useCallback, useImperativeHandle } from 'react';
 import { Terminal as XTerm } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { TabBar } from './components/TabBar';
@@ -21,7 +21,12 @@ import {
   isScrollbackMessage,
   isSessionListMessage,
 } from './protocol';
-import type { MultiTerminalProps, TerminalConfig } from './types/multi-terminal';
+import type {
+  MultiTerminalProps,
+  MultiTerminalHandle,
+  MultiTerminalSessionSnapshot,
+  TerminalConfig,
+} from './types/multi-terminal';
 
 import '@xterm/xterm/css/xterm.css';
 
@@ -40,531 +45,653 @@ interface TerminalInstance {
  * Maintains a SINGLE shared WebSocket using the multi-session protocol.
  * Each tab has its own raw xterm.js instance for rendering.
  */
-export const MultiTerminal: React.FC<MultiTerminalProps> = (props) => {
-  const { wsUrl, onActivity, className = '', config, persistenceKey } = props;
-  const terminalConfig: TerminalConfig = {
-    maxSessions: config?.maxSessions || 10,
-    tabSwitchAnimationMs: config?.tabSwitchAnimationMs || 200,
-    scrollbackLines: config?.scrollbackLines || 1000,
-    shortcuts: config?.shortcuts || {
-      newTab: 'Ctrl+Shift+T',
-      closeTab: 'Ctrl+Shift+W',
-      nextTab: 'Ctrl+Tab',
-      previousTab: 'Ctrl+Shift+Tab',
-      jumpToTab: 'Alt+{n}',
-    },
-  };
-
-  const {
-    sessions,
-    activeSessionId,
-    createSession,
-    closeSession,
-    activateSession,
-    renameSession,
-    canCreateSession,
-    updateSessionStatus,
-    updateSessionWorkingDirectory,
-    updateServerSessionId,
-    getPersistedSessions,
-  } = useTerminalSessions(terminalConfig.maxSessions, persistenceKey);
-
-  // Refs that persist across renders
-  const wsRef = useRef<WebSocket | null>(null);
-  const terminalsRef = useRef<Map<string, TerminalInstance>>(new Map());
-  const [wsConnected, setWsConnected] = useState(false);
-  // Guard against duplicate list_sessions requests during rapid reconnect cycles
-  const reconnectingRef = useRef(false);
-
-  // ── Stable refs for latest callback/state versions ──
-  // This prevents re-creating the WebSocket connection when callbacks change reference.
-  // The WS event handlers read from latestRef.current to always get the latest versions.
-  const latestRef = useRef({
-    createSession,
-    closeSession,
-    updateSessionStatus,
-    updateSessionWorkingDirectory,
-    updateServerSessionId,
-    onActivity,
-    sessions,
-    getPersistedSessions,
-  });
-  latestRef.current = {
-    createSession,
-    closeSession,
-    updateSessionStatus,
-    updateSessionWorkingDirectory,
-    updateServerSessionId,
-    onActivity,
-    sessions,
-    getPersistedSessions,
-  };
-
-  const resolveLocalSessionId = useCallback((sessionId?: string): string | null => {
-    if (!sessionId) return null;
-    if (latestRef.current.sessions.has(sessionId)) return sessionId;
-    for (const [localId, localSession] of latestRef.current.sessions.entries()) {
-      if (localSession.serverSessionId === sessionId) {
-        return localId;
-      }
-    }
-    return null;
-  }, []);
-
-  const getOutboundSessionId = useCallback((localSessionId: string): string => {
-    const localSession = latestRef.current.sessions.get(localSessionId);
-    return localSession?.serverSessionId ?? localSessionId;
-  }, []);
-
-  // Create xterm.js instance for a session (stable — only depends on scrollback config)
-  const createTerminalInstance = useCallback((sessionId: string): TerminalInstance => {
-    const terminal = new XTerm({
-      cursorBlink: true,
-      scrollback: terminalConfig.scrollbackLines,
-      theme: {
-        background: '#1a1b26',
-        foreground: '#a9b1d6',
-        cursor: '#c0caf5',
-        selectionBackground: '#33467c',
-        black: '#32344a',
-        red: '#f7768e',
-        green: '#9ece6a',
-        yellow: '#e0af68',
-        blue: '#7aa2f7',
-        magenta: '#ad8ee6',
-        cyan: '#449dab',
-        white: '#787c99',
-        brightBlack: '#444b6a',
-        brightRed: '#ff7a93',
-        brightGreen: '#b9f27c',
-        brightYellow: '#ff9e64',
-        brightBlue: '#7da6ff',
-        brightMagenta: '#bb9af7',
-        brightCyan: '#0db9d7',
-        brightWhite: '#acb0d0',
+export const MultiTerminal = React.forwardRef<MultiTerminalHandle, MultiTerminalProps>(
+  (props, ref) => {
+    const {
+      wsUrl,
+      onActivity,
+      className = '',
+      config,
+      persistenceKey,
+      hideTabBar = false,
+      onSessionsChange,
+    } = props;
+    const terminalConfig: TerminalConfig = {
+      maxSessions: config?.maxSessions || 10,
+      tabSwitchAnimationMs: config?.tabSwitchAnimationMs || 200,
+      scrollbackLines: config?.scrollbackLines || 1000,
+      shortcuts: config?.shortcuts || {
+        newTab: 'Ctrl+Shift+T',
+        closeTab: 'Ctrl+Shift+W',
+        nextTab: 'Ctrl+Tab',
+        previousTab: 'Ctrl+Shift+Tab',
+        jumpToTab: 'Alt+{n}',
       },
-      fontFamily: 'JetBrains Mono, Menlo, Monaco, monospace',
-      fontSize: 14,
-      lineHeight: 1.2,
+    };
+
+    const {
+      sessions,
+      activeSessionId,
+      createSession,
+      closeSession,
+      activateSession,
+      renameSession,
+      canCreateSession,
+      updateSessionStatus,
+      updateSessionWorkingDirectory,
+      updateServerSessionId,
+      getPersistedSessions,
+    } = useTerminalSessions(terminalConfig.maxSessions, persistenceKey);
+
+    // Refs that persist across renders
+    const wsRef = useRef<WebSocket | null>(null);
+    const terminalsRef = useRef<Map<string, TerminalInstance>>(new Map());
+    const [wsConnected, setWsConnected] = useState(false);
+    // Guard against duplicate list_sessions requests during rapid reconnect cycles
+    const reconnectingRef = useRef(false);
+
+    // ── Stable refs for latest callback/state versions ──
+    // This prevents re-creating the WebSocket connection when callbacks change reference.
+    // The WS event handlers read from latestRef.current to always get the latest versions.
+    const latestRef = useRef({
+      createSession,
+      closeSession,
+      updateSessionStatus,
+      updateSessionWorkingDirectory,
+      updateServerSessionId,
+      onActivity,
+      sessions,
+      getPersistedSessions,
     });
+    latestRef.current = {
+      createSession,
+      closeSession,
+      updateSessionStatus,
+      updateSessionWorkingDirectory,
+      updateServerSessionId,
+      onActivity,
+      sessions,
+      getPersistedSessions,
+    };
 
-    const fitAddon = new FitAddon();
-    terminal.loadAddon(fitAddon);
+    const resolveLocalSessionId = useCallback((sessionId?: string): string | null => {
+      if (!sessionId) return null;
+      if (latestRef.current.sessions.has(sessionId)) return sessionId;
+      for (const [localId, localSession] of latestRef.current.sessions.entries()) {
+        if (localSession.serverSessionId === sessionId) {
+          return localId;
+        }
+      }
+      return null;
+    }, []);
 
-    // Handle user input — route through shared WebSocket with sessionId
-    terminal.onData((data) => {
-      latestRef.current.onActivity?.();
+    const getOutboundSessionId = useCallback((localSessionId: string): string => {
+      const localSession = latestRef.current.sessions.get(localSessionId);
+      return localSession?.serverSessionId ?? localSessionId;
+    }, []);
+
+    // Create xterm.js instance for a session (stable — only depends on scrollback config)
+    const createTerminalInstance = useCallback(
+      (sessionId: string): TerminalInstance => {
+        const terminal = new XTerm({
+          cursorBlink: true,
+          scrollback: terminalConfig.scrollbackLines,
+          theme: {
+            background: '#1a1b26',
+            foreground: '#a9b1d6',
+            cursor: '#c0caf5',
+            selectionBackground: '#33467c',
+            black: '#32344a',
+            red: '#f7768e',
+            green: '#9ece6a',
+            yellow: '#e0af68',
+            blue: '#7aa2f7',
+            magenta: '#ad8ee6',
+            cyan: '#449dab',
+            white: '#787c99',
+            brightBlack: '#444b6a',
+            brightRed: '#ff7a93',
+            brightGreen: '#b9f27c',
+            brightYellow: '#ff9e64',
+            brightBlue: '#7da6ff',
+            brightMagenta: '#bb9af7',
+            brightCyan: '#0db9d7',
+            brightWhite: '#acb0d0',
+          },
+          fontFamily: 'JetBrains Mono, Menlo, Monaco, monospace',
+          fontSize: 14,
+          lineHeight: 1.2,
+        });
+
+        const fitAddon = new FitAddon();
+        terminal.loadAddon(fitAddon);
+
+        // Handle user input — route through shared WebSocket with sessionId
+        terminal.onData((data) => {
+          latestRef.current.onActivity?.();
+          const ws = wsRef.current;
+          if (ws && ws.readyState === WebSocket.OPEN) {
+            ws.send(encodeTerminalWsInput(data, getOutboundSessionId(sessionId)));
+          }
+        });
+
+        const instance: TerminalInstance = { terminal, fitAddon, containerEl: null };
+        terminalsRef.current.set(sessionId, instance);
+        return instance;
+      },
+      [getOutboundSessionId, terminalConfig.scrollbackLines]
+    );
+
+    // Destroy xterm.js instance (completely stable)
+    const destroyTerminalInstance = useCallback((sessionId: string) => {
+      const instance = terminalsRef.current.get(sessionId);
+      if (instance) {
+        instance.terminal.dispose();
+        terminalsRef.current.delete(sessionId);
+      }
+    }, []);
+
+    // Handle new tab creation
+    const handleNewTab = useCallback(() => {
+      const sessionId = latestRef.current.createSession();
+      createTerminalInstance(sessionId);
       const ws = wsRef.current;
       if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(encodeTerminalWsInput(data, getOutboundSessionId(sessionId)));
+        ws.send(encodeTerminalWsCreateSession(sessionId, 24, 80));
       }
-    });
+      return sessionId;
+    }, [createTerminalInstance]);
 
-    const instance: TerminalInstance = { terminal, fitAddon, containerEl: null };
-    terminalsRef.current.set(sessionId, instance);
-    return instance;
-  }, [getOutboundSessionId, terminalConfig.scrollbackLines]);
+    // Handle tab close
+    const handleCloseTab = useCallback(
+      (sessionId: string) => {
+        const ws = wsRef.current;
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          ws.send(encodeTerminalWsCloseSession(getOutboundSessionId(sessionId)));
+        }
+        destroyTerminalInstance(sessionId);
+        latestRef.current.closeSession(sessionId);
+      },
+      [destroyTerminalInstance, getOutboundSessionId]
+    );
 
-  // Destroy xterm.js instance (completely stable)
-  const destroyTerminalInstance = useCallback((sessionId: string) => {
-    const instance = terminalsRef.current.get(sessionId);
-    if (instance) {
-      instance.terminal.dispose();
-      terminalsRef.current.delete(sessionId);
-    }
-  }, []);
+    // Handle tab rename
+    const handleRenameTab = useCallback(
+      (sessionId: string, name: string) => {
+        renameSession(sessionId, name);
+        const ws = wsRef.current;
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          ws.send(encodeTerminalWsRenameSession(getOutboundSessionId(sessionId), name));
+        }
+      },
+      [getOutboundSessionId, renameSession]
+    );
 
-  // Handle new tab creation
-  const handleNewTab = useCallback(() => {
-    const sessionId = latestRef.current.createSession();
-    createTerminalInstance(sessionId);
-    const ws = wsRef.current;
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(encodeTerminalWsCreateSession(sessionId, 24, 80));
-    }
-    return sessionId;
-  }, [createTerminalInstance]);
+    // ── WebSocket connection lifecycle ──
+    // This single effect manages the ENTIRE WebSocket: connect, message routing,
+    // ping heartbeat, and reconnection. It only re-runs when wsUrl changes.
+    useEffect(() => {
+      let disposed = false;
+      let reconnectTimeout: ReturnType<typeof setTimeout>;
+      let pingInterval: ReturnType<typeof setInterval>;
+      let currentWs: WebSocket | null = null;
 
-  // Handle tab close
-  const handleCloseTab = useCallback((sessionId: string) => {
-    const ws = wsRef.current;
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(encodeTerminalWsCloseSession(getOutboundSessionId(sessionId)));
-    }
-    destroyTerminalInstance(sessionId);
-    latestRef.current.closeSession(sessionId);
-  }, [destroyTerminalInstance, getOutboundSessionId]);
+      function connect() {
+        if (disposed) return;
 
-  // Handle tab rename
-  const handleRenameTab = useCallback((sessionId: string, name: string) => {
-    renameSession(sessionId, name);
-    const ws = wsRef.current;
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(encodeTerminalWsRenameSession(getOutboundSessionId(sessionId), name));
-    }
-  }, [getOutboundSessionId, renameSession]);
+        try {
+          const ws = new WebSocket(wsUrl);
+          currentWs = ws;
 
-  // ── WebSocket connection lifecycle ──
-  // This single effect manages the ENTIRE WebSocket: connect, message routing,
-  // ping heartbeat, and reconnection. It only re-runs when wsUrl changes.
-  useEffect(() => {
-    let disposed = false;
-    let reconnectTimeout: ReturnType<typeof setTimeout>;
-    let pingInterval: ReturnType<typeof setInterval>;
-    let currentWs: WebSocket | null = null;
-
-    function connect() {
-      if (disposed) return;
-
-      try {
-        const ws = new WebSocket(wsUrl);
-        currentWs = ws;
-
-        ws.onopen = () => {
-          if (disposed) { ws.close(); return; }
-          setWsConnected(true);
-          wsRef.current = ws;
-
-          // Start ping heartbeat
-          pingInterval = setInterval(() => {
-            if (ws.readyState === WebSocket.OPEN) {
-              ws.send(encodeTerminalWsPing());
+          ws.onopen = () => {
+            if (disposed) {
+              ws.close();
+              return;
             }
-          }, PING_INTERVAL_MS);
+            setWsConnected(true);
+            wsRef.current = ws;
 
-          // Always ask for the authoritative server-side session list on connect.
-          // Guard: if a previous reconnect is still pending, skip duplicate list_sessions.
-          if (reconnectingRef.current) return;
-          reconnectingRef.current = true;
-          ws.send(encodeTerminalWsListSessions());
-        };
+            // Start ping heartbeat
+            pingInterval = setInterval(() => {
+              if (ws.readyState === WebSocket.OPEN) {
+                ws.send(encodeTerminalWsPing());
+              }
+            }, PING_INTERVAL_MS);
 
-        ws.onmessage = (event) => {
-          if (typeof event.data !== 'string') return;
-          const msg = parseTerminalWsServerMessage(event.data);
-          if (!msg) return;
+            // Always ask for the authoritative server-side session list on connect.
+            // Guard: if a previous reconnect is still pending, skip duplicate list_sessions.
+            if (reconnectingRef.current) return;
+            reconnectingRef.current = true;
+            ws.send(encodeTerminalWsListSessions());
+          };
 
-          if (isSessionListMessage(msg) && msg.data) {
-            // Clear reconnecting guard — response received
-            reconnectingRef.current = false;
+          ws.onmessage = (event) => {
+            if (typeof event.data !== 'string') return;
+            const msg = parseTerminalWsServerMessage(event.data);
+            if (!msg) return;
 
-            const serverSessions = msg.data.sessions
-              .filter((s) => s.status !== 'exited')
-              .sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt));
-            const serverMap = new Map(serverSessions.map((s) => [s.sessionId, s]));
+            if (isSessionListMessage(msg) && msg.data) {
+              // Clear reconnecting guard — response received
+              reconnectingRef.current = false;
 
-            const currentSessions = Array.from(latestRef.current.sessions.entries());
-            const pendingLocalSessions: Array<{
-              localId: string;
-              name: string;
-              serverSessionId?: string;
-            }> = currentSessions.map(([localId, localSession]) => ({
-              localId,
-              name: localSession.name,
-              serverSessionId: localSession.serverSessionId,
-            }));
+              const serverSessions = msg.data.sessions
+                .filter((s) => s.status !== 'exited')
+                .sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt));
+              const serverMap = new Map(serverSessions.map((s) => [s.sessionId, s]));
 
-            if (pendingLocalSessions.length === 0) {
-              const persisted = latestRef.current.getPersistedSessions();
-              const sortedPersisted = persisted ? [...persisted].sort((a, b) => a.order - b.order) : [];
-              const hasPersistedServerIds = sortedPersisted.some((entry) => Boolean(entry.serverSessionId));
+              const currentSessions = Array.from(latestRef.current.sessions.entries());
+              const pendingLocalSessions: Array<{
+                localId: string;
+                name: string;
+                serverSessionId?: string;
+              }> = currentSessions.map(([localId, localSession]) => ({
+                localId,
+                name: localSession.name,
+                serverSessionId: localSession.serverSessionId,
+              }));
 
-              if (sortedPersisted.length > 0 && (hasPersistedServerIds || serverSessions.length === 0)) {
-                for (const entry of sortedPersisted) {
-                  const localId = latestRef.current.createSession(entry.name);
+              if (pendingLocalSessions.length === 0) {
+                const persisted = latestRef.current.getPersistedSessions();
+                const sortedPersisted = persisted
+                  ? [...persisted].sort((a, b) => a.order - b.order)
+                  : [];
+                const hasPersistedServerIds = sortedPersisted.some((entry) =>
+                  Boolean(entry.serverSessionId)
+                );
+
+                if (
+                  sortedPersisted.length > 0 &&
+                  (hasPersistedServerIds || serverSessions.length === 0)
+                ) {
+                  for (const entry of sortedPersisted) {
+                    const localId = latestRef.current.createSession(entry.name);
+                    createTerminalInstance(localId);
+                    latestRef.current.updateSessionStatus(localId, 'reconnecting');
+                    if (entry.serverSessionId) {
+                      latestRef.current.updateServerSessionId(localId, entry.serverSessionId);
+                    }
+                    pendingLocalSessions.push({
+                      localId,
+                      name: entry.name,
+                      serverSessionId: entry.serverSessionId,
+                    });
+                  }
+                }
+              }
+
+              if (pendingLocalSessions.length === 0 && serverSessions.length === 0) {
+                const sessionId = latestRef.current.createSession();
+                createTerminalInstance(sessionId);
+                ws.send(encodeTerminalWsCreateSession(sessionId, 24, 80));
+              } else {
+                for (const localSession of pendingLocalSessions) {
+                  const serverId = localSession.serverSessionId;
+                  const serverInfo = serverId ? serverMap.get(serverId) : undefined;
+
+                  if (serverId && serverInfo) {
+                    latestRef.current.updateSessionStatus(localSession.localId, 'reconnecting');
+                    if (serverInfo.workingDirectory) {
+                      latestRef.current.updateSessionWorkingDirectory(
+                        localSession.localId,
+                        serverInfo.workingDirectory
+                      );
+                    }
+                    const instance = terminalsRef.current.get(localSession.localId);
+                    const rows = instance?.terminal?.rows ?? 24;
+                    const cols = instance?.terminal?.cols ?? 80;
+                    ws.send(encodeTerminalWsReattachSession(serverId, rows, cols));
+                    serverMap.delete(serverId);
+                  } else {
+                    ws.send(
+                      encodeTerminalWsCreateSession(localSession.localId, 24, 80, localSession.name)
+                    );
+                  }
+                }
+
+                // Server has sessions not represented locally (e.g. no local cache after reload).
+                for (const serverInfo of serverMap.values()) {
+                  const localId = latestRef.current.createSession(serverInfo.name);
                   createTerminalInstance(localId);
                   latestRef.current.updateSessionStatus(localId, 'reconnecting');
-                  if (entry.serverSessionId) {
-                    latestRef.current.updateServerSessionId(localId, entry.serverSessionId);
-                  }
-                  pendingLocalSessions.push({
-                    localId,
-                    name: entry.name,
-                    serverSessionId: entry.serverSessionId,
-                  });
-                }
-              }
-            }
-
-            if (pendingLocalSessions.length === 0 && serverSessions.length === 0) {
-              const sessionId = latestRef.current.createSession();
-              createTerminalInstance(sessionId);
-              ws.send(encodeTerminalWsCreateSession(sessionId, 24, 80));
-            } else {
-              for (const localSession of pendingLocalSessions) {
-                const serverId = localSession.serverSessionId;
-                const serverInfo = serverId ? serverMap.get(serverId) : undefined;
-
-                if (serverId && serverInfo) {
-                  latestRef.current.updateSessionStatus(localSession.localId, 'reconnecting');
+                  latestRef.current.updateServerSessionId(localId, serverInfo.sessionId);
                   if (serverInfo.workingDirectory) {
-                    latestRef.current.updateSessionWorkingDirectory(localSession.localId, serverInfo.workingDirectory);
+                    latestRef.current.updateSessionWorkingDirectory(
+                      localId,
+                      serverInfo.workingDirectory
+                    );
                   }
-                  const instance = terminalsRef.current.get(localSession.localId);
+                  const instance = terminalsRef.current.get(localId);
                   const rows = instance?.terminal?.rows ?? 24;
                   const cols = instance?.terminal?.cols ?? 80;
-                  ws.send(encodeTerminalWsReattachSession(serverId, rows, cols));
-                  serverMap.delete(serverId);
-                } else {
-                  ws.send(encodeTerminalWsCreateSession(localSession.localId, 24, 80, localSession.name));
+                  ws.send(encodeTerminalWsReattachSession(serverInfo.sessionId, rows, cols));
                 }
               }
-
-              // Server has sessions not represented locally (e.g. no local cache after reload).
-              for (const serverInfo of serverMap.values()) {
-                const localId = latestRef.current.createSession(serverInfo.name);
-                createTerminalInstance(localId);
-                latestRef.current.updateSessionStatus(localId, 'reconnecting');
-                latestRef.current.updateServerSessionId(localId, serverInfo.sessionId);
-                if (serverInfo.workingDirectory) {
-                  latestRef.current.updateSessionWorkingDirectory(localId, serverInfo.workingDirectory);
+            } else if (isSessionReattachedMessage(msg) && msg.data) {
+              // Find the local session that maps to this server session ID
+              const serverId = msg.data.sessionId;
+              const localId = resolveLocalSessionId(serverId);
+              if (localId) {
+                latestRef.current.updateSessionStatus(localId, 'connected');
+                if (msg.data.workingDirectory) {
+                  latestRef.current.updateSessionWorkingDirectory(
+                    localId,
+                    msg.data.workingDirectory
+                  );
                 }
+              }
+            } else if (isScrollbackMessage(msg) && msg.sessionId && msg.data) {
+              // Find the local session mapped to this server session ID and write scrollback
+              const localId = resolveLocalSessionId(msg.sessionId);
+              if (localId) {
                 const instance = terminalsRef.current.get(localId);
-                const rows = instance?.terminal?.rows ?? 24;
-                const cols = instance?.terminal?.cols ?? 80;
-                ws.send(encodeTerminalWsReattachSession(serverInfo.sessionId, rows, cols));
+                if (instance && msg.data.data) {
+                  instance.terminal.write(msg.data.data);
+                }
               }
-            }
-          } else if (isSessionReattachedMessage(msg) && msg.data) {
-            // Find the local session that maps to this server session ID
-            const serverId = msg.data.sessionId;
-            const localId = resolveLocalSessionId(serverId);
-            if (localId) {
+            } else if (isSessionCreatedMessage(msg) && msg.data) {
+              const localId = resolveLocalSessionId(msg.data.sessionId) ?? msg.data.sessionId;
               latestRef.current.updateSessionStatus(localId, 'connected');
+              // Store the server session ID for future reconnection matching
+              latestRef.current.updateServerSessionId(localId, msg.data.sessionId);
               if (msg.data.workingDirectory) {
                 latestRef.current.updateSessionWorkingDirectory(localId, msg.data.workingDirectory);
               }
-            }
-          } else if (isScrollbackMessage(msg) && msg.sessionId && msg.data) {
-            // Find the local session mapped to this server session ID and write scrollback
-            const localId = resolveLocalSessionId(msg.sessionId);
-            if (localId) {
-              const instance = terminalsRef.current.get(localId);
-              if (instance && msg.data.data) {
+            } else if (isSessionClosedMessage(msg) && msg.data) {
+              const localId = resolveLocalSessionId(msg.data.sessionId) ?? msg.data.sessionId;
+              destroyTerminalInstance(localId);
+              latestRef.current.closeSession(localId);
+            } else if (isOutputMessage(msg) && msg.sessionId) {
+              // Output can come with server session ID — route to the right local terminal
+              const targetLocalId = resolveLocalSessionId(msg.sessionId) ?? msg.sessionId;
+              const instance = terminalsRef.current.get(targetLocalId);
+              if (instance && msg.data?.data) {
                 instance.terminal.write(msg.data.data);
               }
-            }
-          } else if (isSessionCreatedMessage(msg) && msg.data) {
-            const localId = resolveLocalSessionId(msg.data.sessionId) ?? msg.data.sessionId;
-            latestRef.current.updateSessionStatus(localId, 'connected');
-            // Store the server session ID for future reconnection matching
-            latestRef.current.updateServerSessionId(localId, msg.data.sessionId);
-            if (msg.data.workingDirectory) {
-              latestRef.current.updateSessionWorkingDirectory(localId, msg.data.workingDirectory);
-            }
-          } else if (isSessionClosedMessage(msg) && msg.data) {
-            const localId = resolveLocalSessionId(msg.data.sessionId) ?? msg.data.sessionId;
-            destroyTerminalInstance(localId);
-            latestRef.current.closeSession(localId);
-          } else if (isOutputMessage(msg) && msg.sessionId) {
-            // Output can come with server session ID — route to the right local terminal
-            const targetLocalId = resolveLocalSessionId(msg.sessionId) ?? msg.sessionId;
-            const instance = terminalsRef.current.get(targetLocalId);
-            if (instance && msg.data?.data) {
-              instance.terminal.write(msg.data.data);
-            }
-          } else if (isErrorMessage(msg)) {
-            if (msg.sessionId) {
-              const localId = resolveLocalSessionId(msg.sessionId) ?? msg.sessionId;
-              latestRef.current.updateSessionStatus(localId, 'error');
-              const instance = terminalsRef.current.get(localId);
-              const errorText = typeof msg.data === 'string' ? msg.data : JSON.stringify(msg.data);
-              if (instance) {
-                instance.terminal.writeln(`\r\n\x1b[31mError: ${errorText}\x1b[0m\r\n`);
+            } else if (isErrorMessage(msg)) {
+              if (msg.sessionId) {
+                const localId = resolveLocalSessionId(msg.sessionId) ?? msg.sessionId;
+                latestRef.current.updateSessionStatus(localId, 'error');
+                const instance = terminalsRef.current.get(localId);
+                const errorText =
+                  typeof msg.data === 'string' ? msg.data : JSON.stringify(msg.data);
+                if (instance) {
+                  instance.terminal.writeln(`\r\n\x1b[31mError: ${errorText}\x1b[0m\r\n`);
+                }
               }
             }
-          }
 
-          latestRef.current.onActivity?.();
-        };
+            latestRef.current.onActivity?.();
+          };
 
-        ws.onerror = () => {
+          ws.onerror = () => {
+            setWsConnected(false);
+          };
+
+          ws.onclose = () => {
+            setWsConnected(false);
+            wsRef.current = null;
+            reconnectingRef.current = false;
+            clearInterval(pingInterval);
+            if (!disposed) {
+              reconnectTimeout = setTimeout(connect, RECONNECT_DELAY_MS);
+            }
+          };
+        } catch {
           setWsConnected(false);
-        };
-
-        ws.onclose = () => {
-          setWsConnected(false);
-          wsRef.current = null;
-          reconnectingRef.current = false;
-          clearInterval(pingInterval);
           if (!disposed) {
             reconnectTimeout = setTimeout(connect, RECONNECT_DELAY_MS);
           }
-        };
-      } catch {
-        setWsConnected(false);
-        if (!disposed) {
-          reconnectTimeout = setTimeout(connect, RECONNECT_DELAY_MS);
         }
       }
-    }
 
-    connect();
+      connect();
 
-    return () => {
-      disposed = true;
-      clearTimeout(reconnectTimeout);
-      clearInterval(pingInterval);
-      if (currentWs) currentWs.close();
-      wsRef.current = null;
-      // Dispose all terminal instances
-      for (const [, instance] of terminalsRef.current) {
-        instance.terminal.dispose();
-      }
-      terminalsRef.current.clear();
-    };
-  }, [wsUrl, createTerminalInstance, destroyTerminalInstance, resolveLocalSessionId]);
+      return () => {
+        disposed = true;
+        clearTimeout(reconnectTimeout);
+        clearInterval(pingInterval);
+        if (currentWs) currentWs.close();
+        wsRef.current = null;
+        // Dispose all terminal instances
+        for (const [, instance] of terminalsRef.current) {
+          instance.terminal.dispose();
+        }
+        terminalsRef.current.clear();
+      };
+    }, [wsUrl, createTerminalInstance, destroyTerminalInstance, resolveLocalSessionId]);
 
-  // Attach/fit xterm.js to DOM container via ref callback
-  const attachTerminal = useCallback((sessionId: string, containerEl: HTMLDivElement | null) => {
-    const instance = terminalsRef.current.get(sessionId);
-    if (!instance) return;
+    // Attach/fit xterm.js to DOM container via ref callback
+    const attachTerminal = useCallback(
+      (sessionId: string, containerEl: HTMLDivElement | null) => {
+        const instance = terminalsRef.current.get(sessionId);
+        if (!instance) return;
 
-    if (containerEl && instance.containerEl !== containerEl) {
-      instance.containerEl = containerEl;
-      if (!containerEl.querySelector('.xterm')) {
-        instance.terminal.open(containerEl);
-      }
-      instance.fitAddon.fit();
+        if (containerEl && instance.containerEl !== containerEl) {
+          instance.containerEl = containerEl;
+          if (!containerEl.querySelector('.xterm')) {
+            instance.terminal.open(containerEl);
+          }
+          instance.fitAddon.fit();
 
-      const ws = wsRef.current;
-      if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(
-          encodeTerminalWsResize(
-            instance.terminal.rows,
-            instance.terminal.cols,
-            getOutboundSessionId(sessionId),
-          ),
-        );
-      }
-    }
-  }, [getOutboundSessionId]);
+          const ws = wsRef.current;
+          if (ws && ws.readyState === WebSocket.OPEN) {
+            ws.send(
+              encodeTerminalWsResize(
+                instance.terminal.rows,
+                instance.terminal.cols,
+                getOutboundSessionId(sessionId)
+              )
+            );
+          }
+        }
+      },
+      [getOutboundSessionId]
+    );
 
-  // Fit active terminal on window resize
-  useEffect(() => {
-    const handleResize = () => {
+    // Fit active terminal on window resize
+    useEffect(() => {
+      const handleResize = () => {
+        if (!activeSessionId) return;
+        const instance = terminalsRef.current.get(activeSessionId);
+        if (instance && instance.containerEl) {
+          instance.fitAddon.fit();
+          const ws = wsRef.current;
+          if (ws && ws.readyState === WebSocket.OPEN) {
+            ws.send(
+              encodeTerminalWsResize(
+                instance.terminal.rows,
+                instance.terminal.cols,
+                getOutboundSessionId(activeSessionId)
+              )
+            );
+          }
+        }
+      };
+      window.addEventListener('resize', handleResize);
+      return () => window.removeEventListener('resize', handleResize);
+    }, [activeSessionId, getOutboundSessionId]);
+
+    // When active tab changes, fit the terminal
+    useEffect(() => {
       if (!activeSessionId) return;
       const instance = terminalsRef.current.get(activeSessionId);
       if (instance && instance.containerEl) {
-        instance.fitAddon.fit();
-        const ws = wsRef.current;
-        if (ws && ws.readyState === WebSocket.OPEN) {
-          ws.send(
-            encodeTerminalWsResize(
-              instance.terminal.rows,
-              instance.terminal.cols,
-              getOutboundSessionId(activeSessionId),
-            ),
-          );
-        }
+        requestAnimationFrame(() => {
+          instance.fitAddon.fit();
+          instance.terminal.focus();
+          const ws = wsRef.current;
+          if (ws && ws.readyState === WebSocket.OPEN) {
+            ws.send(
+              encodeTerminalWsResize(
+                instance.terminal.rows,
+                instance.terminal.cols,
+                getOutboundSessionId(activeSessionId)
+              )
+            );
+          }
+        });
       }
-    };
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, [activeSessionId, getOutboundSessionId]);
+    }, [activeSessionId, getOutboundSessionId]);
 
-  // When active tab changes, fit the terminal
-  useEffect(() => {
-    if (!activeSessionId) return;
-    const instance = terminalsRef.current.get(activeSessionId);
-    if (instance && instance.containerEl) {
-      requestAnimationFrame(() => {
-        instance.fitAddon.fit();
-        instance.terminal.focus();
-        const ws = wsRef.current;
-        if (ws && ws.readyState === WebSocket.OPEN) {
-          ws.send(
-            encodeTerminalWsResize(
-              instance.terminal.rows,
-              instance.terminal.cols,
-              getOutboundSessionId(activeSessionId),
-            ),
-          );
-        }
-      });
-    }
-  }, [activeSessionId, getOutboundSessionId]);
+    const sessionsArray = Array.from(sessions.values());
 
-  const sessionsArray = Array.from(sessions.values());
+    useImperativeHandle(
+      ref,
+      () => ({
+        createSession: (): string | null => {
+          if (!canCreateSession) {
+            return null;
+          }
+          return handleNewTab();
+        },
+        activateSession: (sessionId: string) => {
+          activateSession(sessionId);
+        },
+        closeSession: (sessionId: string) => {
+          handleCloseTab(sessionId);
+        },
+        renameSession: (sessionId: string, name: string) => {
+          handleRenameTab(sessionId, name);
+        },
+      }),
+      [activateSession, canCreateSession, handleCloseTab, handleNewTab, handleRenameTab]
+    );
 
-  return (
-    <div className={`multi-terminal-container ${className}`} style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-      <TabBar
-        sessions={sessionsArray}
-        activeSessionId={activeSessionId}
-        onTabActivate={activateSession}
-        onTabClose={handleCloseTab}
-        onTabRename={handleRenameTab}
-        onNewTab={handleNewTab}
-        maxTabs={terminalConfig.maxSessions}
-      />
+    useEffect(() => {
+      if (!onSessionsChange) return;
 
-      <div style={{ flex: 1, position: 'relative', minHeight: 0 }}>
-        {sessionsArray.map((session) => (
-          <div
-            key={session.id}
-            style={{
-              display: session.id === activeSessionId ? 'block' : 'none',
-              position: 'absolute',
-              inset: 0,
-            }}
-          >
-            {/* Terminal container — keep DOM alive across WS disconnects (T033) */}
-            {session.status === 'error' ? (
-              <div style={{
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
-                height: '100%', color: '#f7768e', backgroundColor: '#1a1b26',
-              }}>
-                Terminal connection error. Please try again.
-              </div>
-            ) : terminalsRef.current.has(session.id) || wsConnected ? (
-              <div style={{ position: 'relative', width: '100%', height: '100%' }}>
-                <div
-                  ref={(el) => attachTerminal(session.id, el)}
-                  style={{ width: '100%', height: '100%' }}
-                />
-                {/* Per-terminal reconnecting overlay (T028) */}
-                {(session.status === 'reconnecting' || (!wsConnected && session.status !== 'connecting')) && (
-                  <div style={{
-                    position: 'absolute', inset: 0,
-                    display: 'flex', alignItems: 'center', justifyContent: 'center',
-                    backgroundColor: 'rgba(26, 27, 38, 0.7)',
-                    color: '#7aa2f7', fontSize: '14px', zIndex: 10,
-                  }}>
-                    Reconnecting...
-                  </div>
-                )}
-              </div>
-            ) : (
-              <div style={{
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
-                height: '100%', color: '#a9b1d6', backgroundColor: '#1a1b26',
-              }}>
-                Connecting to terminal...
-              </div>
-            )}
-          </div>
-        ))}
+      const snapshots: MultiTerminalSessionSnapshot[] = sessionsArray
+        .slice()
+        .sort((a, b) => a.order - b.order)
+        .map((session) => ({
+          id: session.id,
+          name: session.name,
+          status: session.status,
+          workingDirectory: session.workingDirectory,
+          serverSessionId: session.serverSessionId,
+        }));
 
-        {sessions.size === 0 && (
-          <div style={{
-            display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
-            height: '100%', color: '#a9b1d6', backgroundColor: '#1a1b26', gap: '16px',
-          }}>
-            <p>No terminal sessions</p>
-            <button
-              onClick={handleNewTab}
-              disabled={!canCreateSession}
+      onSessionsChange(snapshots, activeSessionId);
+    }, [activeSessionId, onSessionsChange, sessionsArray]);
+
+    return (
+      <div
+        className={`multi-terminal-container ${className}`}
+        style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
+      >
+        {!hideTabBar && (
+          <TabBar
+            sessions={sessionsArray}
+            activeSessionId={activeSessionId}
+            onTabActivate={activateSession}
+            onTabClose={handleCloseTab}
+            onTabRename={handleRenameTab}
+            onNewTab={handleNewTab}
+            maxTabs={terminalConfig.maxSessions}
+          />
+        )}
+
+        <div style={{ flex: 1, position: 'relative', minHeight: 0 }}>
+          {sessionsArray.map((session) => (
+            <div
+              key={session.id}
               style={{
-                padding: '8px 16px', border: '1px solid #7aa2f7', borderRadius: '4px',
-                backgroundColor: 'transparent', color: '#7aa2f7', cursor: 'pointer',
+                display: session.id === activeSessionId ? 'block' : 'none',
+                position: 'absolute',
+                inset: 0,
               }}
             >
-              Create New Terminal
-            </button>
-          </div>
-        )}
+              {/* Terminal container — keep DOM alive across WS disconnects (T033) */}
+              {session.status === 'error' ? (
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '100%',
+                    color: '#f7768e',
+                    backgroundColor: '#1a1b26',
+                  }}
+                >
+                  Terminal connection error. Please try again.
+                </div>
+              ) : terminalsRef.current.has(session.id) || wsConnected ? (
+                <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+                  <div
+                    ref={(el) => attachTerminal(session.id, el)}
+                    style={{ width: '100%', height: '100%' }}
+                  />
+                  {/* Per-terminal reconnecting overlay (T028) */}
+                  {(session.status === 'reconnecting' ||
+                    (!wsConnected && session.status !== 'connecting')) && (
+                    <div
+                      style={{
+                        position: 'absolute',
+                        inset: 0,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        backgroundColor: 'rgba(26, 27, 38, 0.7)',
+                        color: '#7aa2f7',
+                        fontSize: '14px',
+                        zIndex: 10,
+                      }}
+                    >
+                      Reconnecting...
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '100%',
+                    color: '#a9b1d6',
+                    backgroundColor: '#1a1b26',
+                  }}
+                >
+                  Connecting to terminal...
+                </div>
+              )}
+            </div>
+          ))}
+
+          {sessions.size === 0 && (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                height: '100%',
+                color: '#a9b1d6',
+                backgroundColor: '#1a1b26',
+                gap: '16px',
+              }}
+            >
+              <p>No terminal sessions</p>
+              <button
+                onClick={handleNewTab}
+                disabled={!canCreateSession}
+                style={{
+                  padding: '8px 16px',
+                  border: '1px solid #7aa2f7',
+                  borderRadius: '4px',
+                  backgroundColor: 'transparent',
+                  color: '#7aa2f7',
+                  cursor: 'pointer',
+                }}
+              >
+                Create New Terminal
+              </button>
+            </div>
+          )}
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+);
+
+MultiTerminal.displayName = 'MultiTerminal';

--- a/packages/terminal/src/index.ts
+++ b/packages/terminal/src/index.ts
@@ -39,6 +39,8 @@ export type {
   UseTabShortcutsReturn,
   TabShortcutActions,
   MultiTerminalError,
+  MultiTerminalHandle,
+  MultiTerminalSessionSnapshot,
   PersistedSession,
 } from './types/multi-terminal';
 

--- a/packages/terminal/src/types/multi-terminal.ts
+++ b/packages/terminal/src/types/multi-terminal.ts
@@ -69,7 +69,15 @@ export interface ClientMessage {
   sessionId?: string;
 
   /** Message type */
-  type: 'input' | 'resize' | 'ping' | 'create_session' | 'close_session' | 'rename_session' | 'list_sessions' | 'reattach_session';
+  type:
+    | 'input'
+    | 'resize'
+    | 'ping'
+    | 'create_session'
+    | 'close_session'
+    | 'rename_session'
+    | 'list_sessions'
+    | 'reattach_session';
 
   /** Message payload */
   data?: any;
@@ -80,7 +88,17 @@ export interface ServerMessage {
   sessionId?: string;
 
   /** Message type */
-  type: 'output' | 'session' | 'error' | 'pong' | 'session_created' | 'session_closed' | 'session_renamed' | 'session_list' | 'session_reattached' | 'scrollback';
+  type:
+    | 'output'
+    | 'session'
+    | 'error'
+    | 'pong'
+    | 'session_created'
+    | 'session_closed'
+    | 'session_renamed'
+    | 'session_list'
+    | 'session_reattached'
+    | 'scrollback';
 
   /** Message payload */
   data?: any;
@@ -262,6 +280,32 @@ export interface MultiTerminalProps {
 
   /** Key for sessionStorage persistence. Sessions survive page refresh while VM is alive. */
   persistenceKey?: string;
+
+  /** Hide the built-in terminal tab bar when parent renders its own tab UI. */
+  hideTabBar?: boolean;
+
+  /** Emits session snapshots whenever terminal sessions or active tab changes. */
+  onSessionsChange?: (
+    sessions: MultiTerminalSessionSnapshot[],
+    activeSessionId: string | null
+  ) => void;
+}
+
+/** Read-only terminal session snapshot for parent-level tab UIs. */
+export interface MultiTerminalSessionSnapshot {
+  id: string;
+  name: string;
+  status: TerminalSession['status'];
+  workingDirectory?: string;
+  serverSessionId?: string;
+}
+
+/** Imperative API for controlling MultiTerminal from parent components. */
+export interface MultiTerminalHandle {
+  createSession: () => string | null;
+  activateSession: (sessionId: string) => void;
+  closeSession: (sessionId: string) => void;
+  renameSession: (sessionId: string, name: string) => void;
 }
 
 /**

--- a/packages/vm-agent/internal/server/git_credential_test.go
+++ b/packages/vm-agent/internal/server/git_credential_test.go
@@ -106,3 +106,52 @@ func TestHandleGitCredentialControlPlaneFailure(t *testing.T) {
 		t.Fatal("expected error message in response body")
 	}
 }
+
+func TestHandleGitCredentialUsesWorkspaceScopedTokenAndWorkspaceID(t *testing.T) {
+	t.Parallel()
+
+	controlPlane := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST method, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/workspaces/ws-abc/git-token" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer workspace-callback-token" {
+			t.Fatalf("unexpected Authorization header: %q", r.Header.Get("Authorization"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token":"ghs_workspace_token","expiresAt":"2026-01-01T00:00:00Z"}`))
+	}))
+	defer controlPlane.Close()
+
+	s := &Server{
+		config: &config.Config{
+			ControlPlaneURL: controlPlane.URL,
+			CallbackToken:   "node-callback-token",
+		},
+		workspaces: map[string]*WorkspaceRuntime{
+			"ws-abc": {
+				ID:            "ws-abc",
+				CallbackToken: "workspace-callback-token",
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/git-credential?workspaceId=ws-abc", nil)
+	req.Header.Set("Authorization", "Bearer workspace-callback-token")
+
+	rec := httptest.NewRecorder()
+	s.handleGitCredential(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	got := rec.Body.String()
+	want := "protocol=https\nhost=github.com\nusername=x-access-token\npassword=ghs_workspace_token\n\n"
+	if got != want {
+		t.Fatalf("unexpected body:\n%s\nwant:\n%s", got, want)
+	}
+}

--- a/packages/vm-agent/internal/server/server.go
+++ b/packages/vm-agent/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -44,13 +45,17 @@ type Server struct {
 }
 
 type WorkspaceRuntime struct {
-	ID         string
-	Repository string
-	Branch     string
-	Status     string
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
-	PTY        *pty.Manager
+	ID                  string
+	Repository          string
+	Branch              string
+	Status              string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+	WorkspaceDir        string
+	ContainerLabelValue string
+	ContainerWorkDir    string
+	CallbackToken       string
+	PTY                 *pty.Manager
 }
 
 type EventRecord struct {
@@ -158,11 +163,17 @@ func New(cfg *config.Config) (*Server, error) {
 
 	if cfg.WorkspaceID != "" {
 		s.workspaces[cfg.WorkspaceID] = &WorkspaceRuntime{
-			ID:        cfg.WorkspaceID,
-			Status:    "running",
-			CreatedAt: time.Now().UTC(),
-			UpdatedAt: time.Now().UTC(),
-			PTY:       ptyManager,
+			ID:                  cfg.WorkspaceID,
+			Repository:          strings.TrimSpace(cfg.Repository),
+			Branch:              strings.TrimSpace(cfg.Branch),
+			Status:              "running",
+			CreatedAt:           time.Now().UTC(),
+			UpdatedAt:           time.Now().UTC(),
+			WorkspaceDir:        strings.TrimSpace(cfg.WorkspaceDir),
+			ContainerLabelValue: strings.TrimSpace(cfg.ContainerLabelValue),
+			ContainerWorkDir:    strings.TrimSpace(cfg.ContainerWorkDir),
+			CallbackToken:       strings.TrimSpace(cfg.CallbackToken),
+			PTY:                 ptyManager,
 		}
 	}
 

--- a/packages/vm-agent/internal/server/websocket.go
+++ b/packages/vm-agent/internal/server/websocket.go
@@ -177,7 +177,7 @@ func (s *Server) handleTerminalWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	runtime := s.upsertWorkspaceRuntime(workspaceID, "", "", "running")
+	runtime := s.upsertWorkspaceRuntime(workspaceID, "", "", "running", "")
 
 	upgrader := s.createUpgrader()
 	conn, err := upgrader.Upgrade(w, r, nil)
@@ -300,7 +300,7 @@ func (s *Server) handleMultiTerminalWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	runtime := s.upsertWorkspaceRuntime(workspaceID, "", "", "running")
+	runtime := s.upsertWorkspaceRuntime(workspaceID, "", "", "running", "")
 
 	upgrader := s.createUpgrader()
 	conn, err := upgrader.Upgrade(w, r, nil)

--- a/packages/vm-agent/internal/server/workspace_provisioning.go
+++ b/packages/vm-agent/internal/server/workspace_provisioning.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/workspace/vm-agent/internal/bootstrap"
+)
+
+func (s *Server) callbackTokenForWorkspace(workspaceID string) string {
+	if runtime, ok := s.getWorkspaceRuntime(workspaceID); ok {
+		if token := strings.TrimSpace(runtime.CallbackToken); token != "" {
+			return token
+		}
+	}
+
+	return strings.TrimSpace(s.config.CallbackToken)
+}
+
+func (s *Server) provisionWorkspaceRuntime(ctx context.Context, runtime *WorkspaceRuntime) error {
+	if runtime == nil {
+		return fmt.Errorf("workspace runtime is required")
+	}
+
+	callbackToken := strings.TrimSpace(runtime.CallbackToken)
+	if callbackToken == "" {
+		callbackToken = strings.TrimSpace(s.config.CallbackToken)
+	}
+
+	cfg := *s.config
+	cfg.WorkspaceID = runtime.ID
+	cfg.Repository = strings.TrimSpace(runtime.Repository)
+	cfg.Branch = strings.TrimSpace(runtime.Branch)
+	cfg.WorkspaceDir = strings.TrimSpace(runtime.WorkspaceDir)
+	cfg.ContainerLabelValue = strings.TrimSpace(runtime.ContainerLabelValue)
+	cfg.ContainerWorkDir = strings.TrimSpace(runtime.ContainerWorkDir)
+	cfg.CallbackToken = callbackToken
+
+	provisionCtx := ctx
+	cancel := func() {}
+	if s.config.BootstrapTimeout > 0 {
+		provisionCtx, cancel = context.WithTimeout(ctx, s.config.BootstrapTimeout)
+	}
+	defer cancel()
+
+	gitToken, err := s.fetchGitTokenForWorkspace(provisionCtx, runtime.ID, callbackToken)
+	if err != nil {
+		log.Printf("Workspace %s: proceeding without git token: %v", runtime.ID, err)
+	}
+
+	return bootstrap.PrepareWorkspace(provisionCtx, &cfg, bootstrap.ProvisionState{
+		GitHubToken: gitToken,
+	})
+}

--- a/packages/vm-agent/internal/server/workspaces_test.go
+++ b/packages/vm-agent/internal/server/workspaces_test.go
@@ -28,6 +28,8 @@ func TestWorkspaceManagementSourceContract(t *testing.T) {
 		"handleDeleteWorkspace",
 		"closeAgentGateway",
 		"closeAgentGatewaysForWorkspace",
+		"callbackToken",
+		"provisionWorkspaceRuntime",
 	} {
 		if !strings.Contains(content, needle) {
 			t.Fatalf("expected %q in %s", needle, path)

--- a/specs/014-multi-workspace-nodes/contracts/node-agent-api.md
+++ b/specs/014-multi-workspace-nodes/contracts/node-agent-api.md
@@ -28,7 +28,8 @@
 
 - `POST /workspaces`
 - Creates a workspace runtime on the node.
-- Body includes: `workspaceId`, `repository`, `branch`, optional runtime settings.
+- Body includes: `workspaceId`, `repository`, `branch`, `callbackToken`, optional runtime settings.
+- `callbackToken` is workspace-scoped and is used by the Node Agent for control-plane callbacks and per-workspace credential fetches.
 
 - `GET /workspaces/{workspaceId}`
 - Returns workspace runtime status/details.
@@ -75,6 +76,7 @@ Typical codes: `unauthorized`, `forbidden`, `workspace_not_found`, `workspace_no
 ## Related Control Plane Callback Endpoints
 
 Node Agent callback targets exposed by Control Plane:
+
 - `POST https://api.${BASE_DOMAIN}/api/nodes/{nodeId}/ready`
 - `POST https://api.${BASE_DOMAIN}/api/nodes/{nodeId}/heartbeat`
 

--- a/specs/014-multi-workspace-nodes/quickstart.md
+++ b/specs/014-multi-workspace-nodes/quickstart.md
@@ -14,17 +14,20 @@ This quickstart describes the expected user flow once the Multi-Workspace Nodes 
 ## Create a Node
 
 UI flow:
+
 1. Go to Nodes.
 2. Click Create Node.
 3. Choose a name (and optionally size/location).
 4. Wait for the Node to become Ready.
 
 API flow (conceptual):
+
 - `POST https://api.${BASE_DOMAIN}/api/nodes`
 
 ## Create Multiple Workspaces on the Same Node
 
 UI flow:
+
 1. Open a Node.
 2. Click Create Workspace.
 3. Select the repository and branch.
@@ -32,22 +35,33 @@ UI flow:
 5. Repeat to create Workspace B on the same Node.
 
 Behavior:
+
 - If you try to create two Workspaces with the same name on a Node, the system auto-adjusts the second name to a unique display name and shows you the final name.
 - Workspaces are isolated: stopping or deleting Workspace A does not interrupt Workspace B.
 - You can rename a Workspace later; if the target name already exists on the same Node, the system auto-adjusts to a unique final name.
 
 API flow (conceptual):
+
 - `POST https://api.${BASE_DOMAIN}/api/workspaces` with `nodeId`
 
 ## Open a Workspace and Start an Agent Session
 
 UI flow:
+
 1. From the Control Plane, open a Workspace details page.
 2. Click Open Workspace (loads the Workspace UI via its `ws-{workspaceId}` address).
-3. Click New Agent Session.
-4. Attach to the running session (including after a browser refresh while the Workspace remains running).
+3. Use the top tab bar `+` menu:
+   - Select **New Terminal Session** for a terminal tab.
+   - Select **New Chat Session** (or a specific agent option when multiple agent keys are configured) for a chat tab.
+4. Attach to or switch between chat tabs (including after a browser refresh while the Workspace remains running).
+
+Agent selection behavior:
+
+- If exactly one configured agent key is available, creating a chat tab auto-selects that agent.
+- If multiple configured agent keys are available, the `+` menu shows agent-specific chat options so the user can choose before session start.
 
 Behavior:
+
 - Agent Sessions do not survive Workspace stop/restart.
 - Stopping/restarting a Workspace terminates all its Agent Sessions and they become non-attachable.
 - By default, only one interactive attachment is active per Agent Session; a second attach shows a clear "already attached" conflict unless the user explicitly chooses takeover.
@@ -56,6 +70,7 @@ Behavior:
 ## Run Services Without Port Conflicts
 
 Expected behavior:
+
 - Two Workspaces on the same Node can run the same service ports concurrently (for example, both can run a web server on the same internal port) without conflicts.
 - The system provides per-Workspace access so you can reach the correct Workspace's running services independently.
 
@@ -71,12 +86,14 @@ Expected behavior:
 ## Inspect Events and Logs
 
 Expected behavior:
+
 - You can view Node-level events/logs (for example, provisioning and Node Agent health events).
 - You can view Workspace-level events/logs (for example, creation, restart, and failure events).
 - Node health includes freshness/check-in information and a derived `healthy`/`stale`/`unhealthy` state so stale Nodes are visible in the Control Plane.
 - Staleness uses a configurable threshold (for example `NODE_HEARTBEAT_STALE_SECONDS`), not a hardcoded timeout.
 
 API flow (conceptual):
+
 - `GET https://api.${BASE_DOMAIN}/api/nodes/{nodeId}/events`
 - `GET https://api.${BASE_DOMAIN}/api/workspaces/{workspaceId}/events`
 


### PR DESCRIPTION
## Summary

- Fix node/workspace callback token regression paths that caused workspace-scoped VM agent operations (terminal/ACP/git credential) to fail after the multi-workspace node merge.
- Add workspace-scoped runtime provisioning/auth plumbing in VM Agent and API callback verification fallback for node-scoped callback tokens.
- Implement unified workspace tab UX: a top `+` menu creates terminal sessions or chat sessions, with agent-specific chat options when multiple configured ACP agents exist.

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Additional validation run (if applicable)
- [x] Mobile and desktop verification notes added for UI changes

Additional validation run:
- `go test ./...` in `packages/vm-agent`
- `pnpm --filter @simple-agent-manager/api test -- tests/unit/routes/workspaces.test.ts`
- `pnpm --filter @simple-agent-manager/web test -- tests/unit/pages/workspace.test.tsx`
- `pnpm --filter @simple-agent-manager/terminal test`

Mobile/desktop notes:
- Desktop workspace header/tab UX is updated and covered by workspace page unit tests.
- Mobile layout structure was preserved (no new mobile-only layout branch introduced).

## UI Compliance Checklist (Required for UI changes)

- [x] Mobile-first layout verified
- [x] Accessibility checks completed
- [x] Shared UI components used or exception documented

## Exceptions (If any)

- Scope: N/A
- Rationale: N/A
- Expiration: N/A

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [x] cross-component-change
- [x] business-logic-change
- [x] public-surface-change
- [x] docs-sync-change
- [x] security-sensitive-change
- [x] ui-change
- [ ] infra-change

### External References

- N/A: change was implemented using existing repo architecture/spec/contracts and existing package APIs.

### Codebase Impact Analysis

- `packages/vm-agent/internal/server/*` (workspace runtime routing, provisioning, ws/acp/auth callbacks)
- `packages/vm-agent/internal/bootstrap/bootstrap.go` (workspace provisioning helper + git credential helper query wiring)
- `apps/api/src/routes/workspaces.ts` (callback auth verification + node workspace create scheduling)
- `apps/api/src/services/node-agent.ts` (workspace create payload contract)
- `apps/web/src/pages/Workspace.tsx` (unified tabs and create menu UX)
- `packages/terminal/src/*` (imperative multi-terminal handle + session snapshot events)
- `apps/web/tests/unit/pages/workspace.test.tsx`, `apps/api/tests/unit/routes/workspaces.test.ts`, `packages/vm-agent/internal/server/git_credential_test.go`

### Documentation & Specs

- `docs/guides/multi-terminal.md`
- `specs/014-multi-workspace-nodes/contracts/node-agent-api.md`
- `specs/014-multi-workspace-nodes/quickstart.md`
- `CLAUDE.md`

### Constitution & Risk Check

- Checked Principle XI (No Hardcoded Values): no new hardcoded base URLs/timeouts/limits were introduced; existing env/config-driven values remain the source of truth.
- Key risks/tradeoffs:
  - Callback verification now accepts node-scoped callback claim for workspace callback routes when workspace belongs to that node (needed for compatibility).
  - Unified tab UX depends on configured ACP-capable agents for agent-specific menu options.

<!-- AGENT_PREFLIGHT_END -->
