### PR TITLE
fix: restore terminal/agent attach via runtime hydration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -696,6 +696,7 @@ You can also trigger deployment manually via GitHub Actions → Deploy → Run w
 - `POST /api/nodes/:id/heartbeat` - Node Agent heartbeat callback
 - `POST /api/workspaces/:id/ready` - Workspace ready callback
 - `POST /api/workspaces/:id/heartbeat` - Workspace activity heartbeat callback
+- `GET /api/workspaces/:id/runtime` - Workspace runtime metadata callback (repository/branch for recovery)
 - `POST /api/workspaces/:id/boot-log` - Workspace boot progress log callback
 - `POST /api/bootstrap/:token` - Redeem one-time bootstrap token (credentials + git identity)
 - `POST /api/agent/ready` - VM agent ready callback
@@ -777,6 +778,7 @@ See `apps/api/.env.example`:
 
 ## Recent Changes
 - 014-multi-workspace-nodes: Added VM Agent workspace recovery on terminal/ACP attach (rebuilds missing devcontainers and recreates missing in-memory agent sessions by explicit `sessionId`), and ACP client now surfaces gateway error payloads instead of stalling in a waiting state
+- 014-multi-workspace-nodes: Added callback-auth runtime metadata endpoint (`GET /api/workspaces/:id/runtime`) and legacy workspace layout recovery so node restarts can rehydrate terminal/ACP context before attach
 - 014-multi-workspace-nodes: Added first-class Nodes with multi-workspace hosting, node/workspace event streams, agent sessions, node-scoped routing/auth, and explicit lifecycle control (no idle-triggered shutdown)
 - 014-auth-profile-sync: Resolve and persist the GitHub account primary email at login (via `/user/emails`) and propagate git user name/email into workspace bootstrap so VM agent configures commit identity
 - 004-mvp-hardening: Secure bootstrap tokens, workspace ownership validation, provisioning timeouts, shared terminal package, WebSocket reconnection, idle deadline tracking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,7 @@ All configuration lives in **GitHub Settings -> Environments -> production**:
 - `POST /api/nodes/:id/heartbeat` — Node Agent heartbeat callback
 - `POST /api/workspaces/:id/ready` — Workspace ready callback
 - `POST /api/workspaces/:id/heartbeat` — Workspace activity heartbeat callback
+- `GET /api/workspaces/:id/runtime` — Workspace runtime metadata callback (repository/branch for recovery)
 - `POST /api/workspaces/:id/boot-log` — Workspace boot progress log callback
 - `POST /api/bootstrap/:token` — Redeem one-time bootstrap token (credentials + git identity)
 - `POST /api/agent/ready` — VM agent ready callback
@@ -254,6 +255,7 @@ Claude Code now supports dual authentication methods:
 
 ## Recent Changes
 - 014-multi-workspace-nodes: Added VM Agent workspace recovery on terminal/ACP attach (rebuilds missing devcontainers and recreates missing in-memory agent sessions by explicit `sessionId`), and ACP client now surfaces gateway error payloads instead of stalling in a waiting state
+- 014-multi-workspace-nodes: Added callback-auth runtime metadata endpoint (`GET /api/workspaces/:id/runtime`) and legacy workspace layout recovery so node restarts can rehydrate terminal/ACP context before attach
 - 014-multi-workspace-nodes: Added workspace-scoped callback token flow for Node Agent workspace provisioning/ACP/git credential requests, and unified workspace tab creation UX (`+` menu for terminal/chat sessions with agent-specific chat options when multiple agent keys are configured)
 - 014-multi-workspace-nodes: Added first-class Nodes with multi-workspace hosting, node/workspace event streams, agent sessions, node-scoped routing/auth, and explicit lifecycle control (no idle-triggered shutdown)
 - 014-auth-profile-sync: Resolve and persist the GitHub account primary email at login (via `/user/emails`) and propagate git user name/email into workspace bootstrap so VM agent configures commit identity

--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ docs/                 # Documentation
 | `/api/workspaces/:id/agent-sessions/:sessionId/stop` | `POST` | Stop agent session               |
 | `/api/workspaces/:id/ready`                      | `POST`   | Workspace ready callback         |
 | `/api/workspaces/:id/heartbeat`                  | `POST`   | Workspace heartbeat callback     |
+| `/api/workspaces/:id/runtime`                    | `GET`    | Workspace runtime metadata callback |
+| `/api/workspaces/:id/boot-log`                   | `POST`   | Workspace boot-log callback      |
 
 ### Terminal
 

--- a/apps/api/tests/unit/routes/workspaces.test.ts
+++ b/apps/api/tests/unit/routes/workspaces.test.ts
@@ -57,4 +57,11 @@ describe('workspaces routes source contract', () => {
     expect(file).toContain('payload.workspace === workspace.nodeId');
     expect(file).toContain("throw errors.forbidden('Token workspace mismatch')");
   });
+
+  it('exposes callback-auth runtime metadata for node recovery', () => {
+    expect(file).toContain("path.endsWith('/runtime')");
+    expect(file).toContain("workspacesRoutes.get('/:id/runtime'");
+    expect(file).toContain('repository: schema.workspaces.repository');
+    expect(file).toContain('branch: schema.workspaces.branch');
+  });
 });

--- a/apps/web/src/components/AgentSessionList.tsx
+++ b/apps/web/src/components/AgentSessionList.tsx
@@ -4,7 +4,7 @@ import { Button } from '@simple-agent-manager/ui';
 interface AgentSessionListProps {
   sessions: AgentSession[];
   loading?: boolean;
-  onCreate: () => void;
+  onCreate?: () => void;
   onAttach: (sessionId: string) => void;
   onStop: (sessionId: string) => void;
 }
