### PR TITLE
feat(api,vm-agent): wire git identity into workspace provisioning

### DIFF
--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -189,7 +189,9 @@ async function scheduleWorkspaceCreateOnNode(
   nodeId: string,
   userId: string,
   repository: string,
-  branch: string
+  branch: string,
+  gitUserName?: string | null,
+  gitUserEmail?: string | null
 ): Promise<void> {
   const db = drizzle(env.DATABASE, { schema });
   const now = new Date().toISOString();
@@ -206,6 +208,8 @@ async function scheduleWorkspaceCreateOnNode(
       repository,
       branch,
       callbackToken,
+      gitUserName,
+      gitUserEmail,
     });
   } catch (err) {
     await db
@@ -514,7 +518,9 @@ workspacesRoutes.post('/', async (c) => {
         targetNodeId,
         userId,
         body.repository,
-        branch
+        branch,
+        auth.user.name,
+        auth.user.email
       );
     })()
   );

--- a/apps/api/src/services/node-agent.ts
+++ b/apps/api/src/services/node-agent.ts
@@ -170,6 +170,8 @@ export async function createWorkspaceOnNode(
     repository: string;
     branch: string;
     callbackToken: string;
+    gitUserName?: string | null;
+    gitUserEmail?: string | null;
   }
 ): Promise<unknown> {
   return nodeAgentRequest(nodeId, env, '/workspaces', {

--- a/packages/vm-agent/internal/server/server.go
+++ b/packages/vm-agent/internal/server/server.go
@@ -59,6 +59,8 @@ type WorkspaceRuntime struct {
 	ContainerLabelValue string
 	ContainerWorkDir    string
 	CallbackToken       string
+	GitUserName         string
+	GitUserEmail        string
 	PTY                 *pty.Manager
 }
 

--- a/packages/vm-agent/internal/server/workspace_provisioning.go
+++ b/packages/vm-agent/internal/server/workspace_provisioning.go
@@ -65,7 +65,9 @@ func (s *Server) provisionWorkspaceRuntime(ctx context.Context, runtime *Workspa
 	}
 
 	return bootstrap.PrepareWorkspace(provisionCtx, &cfg, bootstrap.ProvisionState{
-		GitHubToken: gitToken,
+		GitHubToken:  gitToken,
+		GitUserName:  runtime.GitUserName,
+		GitUserEmail: runtime.GitUserEmail,
 	})
 }
 

--- a/packages/vm-agent/internal/server/workspaces.go
+++ b/packages/vm-agent/internal/server/workspaces.go
@@ -153,6 +153,8 @@ func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
 		Repository    string `json:"repository"`
 		Branch        string `json:"branch"`
 		CallbackToken string `json:"callbackToken,omitempty"`
+		GitUserName   string `json:"gitUserName,omitempty"`
+		GitUserEmail  string `json:"gitUserEmail,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -175,6 +177,8 @@ func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	runtime := s.upsertWorkspaceRuntime(body.WorkspaceID, strings.TrimSpace(body.Repository), branch, "creating", strings.TrimSpace(body.CallbackToken))
+	runtime.GitUserName = strings.TrimSpace(body.GitUserName)
+	runtime.GitUserEmail = strings.TrimSpace(body.GitUserEmail)
 	s.appendNodeEvent(body.WorkspaceID, "info", "workspace.provisioning", "Workspace provisioning started", map[string]interface{}{
 		"workspaceId": body.WorkspaceID,
 		"repository":  body.Repository,

--- a/tasks/active/2026-02-13-workspace-git-identity.md
+++ b/tasks/active/2026-02-13-workspace-git-identity.md
@@ -1,0 +1,36 @@
+# Workspace Git Identity
+
+**Status**: active
+**Created**: 2026-02-13
+**Priority**: medium
+
+## Goal
+
+Wire authenticated user's git identity (name + email) from the API through to the VM agent so workspaces have correct `git config user.name` and `user.email` set during provisioning.
+
+## Context
+
+The git identity infrastructure was 95% complete:
+- `ProvisionState` struct already had `GitUserName` and `GitUserEmail` fields
+- `bootstrap.go` already resolved git identity and applied `git config --system`
+- `BootstrapTokenData` shared type already had the fields
+- The data was never passed from the API to the VM agent during workspace creation
+
+## Checklist
+
+- [x] API: Add `gitUserName` and `gitUserEmail` to `createWorkspaceOnNode()` workspace parameter
+- [x] API: Update `scheduleWorkspaceCreateOnNode()` to accept and forward git identity
+- [x] API: Pass `auth.user.name` and `auth.user.email` from POST handler
+- [x] VM Agent: Add `GitUserName` and `GitUserEmail` to `WorkspaceRuntime` struct
+- [x] VM Agent: Parse git identity from create workspace request body
+- [x] VM Agent: Pass git identity from runtime to `ProvisionState` in provisioning
+- [x] TypeScript typecheck passes
+- [x] Go build passes
+- [x] All existing tests pass
+
+## Implementation Notes
+
+- `auth.user.name` is `string | null`, `auth.user.email` is `string` (from BetterAuth `AuthContext`)
+- The API sends `gitUserName` and `gitUserEmail` as optional fields in the JSON body
+- The VM agent stores them on the `WorkspaceRuntime` struct and passes them to `bootstrap.PrepareWorkspace`
+- The existing `resolveGitIdentity()` and `configureGitSystem()` in bootstrap.go handle the rest


### PR DESCRIPTION
## Summary

- Pass authenticated user's `name` and `email` from API through to the VM agent during workspace creation
- The VM agent's `bootstrap.PrepareWorkspace()` → `resolveGitIdentity()` → `git config --system` pipeline already existed but was never connected to the data flow
- Workspaces will now have correct `git config user.name` and `user.email` set automatically from the user's GitHub profile

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Additional validation run (if applicable)

## Changes

- `apps/api/src/routes/workspaces.ts` — pass `auth.user.name`/`auth.user.email` through `scheduleWorkspaceCreateOnNode()`
- `apps/api/src/services/node-agent.ts` — add `gitUserName`/`gitUserEmail` to workspace creation request body
- `packages/vm-agent/internal/server/server.go` — add fields to `WorkspaceRuntime` struct
- `packages/vm-agent/internal/server/workspaces.go` — parse git identity from create-workspace request
- `packages/vm-agent/internal/server/workspace_provisioning.go` — pass git identity to `ProvisionState`

## Test plan

- [x] TypeScript typecheck passes (all 10 packages)
- [x] Go build passes (all packages)
- [x] All existing TypeScript tests pass
- [x] All existing Go tests pass
- [ ] Post-deploy: create a workspace and verify `git config user.email` is set correctly

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [x] cross-component-change
- [x] business-logic-change
- [ ] public-surface-change
- [ ] docs-sync-change
- [ ] security-sensitive-change
- [ ] ui-change
- [ ] infra-change

### External References

N/A: No external API changes. All changes are internal data flow wiring between existing components (API routes, node-agent service, VM agent handlers, bootstrap package).

### Codebase Impact Analysis

Affected components: `apps/api/src/routes/workspaces.ts` (workspace creation handler + scheduleWorkspaceCreateOnNode), `apps/api/src/services/node-agent.ts` (createWorkspaceOnNode HTTP client), `packages/vm-agent/internal/server/server.go` (WorkspaceRuntime struct), `packages/vm-agent/internal/server/workspaces.go` (create workspace handler), `packages/vm-agent/internal/server/workspace_provisioning.go` (ProvisionState population). All changes are additive optional fields — no breaking changes to existing behavior.

### Documentation & Specs

N/A: No public API contract changes. The git identity fields are optional additions to internal node-agent communication. The feature was already documented in `specs/` from the 014-auth-profile-sync spec.

### Constitution & Risk Check

Principle XI (No Hardcoded Values): No hardcoded values introduced. Git identity comes from authenticated user session data stored in the database. Graceful fallback when fields are absent (resolveGitIdentity returns false, git config is skipped). No security risks — git identity is user's own GitHub profile data.

<!-- AGENT_PREFLIGHT_END -->