### PR TITLE
fix(workspace): queue fresh-node dispatch on ready callback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -784,6 +784,8 @@ See `apps/api/.env.example`:
 - Cloudflare D1 (SQLite) for app state; Cloudflare KV for bootstrap tokens and boot logs; Cloudflare R2 for Node Agent binaries (014-multi-workspace-nodes)
 
 ## Recent Changes
+- 014-multi-workspace-nodes: Node `ready` callbacks now dispatch queued `creating` workspaces on that node, so auto-created-node workspace requests are not stranded when long node bootstrap work outlives the original create-request background window
+- 014-multi-workspace-nodes: VM Agent workspace create/restart now runs provisioning asynchronously and final state is callback-driven (`/ready` or `/provisioning-failed`) instead of blocking control-plane dispatch requests on full devcontainer setup duration
 - 014-multi-workspace-nodes: Workspace provisioning failures now callback via `POST /api/workspaces/:id/provisioning-failed`, so control-plane status transitions to `error` even when long background create tasks outlive Worker `waitUntil` execution windows
 - 014-multi-workspace-nodes: VM Agent ACP WebSocket workspace routing now resolves workspace scope from token/session context for browser clients (instead of requiring `X-SAM-Workspace-Id`), restoring chat attach for Claude/Codex sessions
 - 014-multi-workspace-nodes: Workspace desktop session tabs now use an integrated terminal-style strip above the content area (instead of crowded header chips) with a `+` dropdown that creates terminal sessions or agent-specific chat sessions (`terminal` + `claude/codex/...` when multiple agent keys are configured)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,8 @@ Claude Code now supports dual authentication methods:
 - Cloudflare D1 (SQLite) for app state; Cloudflare KV for bootstrap tokens and boot logs; Cloudflare R2 for Node Agent binaries (014-multi-workspace-nodes)
 
 ## Recent Changes
+- 014-multi-workspace-nodes: Node `ready` callbacks now dispatch queued `creating` workspaces on that node, so auto-created-node workspace requests are not stranded when long node bootstrap work outlives the original create-request background window
+- 014-multi-workspace-nodes: VM Agent workspace create/restart now runs provisioning asynchronously and final state is callback-driven (`/ready` or `/provisioning-failed`) instead of blocking control-plane dispatch requests on full devcontainer setup duration
 - 014-multi-workspace-nodes: Workspace provisioning failures now callback via `POST /api/workspaces/:id/provisioning-failed`, so control-plane status transitions to `error` even when long background create tasks outlive Worker `waitUntil` execution windows
 - 014-multi-workspace-nodes: VM Agent ACP WebSocket workspace routing now resolves workspace scope from token/session context for browser clients (instead of requiring `X-SAM-Workspace-Id`), restoring chat attach for Claude/Codex sessions
 - 014-multi-workspace-nodes: Workspace desktop session tabs now use an integrated terminal-style strip above the content area (instead of crowded header chips) with a `+` dropdown that creates terminal sessions or agent-specific chat sessions (`terminal` + `claude/codex/...` when multiple agent keys are configured)

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -207,16 +207,6 @@ async function scheduleWorkspaceCreateOnNode(
       branch,
       callbackToken,
     });
-
-    await db
-      .update(schema.workspaces)
-      .set({
-        status: 'running',
-        lastActivityAt: new Date().toISOString(),
-        errorMessage: null,
-        updatedAt: new Date().toISOString(),
-      })
-      .where(eq(schema.workspaces.id, workspaceId));
   } catch (err) {
     await db
       .update(schema.workspaces)
@@ -610,15 +600,6 @@ workspacesRoutes.post('/:id/restart', async (c) => {
       const innerDb = drizzle(c.env.DATABASE, { schema });
       try {
         await restartWorkspaceOnNode(workspace.nodeId!, workspace.id, c.env, userId);
-        await innerDb
-          .update(schema.workspaces)
-          .set({
-            status: 'running',
-            errorMessage: null,
-            lastActivityAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-          })
-          .where(eq(schema.workspaces.id, workspace.id));
       } catch (err) {
         await innerDb
           .update(schema.workspaces)

--- a/apps/api/tests/unit/routes/nodes.test.ts
+++ b/apps/api/tests/unit/routes/nodes.test.ts
@@ -18,6 +18,9 @@ describe('nodes routes source contract', () => {
     expect(file).toContain("nodesRoutes.get('/:id/events',");
     expect(file).toContain("nodesRoutes.post('/:id/ready',");
     expect(file).toContain("nodesRoutes.post('/:id/heartbeat',");
+    expect(file).toContain('createWorkspaceOnNode');
+    expect(file).toContain('signCallbackToken');
+    expect(file).toContain("eq(schema.workspaces.status, 'creating')");
   });
 
   it('implements stop/delete semantics for child workspaces and sessions', () => {


### PR DESCRIPTION
## Summary

- Fix fresh-node workspace dispatch reliability by queueing `creating` workspaces and dispatching them when the node sends `POST /api/nodes/:id/ready`.
- Make VM Agent workspace create/restart provisioning asynchronous so control-plane dispatch requests return quickly and final status transitions are callback-driven (`/ready` or `/provisioning-failed`).
- Keep control-plane status updates consistent by removing premature `running` transitions in API dispatch/restart flows.
- Sync docs (`AGENTS.md`, `CLAUDE.md`) for the updated lifecycle behavior.

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Additional validation run (if applicable)
- [ ] Mobile and desktop verification notes added for UI changes

Additional validation:
- `pnpm --filter @simple-agent-manager/api test -- tests/unit/routes/workspaces.test.ts tests/unit/routes/nodes.test.ts`
- `pnpm --filter @simple-agent-manager/api typecheck`
- `cd packages/vm-agent && go test ./internal/server`

## UI Compliance Checklist (Required for UI changes)

- [ ] Mobile-first layout verified
- [x] Accessibility checks completed
- [x] Shared UI components used or exception documented

## Exceptions (If any)

- Scope: Mobile verification pending live deployment check
- Rationale: This patch is runtime/API-focused; live UX verification is performed post-deploy
- Expiration: Before merge-to-main completion of this fix cycle

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [x] cross-component-change
- [x] business-logic-change
- [x] public-surface-change
- [x] docs-sync-change
- [x] security-sensitive-change
- [ ] ui-change
- [ ] infra-change

### External References

N/A: Internal lifecycle flow changes only.

### Codebase Impact Analysis

- `apps/api/src/routes/nodes.ts`
- `apps/api/src/routes/workspaces.ts`
- `packages/vm-agent/internal/server/workspaces.go`
- `apps/api/tests/unit/routes/nodes.test.ts`
- `AGENTS.md`, `CLAUDE.md`

### Documentation & Specs

Updated docs:
- `AGENTS.md`
- `CLAUDE.md`

No `specs/` updates in this change because this work is outside spec-document editing scope and does not alter spec-bound feature definitions.

### Constitution & Risk Check

- Principle XI checked: no new hardcoded domains; callback and routing URLs remain env-derived.
- Main risk: re-dispatch loop if node-ready is emitted repeatedly while workspace remains `creating`; mitigated by callback-driven terminal states and error transitions on dispatch failures.

<!-- AGENT_PREFLIGHT_END -->