@@ -35,9 +35,11 @@ export function AgentSessionList({
         }}
       >
         <strong style={{ fontSize: '0.875rem' }}>Agent Sessions</strong>
-        <Button size="sm" onClick={onCreate} disabled={loading}>
-          New Session
-        </Button>
+        {onCreate && (
+          <Button size="sm" onClick={onCreate} disabled={loading}>
+            New Session
+          </Button>
+        )}
       </div>
 
       {sessions.length === 0 ? (

--- a/apps/web/src/pages/Workspace.tsx
+++ b/apps/web/src/pages/Workspace.tsx
@@ -502,6 +502,7 @@ export function Workspace() {
   };
 
   const defaultAgentId = configuredAgents.length === 1 ? configuredAgents[0]!.id : null;
+  const defaultAgentName = defaultAgentId ? agentNameById.get(defaultAgentId) ?? null : null;
 
   const visibleTerminalTabs = useMemo<MultiTerminalSessionSnapshot[]>(() => {
     if (terminalTabs.length > 0) {
@@ -1080,7 +1081,7 @@ export function Workspace() {
                         opacity: configuredAgents.length === 0 ? 0.65 : 1,
                       }}
                     >
-                      New Chat Session
+                      {defaultAgentName ? `New ${defaultAgentName} Chat` : 'New Chat Session'}
                     </button>
                   ) : (
                     configuredAgents.map((agent) => (
@@ -1100,7 +1101,7 @@ export function Workspace() {
                           cursor: 'pointer',
                         }}
                       >
-                        New {agent.name} Chat
+                        New {agent.name}
                       </button>
                     ))
                   )}
@@ -1253,13 +1254,6 @@ export function Workspace() {
           <AgentSessionList
             sessions={agentSessions}
             loading={sessionsLoading}
-            onCreate={() => {
-              if (configuredAgents.length > 1) {
-                setCreateMenuOpen(true);
-                return;
-              }
-              void handleCreateSession(defaultAgentId ?? undefined);
-            }}
             onAttach={handleAttachSession}
             onStop={handleStopSession}
           />

--- a/docs/guides/local-system-smoke-tests.md
+++ b/docs/guides/local-system-smoke-tests.md
@@ -14,7 +14,7 @@ That full path is best validated in staging. This harness validates the core run
 
 - Terminal WebSocket auth and PTY execution
 - ACP WebSocket agent selection and subprocess wiring
-- VM Agent -> control plane callback (`/api/workspaces/:id/agent-key`)
+- VM Agent -> control plane callbacks (`/api/workspaces/:id/agent-key`, `/api/workspaces/:id/runtime`)
 - VM Agent container discovery + `docker exec` into a workspace container
 
 ## Test topology


### PR DESCRIPTION
## Summary

- Fix terminal/ACP attach failures after node runtime state loss by adding callback-auth workspace runtime metadata retrieval (`GET /api/workspaces/:id/runtime`) and using it during vm-agent recovery.
- Improve vm-agent recovery to hydrate missing repository/branch context, adopt legacy workspace layout when present, and rebuild PTY manager config before retrying attach.
- Polish workspace tab UX so session creation is consistently driven from the top `+` menu (terminal + agent-specific chat options).

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Additional validation run (if applicable)
- [x] Mobile and desktop verification notes added for UI changes

Additional validation:
- `pnpm --filter @simple-agent-manager/api test -- tests/unit/routes/workspaces.test.ts`
- `pnpm --filter @simple-agent-manager/web test -- tests/unit/pages/workspace.test.tsx`
- `pnpm --filter @simple-agent-manager/web typecheck`
- `cd packages/vm-agent && go test ./...`

Mobile/desktop note:
- UI behavior change is limited to session-create entry points and labels in the existing desktop workspace header flow; mobile layout/controls were not structurally changed.

## UI Compliance Checklist (Required for UI changes)

- [x] Mobile-first layout verified
- [x] Accessibility checks completed
- [x] Shared UI components used or exception documented

## Exceptions (If any)

- Scope: None
- Rationale: N/A
- Expiration: N/A

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [x] cross-component-change
- [x] business-logic-change
- [x] public-surface-change
- [x] docs-sync-change
- [ ] security-sensitive-change
- [x] ui-change
- [ ] infra-change

### External References

N/A: change uses internal API/routes and existing project architecture docs.

### Codebase Impact Analysis

- `apps/api/src/routes/workspaces.ts` callback auth allowlist + runtime metadata endpoint
- `apps/api/tests/unit/routes/workspaces.test.ts` route/source contract updates
- `packages/vm-agent/internal/server/workspace_provisioning.go` runtime hydration + recovery flow
- `packages/vm-agent/internal/server/workspace_routing.go` PTY manager rebuild helper
- `packages/vm-agent/internal/server/workspace_provisioning_test.go` recovery and parsing tests
- `apps/web/src/pages/Workspace.tsx` create-menu UX polish
- `apps/web/src/components/AgentSessionList.tsx` optional sidebar create action
- `apps/web/tests/unit/pages/workspace.test.tsx` create-menu behavior tests

### Documentation & Specs

Updated:
- `AGENTS.md`
- `CLAUDE.md`
- `README.md`
- `docs/guides/local-system-smoke-tests.md`

No `specs/` updates in this task (outside active spec-edit scope).

### Constitution & Risk Check

- Checked Principle XI (No Hardcoded Values): no new hardcoded service hostnames/timeouts/limits introduced; control-plane host remains `config.ControlPlaneURL` and timeout behavior uses existing `BootstrapTimeout` config.
- Risk/tradeoff: recovery now performs one additional callback-auth metadata call during degraded attach flows; this increases control-plane dependency only when runtime context is missing.

<!-- AGENT_PREFLIGHT_END -->
