### PR TITLE
refactor: direct-fetch events from VM Agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -440,7 +440,7 @@ All configuration lives in **GitHub Settings -> Environments -> production**:
 - `GET /api/nodes/:id` — Get node details
 - `POST /api/nodes/:id/stop` — Stop node
 - `DELETE /api/nodes/:id` — Delete node
-- `GET /api/nodes/:id/events` — List node events
+- `POST /api/nodes/:id/token` — Get node-scoped token for direct VM Agent access
 
 ### Workspace Management
 - `POST /api/workspaces` — Create workspace
@@ -450,7 +450,6 @@ All configuration lives in **GitHub Settings -> Environments -> production**:
 - `POST /api/workspaces/:id/stop` — Stop a running workspace
 - `POST /api/workspaces/:id/restart` — Restart a workspace
 - `DELETE /api/workspaces/:id` — Delete a workspace
-- `GET /api/workspaces/:id/events` — List workspace events
 
 ### Agent Sessions
 - `GET /api/workspaces/:id/agent-sessions` — List workspace agent sessions
@@ -662,6 +661,7 @@ For UI changes in `apps/web`, `packages/vm-agent/ui`, or `packages/ui`:
 - **Infra**: Pulumi, Wrangler, @devcontainers/cli, pnpm 9.0+, Cloudflare Pages
 
 ## Recent Changes
+- node-data-ownership: Workspace events and node events fetched directly from VM Agent (browser -> VM Agent), removing control plane proxy; new `POST /api/nodes/:id/token` for node-scoped auth tokens; VM Agent event handlers accept browser workspace/session auth
 - 014-multi-workspace-nodes: First-class Nodes with multi-workspace hosting, async provisioning (callback-driven `/ready` + `/provisioning-failed`), workspace recovery on attach, session tab UX with `+` dropdown, node-scoped routing/auth, explicit lifecycle control
 - 014-multi-workspace-nodes: Default fallback devcontainer image changed to `mcr.microsoft.com/devcontainers/base:ubuntu`; bind-mount permission normalization before `devcontainer up`; fresh-node readiness probing with hard timeouts
 - 014-auth-profile-sync: GitHub primary email resolved at login, propagated into workspace bootstrap for git commit identity

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,7 +440,7 @@ All configuration lives in **GitHub Settings -> Environments -> production**:
 - `GET /api/nodes/:id` — Get node details
 - `POST /api/nodes/:id/stop` — Stop node
 - `DELETE /api/nodes/:id` — Delete node
-- `GET /api/nodes/:id/events` — List node events
+- `POST /api/nodes/:id/token` — Get node-scoped token for direct VM Agent access
 
 ### Workspace Management
 - `POST /api/workspaces` — Create workspace
@@ -450,7 +450,6 @@ All configuration lives in **GitHub Settings -> Environments -> production**:
 - `POST /api/workspaces/:id/stop` — Stop a running workspace
 - `POST /api/workspaces/:id/restart` — Restart a workspace
 - `DELETE /api/workspaces/:id` — Delete a workspace
-- `GET /api/workspaces/:id/events` — List workspace events
 
 ### Agent Sessions
 - `GET /api/workspaces/:id/agent-sessions` — List workspace agent sessions
@@ -662,6 +661,7 @@ For UI changes in `apps/web`, `packages/vm-agent/ui`, or `packages/ui`:
 - **Infra**: Pulumi, Wrangler, @devcontainers/cli, pnpm 9.0+, Cloudflare Pages
 
 ## Recent Changes
