### PR TITLE
fix(workspace): restore chat attach and provisioning failure status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -699,6 +699,7 @@ You can also trigger deployment manually via GitHub Actions → Deploy → Run w
 - `POST /api/nodes/:id/ready` - Node Agent ready callback
 - `POST /api/nodes/:id/heartbeat` - Node Agent heartbeat callback
 - `POST /api/workspaces/:id/ready` - Workspace ready callback
+- `POST /api/workspaces/:id/provisioning-failed` - Workspace provisioning failure callback (sets workspace to `error` when provisioning fails)
 - `POST /api/workspaces/:id/heartbeat` - Workspace activity heartbeat callback
 - `GET /api/workspaces/:id/runtime` - Workspace runtime metadata callback (repository/branch for recovery)
 - `POST /api/workspaces/:id/boot-log` - Workspace boot progress log callback
@@ -783,6 +784,8 @@ See `apps/api/.env.example`:
 - Cloudflare D1 (SQLite) for app state; Cloudflare KV for bootstrap tokens and boot logs; Cloudflare R2 for Node Agent binaries (014-multi-workspace-nodes)
 
 ## Recent Changes
+- 014-multi-workspace-nodes: Workspace provisioning failures now callback via `POST /api/workspaces/:id/provisioning-failed`, so control-plane status transitions to `error` even when long background create tasks outlive Worker `waitUntil` execution windows
+- 014-multi-workspace-nodes: VM Agent ACP WebSocket workspace routing now resolves workspace scope from token/session context for browser clients (instead of requiring `X-SAM-Workspace-Id`), restoring chat attach for Claude/Codex sessions
 - 014-multi-workspace-nodes: Workspace desktop session tabs now use an integrated terminal-style strip above the content area (instead of crowded header chips) with a `+` dropdown that creates terminal sessions or agent-specific chat sessions (`terminal` + `claude/codex/...` when multiple agent keys are configured)
 - 014-multi-workspace-nodes: Fresh-node readiness probing now enforces hard per-request timeouts (`Promise.race` + `AbortController`) so workspace creation fails fast with explicit timeout errors even when runtime fetch abort signals are ignored
 - 014-multi-workspace-nodes: Workspace creation now waits for fresh node-agent backend readiness (`/health`) before dispatching first node workspace create, avoiding immediate fresh-node routing failures (for example Cloudflare 1014/404 races)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ All configuration lives in **GitHub Settings -> Environments -> production**:
 - `POST /api/nodes/:id/ready` — Node Agent ready callback
 - `POST /api/nodes/:id/heartbeat` — Node Agent heartbeat callback
 - `POST /api/workspaces/:id/ready` — Workspace ready callback
+- `POST /api/workspaces/:id/provisioning-failed` — Workspace provisioning failure callback (sets workspace to `error`)
 - `POST /api/workspaces/:id/heartbeat` — Workspace activity heartbeat callback
 - `GET /api/workspaces/:id/runtime` — Workspace runtime metadata callback (repository/branch for recovery)
 - `POST /api/workspaces/:id/boot-log` — Workspace boot progress log callback
@@ -261,6 +262,8 @@ Claude Code now supports dual authentication methods:
 - Cloudflare D1 (SQLite) for app state; Cloudflare KV for bootstrap tokens and boot logs; Cloudflare R2 for Node Agent binaries (014-multi-workspace-nodes)
 
 ## Recent Changes
