### PR TITLE
fix(api): abort stalled fresh-node readiness probes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -783,6 +783,7 @@ See `apps/api/.env.example`:
 - Cloudflare D1 (SQLite) for app state; Cloudflare KV for bootstrap tokens and boot logs; Cloudflare R2 for Node Agent binaries (014-multi-workspace-nodes)
 
 ## Recent Changes
+- 014-multi-workspace-nodes: Fresh-node readiness probing now enforces per-request probe timeouts (AbortController) so workspace creation fails fast with explicit timeout errors instead of hanging in `creating` when `/health` calls stall
 - 014-multi-workspace-nodes: Workspace creation now waits for fresh node-agent backend readiness (`/health`) before dispatching first node workspace create, avoiding immediate fresh-node routing failures (for example Cloudflare 1014/404 races)
 - 014-multi-workspace-nodes: VM Agent legacy-layout recovery now adopts repo-specific workspace paths even when the current runtime path is the existing generic base workspace dir (for example `/workspace`), preventing stale terminal container-label routing on recovered sessions
 - 014-multi-workspace-nodes: VM Agent now avoids reusing legacy single-workspace PTY manager wiring when runtime recovery updates workspace/container paths, so terminal attach uses the recovered workspace-specific devcontainer label instead of stale `/workspace` routing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,7 @@ Claude Code now supports dual authentication methods:
 - Cloudflare D1 (SQLite) for app state; Cloudflare KV for bootstrap tokens and boot logs; Cloudflare R2 for Node Agent binaries (014-multi-workspace-nodes)
 
 ## Recent Changes
+- 014-multi-workspace-nodes: Fresh-node readiness probing now enforces per-request probe timeouts (AbortController) so workspace creation fails fast with explicit timeout errors instead of hanging in `creating` when `/health` calls stall
 - 014-multi-workspace-nodes: Workspace creation now waits for fresh node-agent backend readiness (`/health`) before dispatching first node workspace create, avoiding immediate fresh-node routing failures (for example Cloudflare 1014/404 races)
 - 014-multi-workspace-nodes: VM Agent legacy-layout recovery now adopts repo-specific workspace paths even when the current runtime path is the existing generic base workspace dir (for example `/workspace`), preventing stale terminal container-label routing on recovered sessions
 - 014-multi-workspace-nodes: VM Agent now avoids reusing legacy single-workspace PTY manager wiring when runtime recovery updates workspace/container paths, so terminal attach uses the recovered workspace-specific devcontainer label instead of stale `/workspace` routing


### PR DESCRIPTION
## Summary

- Prevent `waitForNodeAgentReady()` from hanging when node `/health` requests stall.
- Each readiness probe now uses `AbortController` and is bounded by the current remaining readiness window.
- Timeout errors now include explicit probe-timeout details to aid diagnosis.
- Added unit coverage for hung-fetch abort behavior and updated existing readiness-fetch assertion for signal usage.
- Synced `AGENTS.md` and `CLAUDE.md` Recent Changes with this behavior update.

## Validation

- [x] `pnpm lint` (run as `pnpm --filter @simple-agent-manager/api lint`; existing warnings only)
- [x] `pnpm typecheck` (run as `pnpm --filter @simple-agent-manager/api typecheck`)
- [x] `pnpm test` (run as `pnpm --filter @simple-agent-manager/api test`)
- [x] Additional validation run (focused: `pnpm --filter @simple-agent-manager/api test -- tests/unit/services/node-agent.test.ts tests/unit/routes/workspaces.test.ts`)
- [ ] Mobile and desktop verification notes added for UI changes

## UI Compliance Checklist (Required for UI changes)

- [ ] Mobile-first layout verified
- [ ] Accessibility checks completed
- [ ] Shared UI components used or exception documented

## Exceptions (If any)

- Scope: N/A
- Rationale: N/A
- Expiration: N/A

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [ ] cross-component-change
- [x] business-logic-change
- [ ] public-surface-change
- [x] docs-sync-change
- [ ] security-sensitive-change
- [ ] ui-change
- [ ] infra-change

### External References

N/A: Internal code-path reliability fix with existing platform APIs.

### Codebase Impact Analysis

- `apps/api/src/services/node-agent.ts`
- `apps/api/tests/unit/services/node-agent.test.ts`
- `AGENTS.md`
- `CLAUDE.md`

### Documentation & Specs

- Updated: `AGENTS.md`, `CLAUDE.md`
- Specs: N/A (no spec contract or feature-scope change)

### Constitution & Risk Check

- Checked Principle XI (No Hardcoded Values): no hardcoded URLs/limits/timeouts added.
- Health URL remains derived from `BASE_DOMAIN`.
- Probe timeout uses existing configurable readiness timeout/poll interval env vars.
- Risk: slightly more aggressive readiness failures for severely degraded nodes, but this is preferable to indefinite `creating` hangs.

<!-- AGENT_PREFLIGHT_END -->