+- node-data-ownership: Workspace events and node events fetched directly from VM Agent (browser -> VM Agent), removing control plane proxy; new `POST /api/nodes/:id/token` for node-scoped auth tokens; VM Agent event handlers accept browser workspace/session auth
 - 014-multi-workspace-nodes: First-class Nodes with multi-workspace hosting, async provisioning (callback-driven `/ready` + `/provisioning-failed`), workspace recovery on attach, session tab UX with `+` dropdown, node-scoped routing/auth, explicit lifecycle control
 - 014-multi-workspace-nodes: Default fallback devcontainer image changed to `mcr.microsoft.com/devcontainers/base:ubuntu`; bind-mount permission normalization before `devcontainer up`; fresh-node readiness probing with hard timeouts
 - 014-auth-profile-sync: GitHub primary email resolved at login, propagated into workspace bootstrap for git commit identity

--- a/apps/api/src/services/node-agent.ts
+++ b/apps/api/src/services/node-agent.ts
@@ -216,44 +216,6 @@ export async function deleteWorkspaceOnNode(
   });
 }
 
-export async function listNodeEvents(
-  nodeId: string,
-  env: Env,
-  userId: string,
-  limit = 100,
-  cursor?: string
-): Promise<unknown> {
-  const params = new URLSearchParams({ limit: String(limit) });
-  if (cursor) {
-    params.set('cursor', cursor);
-  }
-
-  return nodeAgentRequest(nodeId, env, `/events?${params.toString()}`, {
-    method: 'GET',
-    userId,
-  });
-}
-
-export async function listWorkspaceEvents(
-  nodeId: string,
-  workspaceId: string,
-  env: Env,
-  userId: string,
-  limit = 100,
-  cursor?: string
-): Promise<unknown> {
-  const params = new URLSearchParams({ limit: String(limit) });
-  if (cursor) {
-    params.set('cursor', cursor);
-  }
-
-  return nodeAgentRequest(nodeId, env, `/workspaces/${workspaceId}/events?${params.toString()}`, {
-    method: 'GET',
-    userId,
-    workspaceId,
-  });
-}
-
 export async function createAgentSessionOnNode(
   nodeId: string,
   workspaceId: string,

--- a/apps/api/tests/unit/routes/nodes.test.ts
+++ b/apps/api/tests/unit/routes/nodes.test.ts
@@ -14,13 +14,19 @@ describe('nodes routes source contract', () => {
     expect(file).toContain("nodesRoutes.delete('/:id',");
   });
 
-  it('defines node callback and events endpoints', () => {
-    expect(file).toContain("nodesRoutes.get('/:id/events',");
+  it('defines node callback and token endpoints', () => {
+    expect(file).toContain("nodesRoutes.post('/:id/token',");
     expect(file).toContain("nodesRoutes.post('/:id/ready',");
     expect(file).toContain("nodesRoutes.post('/:id/heartbeat',");
     expect(file).toContain('createWorkspaceOnNode');
     expect(file).toContain('signCallbackToken');
     expect(file).toContain("eq(schema.workspaces.status, 'creating')");
+  });
+
+  it('does not proxy node events (browser fetches directly from VM Agent)', () => {
+    expect(file).not.toContain("nodesRoutes.get('/:id/events',");
+    expect(file).not.toContain('fetchNodeEvents');
+    expect(file).toContain('signNodeManagementToken');
   });
 
   it('implements stop/delete semantics for child workspaces and sessions', () => {

--- a/apps/api/tests/unit/routes/workspaces.test.ts
+++ b/apps/api/tests/unit/routes/workspaces.test.ts
@@ -19,8 +19,9 @@ describe('workspaces routes source contract', () => {
     expect(file).toContain('normalizedDisplayName');
   });
 
-  it('defines workspace events and agent sessions endpoints', () => {
-    expect(file).toContain("workspacesRoutes.get('/:id/events'");
+  it('defines agent sessions endpoints (events moved to direct VM Agent access)', () => {
+    expect(file).not.toContain("workspacesRoutes.get('/:id/events'");
+    expect(file).not.toContain('fetchWorkspaceEvents');
     expect(file).toContain("workspacesRoutes.get('/:id/agent-sessions'");
     expect(file).toContain("workspacesRoutes.post('/:id/agent-sessions'");
     expect(file).toContain("workspacesRoutes.post('/:id/agent-sessions/:sessionId/stop'");

--- a/apps/web/tests/unit/pages/workspace.test.tsx
+++ b/apps/web/tests/unit/pages/workspace.test.tsx
@@ -474,6 +474,11 @@ describe('Workspace page', () => {
       renderWorkspace('/workspaces/ws-123');
       await screen.findByText('Workspace A');
 
+      // Wait for events to load (fetched from VM Agent after terminal token is available)
+      await waitFor(() => {
+        expect(mocks.listWorkspaceEvents).toHaveBeenCalled();
+      });
+
       // No overlay initially
       expect(screen.queryByRole('dialog', { name: 'Workspace menu' })).not.toBeInTheDocument();
 

--- a/packages/vm-agent/internal/server/events_test.go
+++ b/packages/vm-agent/internal/server/events_test.go
@@ -20,9 +20,34 @@ func TestEventsSourceContract(t *testing.T) {
 		"handleListWorkspaceEvents",
 		"nextCursor",
 		"parseEventLimit",
+		"requireNodeEventAuth",
 	} {
 		if !strings.Contains(content, needle) {
 			t.Fatalf("expected %q in %s", needle, path)
 		}
+	}
+}
+
+func TestEventsHandlersAcceptBrowserAuth(t *testing.T) {
+	path := filepath.Join("events.go")
+	contentBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	content := string(contentBytes)
+
+	// Workspace events should accept browser workspace auth (same pattern as tabs)
+	if !strings.Contains(content, "requireWorkspaceRequestAuth") {
+		t.Fatal("workspace events handler must accept workspace request auth for browser direct access")
+	}
+
+	// Node events should accept management token via query param
+	if !strings.Contains(content, "r.URL.Query().Get(\"token\")") {
+		t.Fatal("node events handler must accept token via query parameter for browser direct access")
+	}
+
+	// Node events should accept workspace session cookie
+	if !strings.Contains(content, "sessionManager.GetSessionFromRequest") {
+		t.Fatal("node events handler must accept workspace session cookie for browser direct access")
 	}
 }

--- a/tasks/active/2026-02-13-node-data-ownership-audit.md
+++ b/tasks/active/2026-02-13-node-data-ownership-audit.md
@@ -1,0 +1,216 @@
+# Node Data Ownership Audit
+
+## Summary
+
+Our architecture principle states: **anything that lives inside a node (workspaces, terminal states, chat states, logs, etc.) should be managed by the node and exposed directly by the node.** The browser should fetch node-scoped data directly from the VM Agent, not through the control plane.
+
+A thorough audit of the current codebase reveals several violations where node-local data is either proxied through the control plane or duplicated between the control plane and VM Agent.
+
+## Principle
+
+```
+Control Plane (API Worker)     = owns user accounts, cloud credentials, node/workspace
+                                  lifecycle ownership (who owns what), display metadata
+VM Agent (node-local)          = owns everything that happens INSIDE the node:
+                                  terminal state, chat state, events, logs, agent sessions
+Browser                        = fetches ownership/lifecycle from control plane,
+                                  fetches runtime/operational data directly from VM Agent
+```
+
+## Current State: What's Correct
+
+### Correctly Node-Local (browser fetches directly from VM Agent)
+
+| Data | Storage | Browser Access |
+|------|---------|----------------|
+| Terminal PTY sessions | In-memory (Go) | `wss://ws-{id}.{BASE_DOMAIN}/terminal/ws/multi` |
+| ACP chat sessions | In-memory (Go) | `wss://ws-{id}.{BASE_DOMAIN}/agent/ws` |
+| Workspace tabs | SQLite on disk | `GET https://ws-{id}.{BASE_DOMAIN}/workspaces/{wid}/tabs` |
+| PTY ring buffers | In-memory (Go) | Replayed on WebSocket reconnect |
+
+### Correctly Control-Plane-Owned
+
+| Data | Storage | Rationale |
+|------|---------|-----------|
+| User accounts & sessions | D1 + KV | Authentication is a platform concern |
+| Cloud provider credentials | D1 (encrypted) | BYOC model, per-user encryption |
+| GitHub App installations | GitHub API | Platform integration |
+| Node/workspace ownership | D1 | Which user owns which node/workspace |
+| Workspace display names | D1 | User-facing metadata, survives node restarts |
+| Workspace/node lifecycle state | D1 | `creating`/`running`/`stopped`/`error` transitions |
+
+## Violations Found
+
+### 1. Workspace Events — Proxied Through Control Plane
+
+**Current flow:**
+```
+Browser → GET /api/workspaces/:id/events (control plane)
+       → control plane proxies to VM Agent /workspaces/{wid}/events
+       → VM Agent returns in-memory events
+       → control plane forwards to browser
+```
+
+**Problem:** Events are generated and stored ONLY in the VM Agent (in-memory map in `events.go`). The control plane adds no value — it just proxies. This adds latency, requires the control plane to know the node's address, and is fragile if the Worker times out.
+
+**Fix:** Browser should fetch events directly from the VM Agent:
+```
+Browser → GET https://ws-{id}.{BASE_DOMAIN}/workspaces/{wid}/events?token={token}
+```
+
+**Files:**
+- `apps/web/src/lib/api.ts` — `listWorkspaceEvents()` should call VM Agent directly (similar to `getWorkspaceTabs()`)
+- `apps/api/src/routes/workspaces.ts` — proxy route can be deprecated/removed
+- `apps/api/src/services/node-agent.ts` — `listWorkspaceEvents()` can be removed
+
+### 2. Node Events — Proxied Through Control Plane
+
+**Current flow:**
+```
+Browser → GET /api/nodes/:id/events (control plane)
+       → control plane proxies to VM Agent /events
+       → VM Agent returns in-memory events
+       → control plane forwards to browser
+```
+
+**Problem:** Same as workspace events — node events exist ONLY in VM Agent memory (`s.nodeEvents` in `events.go`). The proxy adds no value.
+
+**Fix:** Browser should fetch node events directly from the VM Agent:
+```
+Browser → GET https://vm-{nodeId}.{BASE_DOMAIN}:8080/events?token={token}
+```
+
+**Files:**
+- `apps/web/src/lib/api.ts` — `listNodeEvents()` should call VM Agent directly
+- `apps/api/src/routes/nodes.ts` — proxy route can be deprecated/removed
+- `apps/api/src/services/node-agent.ts` — `listNodeEvents()` can be removed
+
+### 3. Agent Sessions — Duplicated in D1 and VM Agent
+
+**Current flow:**
+```
+Browser → GET /api/workspaces/:id/agent-sessions (control plane D1)
+Browser → POST /api/workspaces/:id/agent-sessions (control plane D1 + proxies to VM Agent)
+Browser → POST /api/workspaces/:id/agent-sessions/:sid/stop (control plane D1 + proxies to VM Agent)
+```
+
+**Problem:** Agent sessions are stored in BOTH:
+- **D1** (`agentSessions` table in `schema.ts`) — browser reads from here
+- **VM Agent** (in-memory `workspaceSessions` map in `manager.go`) — runtime ACP process management
+
+This causes:
+- **Consistency risk** — If VM Agent crashes, in-memory sessions are lost but D1 still shows them as `active`
+- **Unnecessary control plane storage** — The control plane doesn't need to know about individual agent sessions; it's a node-internal concern
+- **Extra network hops** — Create/stop operations hit both D1 and VM Agent
+
+**Fix:** Agent sessions should be node-local only. The browser should list/create/stop sessions directly via the VM Agent:
+```
+Browser → GET https://ws-{id}.{BASE_DOMAIN}/workspaces/{wid}/agent-sessions?token={token}
+Browser → POST https://ws-{id}.{BASE_DOMAIN}/workspaces/{wid}/agent-sessions?token={token}
+Browser → POST https://ws-{id}.{BASE_DOMAIN}/workspaces/{wid}/agent-sessions/{sid}/stop?token={token}
+```
+
+Session metadata should be persisted in VM Agent SQLite (not D1) for survivability across agent restarts.
+
+**Files:**
+- `apps/api/src/db/schema.ts` — remove `agentSessions` table (or keep as audit log if needed)
+- `apps/api/src/routes/workspaces.ts` — remove agent session CRUD routes (or convert to thin proxies temporarily)
+- `packages/vm-agent/internal/agentsessions/manager.go` — add SQLite persistence (similar to tabs)
+- `packages/vm-agent/internal/server/workspaces.go` — expose REST endpoints for session CRUD
+- `apps/web/src/lib/api.ts` — point session API calls to VM Agent directly
+
+### 4. Boot Logs — Stored in Control Plane KV
+
+**Current flow:**
+```
+VM Agent → POST /api/workspaces/:id/boot-log (callback to control plane)
+        → control plane writes to Cloudflare KV (key: bootlog:{workspaceId}, TTL: 30min)
+Browser  → GET /api/workspaces/:id (control plane)
+        → control plane reads boot logs from KV and embeds in response
+```
+
+**Problem:** Boot logs are generated by the VM Agent during provisioning but stored in Cloudflare KV via callbacks. This:
+- Consumes KV writes (1,000/day free tier limit — this was a real problem, see MEMORY.md)
+- Adds latency (VM Agent → Worker → KV → Worker → Browser instead of VM Agent → Browser)
+- Is fragile if callbacks fail (lost boot progress)
+
+**Fix:** Boot logs should be stored and served by the VM Agent:
+- VM Agent writes boot logs to SQLite or an in-memory buffer
+- Browser fetches boot logs directly from VM Agent during provisioning
+- Remove the `POST /api/workspaces/:id/boot-log` callback endpoint
+- Remove KV boot log storage (`appendBootLog`, `getBootLogs` in `boot-log.ts`)
+
+```
+Browser → GET https://ws-{id}.{BASE_DOMAIN}/workspaces/{wid}/boot-log?token={token}
+   OR
+Browser → GET https://vm-{nodeId}.{BASE_DOMAIN}:8080/workspaces/{wid}/boot-log?token={token}
+```
+
+**Caveat:** During initial node bootstrap (before the VM Agent is even running), boot logs can't come from the VM Agent. We may need to keep a minimal callback for the "node is booting" phase, but workspace-level boot logs (devcontainer build) should be node-local.
+
+**Files:**
+- `apps/api/src/services/boot-log.ts` — remove or reduce to node-level-only
+- `apps/api/src/routes/workspaces.ts` — remove `POST /boot-log` callback endpoint for workspaces
+- `packages/vm-agent/internal/server/` — add boot log storage (SQLite or in-memory) and GET endpoint
+- `apps/web/src/pages/Workspace.tsx` — fetch boot logs from VM Agent directly during provisioning
+
+### 5. Workspace Status Polling — Browser Polls Control Plane
+
+**Current flow:**
+```
+Browser → GET /api/workspaces/:id (every 5 seconds)
+       → control plane reads status from D1
+       → returns workspace object with current status
+```
+
+**Problem:** The browser polls the control plane every 5 seconds to check if a workspace has transitioned from `creating` to `running`. But the actual runtime status lives on the node — the control plane only knows because the VM Agent sends callbacks (`POST /api/workspaces/:id/ready`, `POST /api/workspaces/:id/provisioning-failed`).
+
+This is a **partial violation** — the lifecycle state machine legitimately lives in the control plane (it needs to survive node restarts and is needed for listing workspaces). But polling the control plane for real-time status during active use is wasteful.
+
+**Fix (stretch goal):** Consider a WebSocket or SSE connection from browser to VM Agent for real-time workspace status updates during provisioning, instead of polling the control plane REST API. This would give instant feedback and reduce API load.
+
+**Note:** This is lower priority than violations 1-4 because the control plane IS the source of truth for lifecycle state. The improvement is about efficiency, not architectural correctness.
+
+## Implementation Order
+
+| Priority | Violation | Effort | Impact |
+|----------|-----------|--------|--------|
+| 1 | Workspace events → direct fetch | Low | Removes unnecessary proxy |
+| 2 | Node events → direct fetch | Low | Removes unnecessary proxy |
+| 3 | Boot logs → node-local storage | Medium | Reduces KV writes, improves reliability |
+| 4 | Agent sessions → node-local only | High | Removes D1 duplication, simplifies architecture |
+| 5 | Status polling → WebSocket/SSE | Medium | Efficiency improvement (stretch goal) |
+
+Violations 1 and 2 are straightforward — just change the browser fetch target from the control plane proxy to the VM Agent directly, with the workspace token for authentication. The VM Agent already has these endpoints.
+
+Violation 3 saves real KV write quota and makes boot logs more reliable.
+
+Violation 4 is the biggest change — it requires adding SQLite persistence to the agent session manager and exposing full CRUD endpoints on the VM Agent.
+
+## Authentication Pattern for Direct VM Agent Calls
+
+When the browser calls the VM Agent directly, it needs authentication. The existing pattern (used by tabs and WebSocket connections) is:
+
+1. Browser gets a workspace-scoped token from the control plane (`POST /api/terminal/token`)
+2. Browser passes the token as a query parameter (`?token={token}`) to VM Agent endpoints
+3. VM Agent validates the token
+
+This pattern should be extended to all direct VM Agent calls (events, boot logs, agent sessions).
+
+## Acceptance Criteria
+
+- [ ] Browser fetches workspace events directly from VM Agent (not proxied through control plane)
+- [ ] Browser fetches node events directly from VM Agent (not proxied through control plane)
+- [ ] Boot logs are stored and served by the VM Agent (not in Cloudflare KV)
+- [ ] Agent sessions are managed entirely by the VM Agent (not duplicated in D1)
+- [ ] All direct VM Agent calls use the existing token authentication pattern
+- [ ] Control plane proxy routes are removed or deprecated
+- [ ] No regression in functionality — all data remains accessible in the UI
+- [ ] Works on both node-mode (multi-workspace) and legacy single-workspace layouts
+
+## Notes
+
+- The VM Agent already exposes most of these endpoints internally — the main work is changing the browser to call them directly and removing the control plane proxy layer.
+- The workspace token flow (`POST /api/terminal/token`) already handles authentication for direct VM Agent calls — no new auth mechanism needed.
+- Events are currently in-memory only on the VM Agent. If persistence across VM Agent restarts is desired, they could be added to SQLite (same pattern as tabs). But for now, in-memory is acceptable since events are ephemeral.
+- Removing the `agentSessions` table from D1 is a schema migration. Consider keeping the table temporarily as an audit log while transitioning, then removing it once the node-local pattern is proven.


### PR DESCRIPTION
## Summary
- Browser now fetches workspace events and node events directly from the VM Agent instead of proxying through the control plane API worker
- Removes `GET /api/workspaces/:id/events` and `GET /api/nodes/:id/events` proxy routes
- Adds `POST /api/nodes/:id/token` endpoint for node-scoped management tokens (browser needs auth for direct VM Agent calls)
- VM Agent event handlers updated to accept browser auth tokens (same pattern as `getWorkspaceTabs()`)
- 14 files changed across Go, TypeScript API, React client, and docs

## Test plan
- [x] API tests: 83/83 pass
- [x] Go tests: all packages pass (events_test.go: 2/2)
- [x] Web tests: 45/47 pass (2 pre-existing failures unrelated)
- [x] Typecheck: 16/16 packages pass
- [ ] Verify events load on workspace page after deploy
- [ ] Verify events load on node detail page after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>