+- 014-multi-workspace-nodes: Workspace provisioning failures now callback via `POST /api/workspaces/:id/provisioning-failed`, so control-plane status transitions to `error` even when long background create tasks outlive Worker `waitUntil` execution windows
+- 014-multi-workspace-nodes: VM Agent ACP WebSocket workspace routing now resolves workspace scope from token/session context for browser clients (instead of requiring `X-SAM-Workspace-Id`), restoring chat attach for Claude/Codex sessions
 - 014-multi-workspace-nodes: Workspace desktop session tabs now use an integrated terminal-style strip above the content area (instead of crowded header chips) with a `+` dropdown that creates terminal sessions or agent-specific chat sessions (`terminal` + `claude/codex/...` when multiple agent keys are configured)
 - 014-multi-workspace-nodes: Fresh-node readiness probing now enforces hard per-request timeouts (`Promise.race` + `AbortController`) so workspace creation fails fast with explicit timeout errors even when runtime fetch abort signals are ignored
 - 014-multi-workspace-nodes: Workspace creation now waits for fresh node-agent backend readiness (`/health`) before dispatching first node workspace create, avoiding immediate fresh-node routing failures (for example Cloudflare 1014/404 races)

--- a/apps/api/tests/unit/routes/workspaces.test.ts
+++ b/apps/api/tests/unit/routes/workspaces.test.ts
@@ -56,6 +56,9 @@ describe('workspaces routes source contract', () => {
   it('accepts node-scoped callback tokens for workspace callbacks', () => {
     expect(file).toContain('payload.workspace === workspace.nodeId');
     expect(file).toContain("throw errors.forbidden('Token workspace mismatch')");
+    expect(file).toContain("path.endsWith('/provisioning-failed')");
+    expect(file).toContain("workspacesRoutes.post('/:id/provisioning-failed'");
+    expect(file).toContain("reason: 'workspace_not_creating'");
   });
 
   it('exposes callback-auth runtime metadata for node recovery', () => {

--- a/apps/web/src/pages/Workspace.tsx
+++ b/apps/web/src/pages/Workspace.tsx
@@ -1107,10 +1107,10 @@ export function Workspace() {
                   style={{
                     display: 'flex',
                     alignItems: 'center',
-                    gap: 6,
+                    gap: 7,
                     padding: '0 12px',
-                    minWidth: 110,
-                    maxWidth: 220,
+                    minWidth: 100,
+                    maxWidth: 180,
                     cursor: 'pointer',
                     fontSize: 13,
                     border: 'none',
@@ -1138,8 +1138,8 @@ export function Workspace() {
                   <span
                     style={{
                       display: 'inline-block',
-                      width: 8,
-                      height: 8,
+                      width: 7,
+                      height: 7,
                       borderRadius: '50%',
                       backgroundColor: statusColor,
                       flexShrink: 0,
@@ -1147,19 +1147,8 @@ export function Workspace() {
                   />
                   <span
                     style={{
-                      fontSize: 10,
-                      border: '1px solid #2a2d3a',
-                      borderRadius: 999,
-                      padding: '0 5px',
-                      lineHeight: '14px',
-                      color: '#9aa0ba',
-                      flexShrink: 0,
-                    }}
-                  >
-                    {tab.kind === 'terminal' ? 'TER' : 'CHAT'}
-                  </span>
-                  <span
-                    style={{
+                      flex: 1,
+                      minWidth: 0,
                       overflow: 'hidden',
                       textOverflow: 'ellipsis',
                       whiteSpace: 'nowrap',

--- a/packages/vm-agent/internal/server/agent_ws.go
+++ b/packages/vm-agent/internal/server/agent_ws.go
@@ -31,12 +31,13 @@ func writeSessionError(w http.ResponseWriter, statusCode int, code, message stri
 // handleAgentWS handles WebSocket connections for ACP agent communication.
 // Supports optional sessionId query for deterministic attach/takeover semantics.
 func (s *Server) handleAgentWS(w http.ResponseWriter, r *http.Request) {
-	workspaceID, ok := s.requireWorkspaceRoute(w, r)
-	if !ok {
+	workspaceID := s.resolveWorkspaceIDForWebsocket(r)
+	if workspaceID == "" {
+		writeSessionError(w, http.StatusBadRequest, "workspace_required", "Missing workspace route")
 		return
 	}
 
-	_, ok = s.authenticateWorkspaceWebsocket(w, r, workspaceID)
+	_, ok := s.authenticateWorkspaceWebsocket(w, r, workspaceID)
 	if !ok {
 		return
 	}

--- a/packages/vm-agent/internal/server/agent_ws_test.go
+++ b/packages/vm-agent/internal/server/agent_ws_test.go
@@ -42,7 +42,7 @@ func TestAgentWebSocketRoutingAndAuthContract(t *testing.T) {
 	content := string(contentBytes)
 
 	for _, needle := range []string{
-		"requireWorkspaceRoute",
+		"resolveWorkspaceIDForWebsocket",
 		"authenticateWorkspaceWebsocket",
 		"attach/stop race handling",
 	} {

--- a/packages/vm-agent/internal/server/workspace_callbacks.go
+++ b/packages/vm-agent/internal/server/workspace_callbacks.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	neturl "net/url"
+	"strings"
+)
+
+func (s *Server) notifyWorkspaceProvisioningFailed(
+	ctx context.Context,
+	workspaceID string,
+	callbackToken string,
+	errorMessage string,
+) error {
+	trimmedWorkspaceID := strings.TrimSpace(workspaceID)
+	if trimmedWorkspaceID == "" {
+		return fmt.Errorf("workspace id is required")
+	}
+
+	trimmedCallbackToken := strings.TrimSpace(callbackToken)
+	if trimmedCallbackToken == "" {
+		return fmt.Errorf("callback token is required")
+	}
+
+	payload := map[string]string{
+		"errorMessage": strings.TrimSpace(errorMessage),
+	}
+	if payload["errorMessage"] == "" {
+		payload["errorMessage"] = "workspace provisioning failed"
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal provisioning-failed payload: %w", err)
+	}
+
+	endpoint := fmt.Sprintf(
+		"%s/api/workspaces/%s/provisioning-failed",
+		strings.TrimRight(s.config.ControlPlaneURL, "/"),
+		neturl.PathEscape(trimmedWorkspaceID),
+	)
+
+	requestCtx := ctx
+	cancel := func() {}
+	if s.config.HTTPReadTimeout > 0 {
+		requestCtx, cancel = context.WithTimeout(ctx, s.config.HTTPReadTimeout)
+	}
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build provisioning-failed request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+trimmedCallbackToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send provisioning-failed request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 8*1024))
+		return fmt.Errorf(
+			"provisioning-failed callback returned HTTP %d: %s",
+			resp.StatusCode,
+			strings.TrimSpace(string(responseBody)),
+		)
+	}
+
+	return nil
+}

--- a/packages/vm-agent/internal/server/workspace_callbacks_test.go
+++ b/packages/vm-agent/internal/server/workspace_callbacks_test.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/workspace/vm-agent/internal/config"
+)
+
+func TestNotifyWorkspaceProvisioningFailed(t *testing.T) {
+	t.Run("sends callback payload with auth", func(t *testing.T) {
+		t.Parallel()
+
+		callbackToken := "test-callback-token"
+		called := false
+		controlPlane := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+
+			if r.Method != http.MethodPost {
+				t.Fatalf("expected POST, got %s", r.Method)
+			}
+			if r.URL.Path != "/api/workspaces/ws-123/provisioning-failed" {
+				t.Fatalf("unexpected path: %s", r.URL.Path)
+			}
+
+			if got := r.Header.Get("Authorization"); got != "Bearer "+callbackToken {
+				t.Fatalf("unexpected auth header: %s", got)
+			}
+
+			var payload map[string]string
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode payload: %v", err)
+			}
+			if payload["errorMessage"] != "devcontainer up failed: signal: killed" {
+				t.Fatalf("unexpected errorMessage payload: %q", payload["errorMessage"])
+			}
+
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer controlPlane.Close()
+
+		s := &Server{
+			config: &config.Config{
+				ControlPlaneURL: controlPlane.URL,
+				HTTPReadTimeout: 5 * time.Second,
+			},
+		}
+
+		err := s.notifyWorkspaceProvisioningFailed(
+			context.Background(),
+			"ws-123",
+			callbackToken,
+			"devcontainer up failed: signal: killed",
+		)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !called {
+			t.Fatal("expected callback request to be sent")
+		}
+	})
+
+	t.Run("returns error when callback endpoint fails", func(t *testing.T) {
+		t.Parallel()
+
+		controlPlane := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("control-plane-error"))
+		}))
+		defer controlPlane.Close()
+
+		s := &Server{
+			config: &config.Config{
+				ControlPlaneURL: controlPlane.URL,
+				HTTPReadTimeout: 5 * time.Second,
+			},
+		}
+
+		err := s.notifyWorkspaceProvisioningFailed(context.Background(), "ws-123", "token", "")
+		if err == nil {
+			t.Fatal("expected error for non-2xx callback response")
+		}
+		if !strings.Contains(err.Error(), "HTTP 500") {
+			t.Fatalf("expected HTTP 500 in error, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Restore agent chat WebSocket attach behavior by removing browser-impossible `X-SAM-Workspace-Id` dependency on VM Agent `GET /agent/ws` and resolving workspace scope from token/session context.
- Add explicit workspace provisioning failure callback flow:
  - New API callback endpoint `POST /api/workspaces/:id/provisioning-failed`
  - VM Agent now calls this endpoint when workspace create/restart provisioning fails.
- Keep the unified workspace session strip but simplify tab visuals to match the existing integrated terminal strip style (less clutter) while preserving the `+` dropdown for terminal/agent session creation.
- Sync docs (`AGENTS.md`, `CLAUDE.md`) for new callback endpoint and runtime behavior.

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Additional validation run (if applicable)
- [ ] Mobile and desktop verification notes added for UI changes

Additional validation:
- `pnpm --filter @simple-agent-manager/api test -- tests/unit/routes/workspaces.test.ts tests/unit/services/node-agent.test.ts`
- `pnpm --filter @simple-agent-manager/web test -- tests/unit/pages/workspace.test.tsx`
- `cd packages/vm-agent && go test ./internal/server`

## UI Compliance Checklist (Required for UI changes)

- [ ] Mobile-first layout verified
- [x] Accessibility checks completed
- [x] Shared UI components used or exception documented

## Exceptions (If any)

- Scope: Mobile verification pending live deployment check
- Rationale: Live app verification is being run immediately after deploy
- Expiration: Before merge-to-main completion of this fix cycle

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [x] cross-component-change
- [x] business-logic-change
- [x] public-surface-change
- [x] docs-sync-change
- [x] security-sensitive-change
- [x] ui-change
- [ ] infra-change

### External References

N/A: Internal code-path changes; no external API/document contract changes required.

### Codebase Impact Analysis

- `apps/api/src/routes/workspaces.ts` (new provisioning failure callback endpoint)
- `packages/vm-agent/internal/server/workspaces.go` (emit provisioning failure callback)
- `packages/vm-agent/internal/server/workspace_callbacks.go` (callback request helper)
- `packages/vm-agent/internal/server/agent_ws.go`, `packages/vm-agent/internal/server/websocket.go` (workspace routing for browser WebSocket attach)
- `apps/web/src/pages/Workspace.tsx` (tab strip visual simplification)
- Unit tests and source-contract tests across API/Web/VM Agent

### Documentation & Specs

Updated docs:
- `AGENTS.md`
- `CLAUDE.md`

No `specs/` updates in this change because this work is outside a spec-document editing scope and does not alter spec-bound feature definitions.

### Constitution & Risk Check

- Principle XI checked: no new hardcoded URLs; callback endpoint uses existing `ControlPlaneURL`, API URLs continue deriving from `BASE_DOMAIN`.
- Timeout handling uses existing VM agent config (`HTTPReadTimeout`) rather than introducing a fixed timeout constant.
- Main risk: callback delivery failures could still delay status transitions if control-plane callback is unreachable; mitigated by preserving node event logs and explicit error logging for callback failures.

<!-- AGENT_PREFLIGHT_END -->
