### PR TITLE
fix(workspace): mark node-mode ready and align tab UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -784,6 +784,9 @@ See `apps/api/.env.example`:
 - Cloudflare D1 (SQLite) for app state; Cloudflare KV for bootstrap tokens and boot logs; Cloudflare R2 for Node Agent binaries (014-multi-workspace-nodes)
 
 ## Recent Changes
+- 014-multi-workspace-nodes: Node-mode `PrepareWorkspace` now calls `POST /api/workspaces/:id/ready` after successful provisioning (same as bootstrap `Run`), preventing workspaces from getting stuck in `creating` after successful devcontainer setup
+- 014-multi-workspace-nodes: VM Agent now normalizes workspace bind-mount permissions (`chmod -R a+rwX`) before `devcontainer up` so repo `postCreateCommand` steps can write files (for example `npm install` updating lockfiles) when container lifecycle commands run as non-root users
+- 014-multi-workspace-nodes: Unified workspace session tabs were refined to match the existing integrated terminal tab style and now support tab-close actions (`terminal` close for extra terminals, `chat` close to stop session) while keeping the `+` dropdown for terminal or agent-specific chat creation
 - 014-multi-workspace-nodes: Default fallback devcontainer image for repos without a `.devcontainer` config is now `mcr.microsoft.com/devcontainers/base:ubuntu` (instead of `.../universal:2`) to reduce bootstrap resource pressure and avoid frequent `devcontainer up ... signal: killed` failures on modest nodes
 - 014-multi-workspace-nodes: Node `ready` callbacks now dispatch queued `creating` workspaces on that node, so auto-created-node workspace requests are not stranded when long node bootstrap work outlives the original create-request background window
 - 014-multi-workspace-nodes: VM Agent workspace create/restart now runs provisioning asynchronously and final state is callback-driven (`/ready` or `/provisioning-failed`) instead of blocking control-plane dispatch requests on full devcontainer setup duration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,9 @@ Claude Code now supports dual authentication methods:
 - Cloudflare D1 (SQLite) for app state; Cloudflare KV for bootstrap tokens and boot logs; Cloudflare R2 for Node Agent binaries (014-multi-workspace-nodes)
 
 ## Recent Changes
+- 014-multi-workspace-nodes: Node-mode `PrepareWorkspace` now calls `POST /api/workspaces/:id/ready` after successful provisioning (same as bootstrap `Run`), preventing workspaces from getting stuck in `creating` after successful devcontainer setup
+- 014-multi-workspace-nodes: VM Agent now normalizes workspace bind-mount permissions (`chmod -R a+rwX`) before `devcontainer up` so repo `postCreateCommand` steps can write files (for example `npm install` updating lockfiles) when container lifecycle commands run as non-root users
+- 014-multi-workspace-nodes: Unified workspace session tabs were refined to match the existing integrated terminal tab style and now support tab-close actions (`terminal` close for extra terminals, `chat` close to stop session) while keeping the `+` dropdown for terminal or agent-specific chat creation
 - 014-multi-workspace-nodes: Default fallback devcontainer image for repos without a `.devcontainer` config is now `mcr.microsoft.com/devcontainers/base:ubuntu` (instead of `.../universal:2`) to reduce bootstrap resource pressure and avoid frequent `devcontainer up ... signal: killed` failures on modest nodes
 - 014-multi-workspace-nodes: Node `ready` callbacks now dispatch queued `creating` workspaces on that node, so auto-created-node workspace requests are not stranded when long node bootstrap work outlives the original create-request background window
 - 014-multi-workspace-nodes: VM Agent workspace create/restart now runs provisioning asynchronously and final state is callback-driven (`/ready` or `/provisioning-failed`) instead of blocking control-plane dispatch requests on full devcontainer setup duration


### PR DESCRIPTION
## Summary

- Fixes a node-mode provisioning regression where workspaces could remain in `creating` after successful VM-agent provisioning because `PrepareWorkspace` did not call `/api/workspaces/:id/ready`.
- Adds pre-devcontainer permission normalization in VM agent (`chmod -R a+rwX`) so repo `postCreateCommand` flows can write workspace files when lifecycle steps run as non-root users.
- Refines unified workspace session tabs to match the integrated terminal tab style, adds tab-close actions (close terminal tab / stop chat tab), and keeps the `+` menu for terminal or agent-specific chat creation.
- Removes redundant desktop sidebar session list now that active sessions are managed directly in the shared tab strip.
- Updates `AGENTS.md` and `CLAUDE.md` recent changes to keep docs in sync.

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Additional validation run (if applicable)
- [ ] Mobile and desktop verification notes added for UI changes

Additional validation:
- `cd packages/vm-agent && go test ./internal/bootstrap ./internal/server`
- `pnpm --filter @simple-agent-manager/web test -- tests/unit/pages/workspace.test.tsx`
- `pnpm --filter @simple-agent-manager/web typecheck`

## UI Compliance Checklist (Required for UI changes)

- [ ] Mobile-first layout verified
- [x] Accessibility checks completed
- [x] Shared UI components used or exception documented

Notes:
- Accessibility coverage was updated via unit tests around tab roles, close actions, and menu actions.
- Mobile live verification is planned post-deploy in Playwright.

## Exceptions (If any)

- Scope: None
- Rationale: N/A
- Expiration: N/A

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [x] cross-component-change
- [x] business-logic-change
- [x] public-surface-change
- [x] docs-sync-change
- [ ] security-sensitive-change
- [x] ui-change
- [ ] infra-change

### External References

- N/A: No external SDK/API behavior was changed; work was constrained to existing repo architecture/spec docs and existing internal APIs.

### Codebase Impact Analysis

- `packages/vm-agent/internal/bootstrap/bootstrap.go`
  - Node-mode workspace provisioning readiness callback behavior.
  - Pre-devcontainer permissions normalization.
- `packages/vm-agent/internal/bootstrap/bootstrap_test.go`
  - New coverage for readiness callback and permission normalization behavior.
- `apps/web/src/pages/Workspace.tsx`
  - Unified terminal/chat tab UX behavior and close semantics.
- `apps/web/tests/unit/pages/workspace.test.tsx`
  - Updated UI behavior coverage for chat tab attach/close and `+` menu options.
- `AGENTS.md`, `CLAUDE.md`
  - Documentation synchronization of new behavior.

### Documentation & Specs

- Updated:
  - `AGENTS.md`
  - `CLAUDE.md`
- Specs:
  - N/A: No `specs/` files modified (respecting non-spec task scope rule).

### Constitution & Risk Check

- Principles checked:
  - Principle II (Infrastructure Stability): Added tests for changed VM-agent provisioning path.
  - Principle XI (No Hardcoded Values): No new hardcoded internal URLs/timeouts/limits; callback URL construction still derives from config (`ControlPlaneURL`) and existing defaults remain override-driven.
- Key risks/tradeoffs:
  - Permission normalization (`chmod -R a+rwX`) is intentionally permissive to unblock common non-root devcontainer lifecycle writes; this is acceptable within isolated per-workspace/node runtime boundaries but should be revisited if multi-tenant filesystem constraints tighten.

<!-- AGENT_PREFLIGHT_END -->
