### PR TITLE
feat: add git changes viewer with diff/full file view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,6 +478,11 @@ All configuration lives in **GitHub Settings -> Environments -> production**:
 ### Terminal Access
 - `POST /api/terminal/token` — Get terminal WebSocket token
 
+### Git Integration (VM Agent direct — browser calls via ws-{id} subdomain)
+- `GET /workspaces/:id/git/status` — Git status (staged, unstaged, untracked files)
+- `GET /workspaces/:id/git/diff?path=...&staged=true|false` — Unified diff for a single file
+- `GET /workspaces/:id/git/file?path=...&ref=HEAD` — Full file content (optional ref for committed version)
+
 ### Voice Transcription
 - `POST /api/transcribe` — Transcribe audio via Workers AI (Whisper)
 
@@ -641,6 +646,8 @@ See `apps/api/.env.example`:
 - `MAX_AUDIO_SIZE_BYTES` - Maximum audio upload size in bytes (default: 10485760)
 - `MAX_AUDIO_DURATION_SECONDS` - Maximum recording duration in seconds (default: 60)
 - `RATE_LIMIT_TRANSCRIBE` - Optional rate limit for transcription requests
+- `GIT_EXEC_TIMEOUT` - VM Agent: timeout for git commands via docker exec (default: 30s)
+- `GIT_FILE_MAX_SIZE` - VM Agent: max file size in bytes for git/file endpoint (default: 1048576)
 
 ## Testing
 
@@ -676,6 +683,7 @@ For UI changes in `apps/web`, `packages/vm-agent/ui`, or `packages/ui`:
 - **Infra**: Pulumi, Wrangler, @devcontainers/cli, pnpm 9.0+, Cloudflare Pages
 
 ## Recent Changes
+- git-changes-viewer: GitHub PR-style git changes viewer accessible via nav bar icon; VM Agent endpoints for git status/diff/file via docker exec; full-screen overlay with staged/unstaged/untracked sections, unified diff view with green/red coloring, Diff/Full toggle; URL search params for browser back/forward navigation
 - voice-to-text: Voice input button for agent chat with Workers AI Whisper transcription, VoiceButton component in acp-client, POST /api/transcribe endpoint, configurable model/limits
 - node-data-ownership: Workspace events fetched directly from VM Agent (browser -> VM Agent via ws-{id} proxy); node events proxied through control plane (vm-* DNS records lack SSL termination); new `POST /api/nodes/:id/token` for node-scoped auth tokens; VM Agent event handlers accept browser workspace/session auth
 - 014-multi-workspace-nodes: First-class Nodes with multi-workspace hosting, async provisioning (callback-driven `/ready` + `/provisioning-failed`), workspace recovery on attach, session tab UX with `+` dropdown, node-scoped routing/auth, explicit lifecycle control

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -478,6 +478,11 @@ All configuration lives in **GitHub Settings -> Environments -> production**:
 ### Terminal Access
 - `POST /api/terminal/token` — Get terminal WebSocket token
 
+### Git Integration (VM Agent direct — browser calls via ws-{id} subdomain)
+- `GET /workspaces/:id/git/status` — Git status (staged, unstaged, untracked files)
+- `GET /workspaces/:id/git/diff?path=...&staged=true|false` — Unified diff for a single file
+- `GET /workspaces/:id/git/file?path=...&ref=HEAD` — Full file content (optional ref for committed version)
+
 ### Voice Transcription
 - `POST /api/transcribe` — Transcribe audio via Workers AI (Whisper)
 
@@ -641,6 +646,8 @@ See `apps/api/.env.example`:
 - `MAX_AUDIO_SIZE_BYTES` - Maximum audio upload size in bytes (default: 10485760)
 - `MAX_AUDIO_DURATION_SECONDS` - Maximum recording duration in seconds (default: 60)
 - `RATE_LIMIT_TRANSCRIBE` - Optional rate limit for transcription requests
+- `GIT_EXEC_TIMEOUT` - VM Agent: timeout for git commands via docker exec (default: 30s)
+- `GIT_FILE_MAX_SIZE` - VM Agent: max file size in bytes for git/file endpoint (default: 1048576)
 
 ## Testing
 
@@ -676,6 +683,7 @@ For UI changes in `apps/web`, `packages/vm-agent/ui`, or `packages/ui`:
 - **Infra**: Pulumi, Wrangler, @devcontainers/cli, pnpm 9.0+, Cloudflare Pages
 
 ## Recent Changes
+- git-changes-viewer: GitHub PR-style git changes viewer accessible via nav bar icon; VM Agent endpoints for git status/diff/file via docker exec; full-screen overlay with staged/unstaged/untracked sections, unified diff view with green/red coloring, Diff/Full toggle; URL search params for browser back/forward navigation
 - voice-to-text: Voice input button for agent chat with Workers AI Whisper transcription, VoiceButton component in acp-client, POST /api/transcribe endpoint, configurable model/limits
 - node-data-ownership: Workspace events fetched directly from VM Agent (browser -> VM Agent via ws-{id} proxy); node events proxied through control plane (vm-* DNS records lack SSL termination); new `POST /api/nodes/:id/token` for node-scoped auth tokens; VM Agent event handlers accept browser workspace/session auth
 - 014-multi-workspace-nodes: First-class Nodes with multi-workspace hosting, async provisioning (callback-driven `/ready` + `/provisioning-failed`), workspace recovery on attach, session tab UX with `+` dropdown, node-scoped routing/auth, explicit lifecycle control

--- a/apps/web/src/components/GitChangesButton.tsx
+++ b/apps/web/src/components/GitChangesButton.tsx
@@ -1,0 +1,64 @@
+import { type CSSProperties, type FC } from 'react';
+import { GitBranch } from 'lucide-react';
+
+interface GitChangesButtonProps {
+  onClick: () => void;
+  changeCount?: number;
+  disabled?: boolean;
+  isMobile: boolean;
+}
+
+export const GitChangesButton: FC<GitChangesButtonProps> = ({
+  onClick,
+  changeCount,
+  disabled,
+  isMobile,
+}) => {
+  const buttonStyle: CSSProperties = {
+    position: 'relative',
+    background: 'none',
+    border: 'none',
+    cursor: disabled ? 'default' : 'pointer',
+    color: disabled ? 'var(--sam-color-fg-muted)' : 'var(--sam-color-fg-primary)',
+    opacity: disabled ? 0.5 : 1,
+    padding: isMobile ? '8px' : '4px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: isMobile ? 44 : 32,
+    minHeight: isMobile ? 44 : 32,
+    flexShrink: 0,
+  };
+
+  const badgeStyle: CSSProperties = {
+    position: 'absolute',
+    top: isMobile ? 4 : 0,
+    right: isMobile ? 4 : 0,
+    minWidth: 16,
+    height: 16,
+    borderRadius: 8,
+    backgroundColor: 'var(--sam-color-accent-primary)',
+    color: '#fff',
+    fontSize: '0.625rem',
+    fontWeight: 700,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '0 4px',
+    lineHeight: 1,
+  };
+
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      aria-label="View git changes"
+      style={buttonStyle}
+    >
+      <GitBranch size={isMobile ? 18 : 16} />
+      {changeCount != null && changeCount > 0 && (
+        <span style={badgeStyle}>{changeCount > 99 ? '99+' : changeCount}</span>
+      )}
+    </button>
+  );
+};

--- a/apps/web/src/components/GitChangesPanel.tsx
+++ b/apps/web/src/components/GitChangesPanel.tsx
@@ -1,0 +1,449 @@
+import { type CSSProperties, type FC, useCallback, useEffect, useState } from 'react';
+import { ChevronDown, RefreshCw, X } from 'lucide-react';
+import { Spinner } from '@simple-agent-manager/ui';
+import { getGitStatus, type GitFileStatus, type GitStatusData } from '../lib/api';
+
+interface GitChangesPanelProps {
+  workspaceUrl: string;
+  workspaceId: string;
+  token: string;
+  isMobile: boolean;
+  onClose: () => void;
+  onSelectFile: (filePath: string, staged: boolean) => void;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  M: 'Modified',
+  A: 'Added',
+  D: 'Deleted',
+  R: 'Renamed',
+  C: 'Copied',
+  U: 'Unmerged',
+  '??': 'Untracked',
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  M: '#e0af68', // yellow
+  A: '#9ece6a', // green
+  D: '#f7768e', // red
+  R: '#7aa2f7', // blue
+  C: '#7aa2f7', // blue
+  U: '#ff9e64', // orange
+  '??': '#787c99', // grey
+};
+
+function statusColor(status: string): string {
+  return STATUS_COLORS[status] ?? 'var(--sam-color-fg-muted)';
+}
+
+function statusLabel(status: string): string {
+  return STATUS_LABELS[status] ?? status;
+}
+
+export const GitChangesPanel: FC<GitChangesPanelProps> = ({
+  workspaceUrl,
+  workspaceId,
+  token,
+  isMobile,
+  onClose,
+  onSelectFile,
+}) => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<GitStatusData | null>(null);
+  const [expandedSections, setExpandedSections] = useState({
+    staged: true,
+    unstaged: true,
+    untracked: true,
+  });
+
+  const fetchStatus = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await getGitStatus(workspaceUrl, workspaceId, token);
+      setData(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch git status');
+    } finally {
+      setLoading(false);
+    }
+  }, [workspaceUrl, workspaceId, token]);
+
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const toggleSection = (section: 'staged' | 'unstaged' | 'untracked') => {
+    setExpandedSections((prev) => ({ ...prev, [section]: !prev[section] }));
+  };
+
+  const totalChanges = data
+    ? data.staged.length + data.unstaged.length + data.untracked.length
+    : 0;
+
+  const overlayStyle: CSSProperties = {
+    position: 'fixed',
+    inset: 0,
+    zIndex: 60,
+    backgroundColor: 'var(--sam-color-bg-canvas)',
+    display: 'flex',
+    flexDirection: 'column',
+  };
+
+  const headerStyle: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    padding: isMobile ? '0 8px' : '0 16px',
+    height: isMobile ? 44 : 40,
+    backgroundColor: 'var(--sam-color-bg-surface)',
+    borderBottom: '1px solid var(--sam-color-border-default)',
+    gap: isMobile ? 8 : 12,
+    flexShrink: 0,
+  };
+
+  return (
+    <div style={overlayStyle}>
+      {/* Header */}
+      <header style={headerStyle}>
+        <button
+          onClick={onClose}
+          aria-label="Close git changes"
+          style={iconButtonStyle(isMobile)}
+        >
+          <svg
+            style={{ height: isMobile ? 18 : 16, width: isMobile ? 18 : 16 }}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+
+        <span
+          style={{
+            fontWeight: 600,
+            fontSize: '0.875rem',
+            color: 'var(--sam-color-fg-primary)',
+            flex: 1,
+          }}
+        >
+          Git Changes
+          {data && !loading && (
+            <span style={{ color: 'var(--sam-color-fg-muted)', fontWeight: 400, marginLeft: 6 }}>
+              ({totalChanges})
+            </span>
+          )}
+        </span>
+
+        <button
+          onClick={fetchStatus}
+          disabled={loading}
+          aria-label="Refresh git status"
+          style={{
+            ...iconButtonStyle(isMobile),
+            opacity: loading ? 0.5 : 1,
+          }}
+        >
+          <RefreshCw size={isMobile ? 16 : 14} style={loading ? { animation: 'spin 1s linear infinite' } : undefined} />
+        </button>
+
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          style={iconButtonStyle(isMobile)}
+        >
+          <X size={isMobile ? 18 : 16} />
+        </button>
+      </header>
+
+      {/* Content */}
+      <div style={{ flex: 1, overflow: 'auto', padding: isMobile ? '8px 0' : '8px 0' }}>
+        {loading && !data && (
+          <div style={{ display: 'flex', justifyContent: 'center', padding: 32 }}>
+            <Spinner size="md" />
+          </div>
+        )}
+
+        {error && (
+          <div
+            style={{
+              margin: 16,
+              padding: 12,
+              backgroundColor: 'rgba(247, 118, 142, 0.1)',
+              borderRadius: 8,
+              color: '#f7768e',
+              fontSize: '0.8125rem',
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {data && !loading && totalChanges === 0 && (
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              padding: 48,
+              color: 'var(--sam-color-fg-muted)',
+              fontSize: '0.875rem',
+            }}
+          >
+            <span style={{ fontSize: '1.5rem', marginBottom: 8 }}>Clean</span>
+            <span>No changes detected</span>
+          </div>
+        )}
+
+        {data && data.staged.length > 0 && (
+          <FileSection
+            title="Staged"
+            count={data.staged.length}
+            expanded={expandedSections.staged}
+            onToggle={() => toggleSection('staged')}
+            files={data.staged}
+            onSelectFile={(path) => onSelectFile(path, true)}
+            isMobile={isMobile}
+          />
+        )}
+
+        {data && data.unstaged.length > 0 && (
+          <FileSection
+            title="Unstaged"
+            count={data.unstaged.length}
+            expanded={expandedSections.unstaged}
+            onToggle={() => toggleSection('unstaged')}
+            files={data.unstaged}
+            onSelectFile={(path) => onSelectFile(path, false)}
+            isMobile={isMobile}
+          />
+        )}
+
+        {data && data.untracked.length > 0 && (
+          <FileSection
+            title="Untracked"
+            count={data.untracked.length}
+            expanded={expandedSections.untracked}
+            onToggle={() => toggleSection('untracked')}
+            files={data.untracked}
+            onSelectFile={(path) => onSelectFile(path, false)}
+            isMobile={isMobile}
+          />
+        )}
+      </div>
+
+      {/* Inline keyframe for spinner */}
+      <style>{`@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+};
+
+// ---------- Sub-components ----------
+
+interface FileSectionProps {
+  title: string;
+  count: number;
+  expanded: boolean;
+  onToggle: () => void;
+  files: GitFileStatus[];
+  onSelectFile: (path: string) => void;
+  isMobile: boolean;
+}
+
+const FileSection: FC<FileSectionProps> = ({
+  title,
+  count,
+  expanded,
+  onToggle,
+  files,
+  onSelectFile,
+  isMobile,
+}) => {
+  const sectionHeaderStyle: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    padding: isMobile ? '10px 16px' : '8px 16px',
+    cursor: 'pointer',
+    userSelect: 'none',
+    gap: 8,
+    borderBottom: '1px solid var(--sam-color-border-default)',
+  };
+
+  return (
+    <div>
+      <div
+        onClick={onToggle}
+        style={sectionHeaderStyle}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onToggle();
+          }
+        }}
+      >
+        <ChevronDown
+          size={14}
+          style={{
+            color: 'var(--sam-color-fg-muted)',
+            transition: 'transform 0.15s',
+            transform: expanded ? 'rotate(0deg)' : 'rotate(-90deg)',
+            flexShrink: 0,
+          }}
+        />
+        <span
+          style={{
+            fontWeight: 600,
+            fontSize: '0.75rem',
+            color: 'var(--sam-color-fg-muted)',
+            textTransform: 'uppercase',
+            letterSpacing: '0.05em',
+          }}
+        >
+          {title}
+        </span>
+        <span
+          style={{
+            fontSize: '0.6875rem',
+            color: 'var(--sam-color-fg-muted)',
+            backgroundColor: 'var(--sam-color-bg-surface)',
+            borderRadius: 10,
+            padding: '1px 8px',
+            fontWeight: 600,
+          }}
+        >
+          {count}
+        </span>
+      </div>
+
+      {expanded && (
+        <div>
+          {files.map((file) => (
+            <FileRow
+              key={file.path}
+              file={file}
+              onClick={() => onSelectFile(file.path)}
+              isMobile={isMobile}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface FileRowProps {
+  file: GitFileStatus;
+  onClick: () => void;
+  isMobile: boolean;
+}
+
+const FileRow: FC<FileRowProps> = ({ file, onClick, isMobile }) => {
+  const [hovered, setHovered] = useState(false);
+
+  // Split path into directory and filename
+  const lastSlash = file.path.lastIndexOf('/');
+  const dir = lastSlash >= 0 ? file.path.slice(0, lastSlash + 1) : '';
+  const name = lastSlash >= 0 ? file.path.slice(lastSlash + 1) : file.path;
+
+  const rowStyle: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    padding: isMobile ? '10px 16px 10px 32px' : '6px 16px 6px 32px',
+    minHeight: isMobile ? 44 : 32,
+    cursor: 'pointer',
+    gap: 10,
+    backgroundColor: hovered ? 'var(--sam-color-bg-surface-hover)' : 'transparent',
+    transition: 'background-color 0.1s',
+  };
+
+  return (
+    <div
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={rowStyle}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+    >
+      <span
+        style={{
+          fontFamily: 'monospace',
+          fontSize: '0.6875rem',
+          fontWeight: 700,
+          color: statusColor(file.status),
+          minWidth: 20,
+          textAlign: 'center',
+          flexShrink: 0,
+        }}
+        title={statusLabel(file.status)}
+      >
+        {file.status}
+      </span>
+      <span
+        style={{
+          fontFamily: 'monospace',
+          fontSize: '0.8125rem',
+          color: 'var(--sam-color-fg-primary)',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          minWidth: 0,
+        }}
+      >
+        {dir && (
+          <span style={{ color: 'var(--sam-color-fg-muted)' }}>{dir}</span>
+        )}
+        {name}
+      </span>
+      {file.oldPath && (
+        <span
+          style={{
+            fontFamily: 'monospace',
+            fontSize: '0.6875rem',
+            color: 'var(--sam-color-fg-muted)',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          (from {file.oldPath})
+        </span>
+      )}
+    </div>
+  );
+};
+
+// ---------- Shared styles ----------
+
+function iconButtonStyle(isMobile: boolean): CSSProperties {
+  return {
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    color: 'var(--sam-color-fg-muted)',
+    padding: isMobile ? 8 : 4,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: isMobile ? 44 : 32,
+    minHeight: isMobile ? 44 : 32,
+    flexShrink: 0,
+  };
+}

--- a/apps/web/src/components/GitDiffView.tsx
+++ b/apps/web/src/components/GitDiffView.tsx
@@ -1,0 +1,415 @@
+import { type CSSProperties, type FC, useCallback, useEffect, useState } from 'react';
+import { X } from 'lucide-react';
+import { Spinner } from '@simple-agent-manager/ui';
+import { getGitDiff, getGitFile } from '../lib/api';
+
+interface GitDiffViewProps {
+  workspaceUrl: string;
+  workspaceId: string;
+  token: string;
+  filePath: string;
+  staged: boolean;
+  isMobile: boolean;
+  onBack: () => void;
+  onClose: () => void;
+}
+
+type ViewMode = 'diff' | 'full';
+
+export const GitDiffView: FC<GitDiffViewProps> = ({
+  workspaceUrl,
+  workspaceId,
+  token,
+  filePath,
+  staged,
+  isMobile,
+  onBack,
+  onClose,
+}) => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [diff, setDiff] = useState('');
+  const [fullContent, setFullContent] = useState<string | null>(null);
+  const [fullLoading, setFullLoading] = useState(false);
+  const [viewMode, setViewMode] = useState<ViewMode>('diff');
+
+  const fetchDiff = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await getGitDiff(workspaceUrl, workspaceId, token, filePath, staged);
+      setDiff(result.diff);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch diff');
+    } finally {
+      setLoading(false);
+    }
+  }, [workspaceUrl, workspaceId, token, filePath, staged]);
+
+  const fetchFullFile = useCallback(async () => {
+    if (fullContent !== null) return; // already loaded
+    setFullLoading(true);
+    try {
+      const result = await getGitFile(workspaceUrl, workspaceId, token, filePath);
+      setFullContent(result.content);
+    } catch {
+      // Fallback: just show diff if full file fails
+      setFullContent(null);
+      setViewMode('diff');
+    } finally {
+      setFullLoading(false);
+    }
+  }, [workspaceUrl, workspaceId, token, filePath, fullContent]);
+
+  useEffect(() => {
+    fetchDiff();
+  }, [fetchDiff]);
+
+  useEffect(() => {
+    if (viewMode === 'full') {
+      fetchFullFile();
+    }
+  }, [viewMode, fetchFullFile]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  // Parse diff to get set of added line numbers (for full-file view highlighting)
+  const addedLines = parseDiffAddedLines(diff);
+
+  const overlayStyle: CSSProperties = {
+    position: 'fixed',
+    inset: 0,
+    zIndex: 60,
+    backgroundColor: 'var(--sam-color-bg-canvas)',
+    display: 'flex',
+    flexDirection: 'column',
+  };
+
+  const headerStyle: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    padding: isMobile ? '0 8px' : '0 16px',
+    height: isMobile ? 44 : 40,
+    backgroundColor: 'var(--sam-color-bg-surface)',
+    borderBottom: '1px solid var(--sam-color-border-default)',
+    gap: isMobile ? 6 : 12,
+    flexShrink: 0,
+  };
+
+  return (
+    <div style={overlayStyle}>
+      {/* Header */}
+      <header style={headerStyle}>
+        <button
+          onClick={onBack}
+          aria-label="Back to file list"
+          style={iconBtnStyle(isMobile)}
+        >
+          <svg
+            style={{ height: isMobile ? 18 : 16, width: isMobile ? 18 : 16 }}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+
+        <span
+          style={{
+            fontFamily: 'monospace',
+            fontSize: isMobile ? '0.75rem' : '0.8125rem',
+            color: 'var(--sam-color-fg-primary)',
+            flex: 1,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            minWidth: 0,
+          }}
+        >
+          {filePath}
+        </span>
+
+        {/* Diff / Full toggle */}
+        <div
+          style={{
+            display: 'flex',
+            borderRadius: 6,
+            overflow: 'hidden',
+            border: '1px solid var(--sam-color-border-default)',
+            flexShrink: 0,
+          }}
+        >
+          <ToggleButton
+            label="Diff"
+            active={viewMode === 'diff'}
+            onClick={() => setViewMode('diff')}
+          />
+          <ToggleButton
+            label="Full"
+            active={viewMode === 'full'}
+            onClick={() => setViewMode('full')}
+          />
+        </div>
+
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          style={iconBtnStyle(isMobile)}
+        >
+          <X size={isMobile ? 18 : 16} />
+        </button>
+      </header>
+
+      {/* Content */}
+      <div style={{ flex: 1, overflow: 'auto' }}>
+        {loading && (
+          <div style={{ display: 'flex', justifyContent: 'center', padding: 32 }}>
+            <Spinner size="md" />
+          </div>
+        )}
+
+        {error && (
+          <div
+            style={{
+              margin: 16,
+              padding: 12,
+              backgroundColor: 'rgba(247, 118, 142, 0.1)',
+              borderRadius: 8,
+              color: '#f7768e',
+              fontSize: '0.8125rem',
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {!loading && !error && diff === '' && (
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              padding: 48,
+              color: 'var(--sam-color-fg-muted)',
+              fontSize: '0.875rem',
+            }}
+          >
+            No diff available
+          </div>
+        )}
+
+        {!loading && !error && diff !== '' && viewMode === 'diff' && (
+          <DiffRenderer diff={diff} />
+        )}
+
+        {!loading && !error && viewMode === 'full' && (
+          fullLoading ? (
+            <div style={{ display: 'flex', justifyContent: 'center', padding: 32 }}>
+              <Spinner size="md" />
+            </div>
+          ) : fullContent !== null ? (
+            <FullFileRenderer content={fullContent} addedLines={addedLines} />
+          ) : (
+            <DiffRenderer diff={diff} />
+          )
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ---------- Diff Renderer ----------
+
+const DiffRenderer: FC<{ diff: string }> = ({ diff }) => {
+  const lines = diff.split('\n');
+
+  return (
+    <div style={{ fontFamily: 'monospace', fontSize: '0.8125rem' }}>
+      {lines.map((line, idx) => (
+        <div key={idx} style={diffLineStyle(line)}>
+          {line}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+function diffLineStyle(line: string): CSSProperties {
+  const base: CSSProperties = {
+    padding: '1px 12px',
+    whiteSpace: 'pre',
+    minHeight: '1.4em',
+    lineHeight: '1.4',
+  };
+
+  if (line.startsWith('+') && !line.startsWith('+++')) {
+    return {
+      ...base,
+      backgroundColor: 'rgba(154, 206, 106, 0.15)',
+      color: '#9ece6a',
+    };
+  }
+  if (line.startsWith('-') && !line.startsWith('---')) {
+    return {
+      ...base,
+      backgroundColor: 'rgba(247, 118, 142, 0.15)',
+      color: '#f7768e',
+    };
+  }
+  if (line.startsWith('@@')) {
+    return {
+      ...base,
+      backgroundColor: 'rgba(122, 162, 247, 0.1)',
+      color: '#7aa2f7',
+    };
+  }
+  if (line.startsWith('diff ') || line.startsWith('index ') || line.startsWith('---') || line.startsWith('+++')) {
+    return {
+      ...base,
+      color: 'var(--sam-color-fg-muted)',
+      fontWeight: 600,
+    };
+  }
+
+  return {
+    ...base,
+    color: 'var(--sam-color-fg-muted)',
+  };
+}
+
+// ---------- Full File Renderer ----------
+
+const FullFileRenderer: FC<{ content: string; addedLines: Set<number> }> = ({
+  content,
+  addedLines,
+}) => {
+  const lines = content.split('\n');
+
+  return (
+    <div style={{ fontFamily: 'monospace', fontSize: '0.8125rem' }}>
+      {lines.map((line, idx) => {
+        const lineNum = idx + 1;
+        const isAdded = addedLines.has(lineNum);
+
+        return (
+          <div
+            key={idx}
+            style={{
+              display: 'flex',
+              padding: '1px 0',
+              whiteSpace: 'pre',
+              minHeight: '1.4em',
+              lineHeight: '1.4',
+              backgroundColor: isAdded ? 'rgba(154, 206, 106, 0.1)' : 'transparent',
+            }}
+          >
+            <span
+              style={{
+                display: 'inline-block',
+                width: 48,
+                textAlign: 'right',
+                paddingRight: 12,
+                color: isAdded ? '#9ece6a' : 'var(--sam-color-fg-muted)',
+                opacity: isAdded ? 1 : 0.5,
+                userSelect: 'none',
+                flexShrink: 0,
+              }}
+            >
+              {lineNum}
+            </span>
+            <span
+              style={{
+                color: isAdded ? '#9ece6a' : 'var(--sam-color-fg-primary)',
+                flex: 1,
+              }}
+            >
+              {line}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+// ---------- Toggle Button ----------
+
+const ToggleButton: FC<{ label: string; active: boolean; onClick: () => void }> = ({
+  label,
+  active,
+  onClick,
+}) => (
+  <button
+    onClick={onClick}
+    style={{
+      padding: '3px 10px',
+      fontSize: '0.6875rem',
+      fontWeight: 600,
+      border: 'none',
+      cursor: 'pointer',
+      backgroundColor: active ? 'var(--sam-color-accent-primary)' : 'transparent',
+      color: active ? '#fff' : 'var(--sam-color-fg-muted)',
+      transition: 'background-color 0.15s, color 0.15s',
+    }}
+  >
+    {label}
+  </button>
+);
+
+// ---------- Helpers ----------
+
+function iconBtnStyle(isMobile: boolean): CSSProperties {
+  return {
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    color: 'var(--sam-color-fg-muted)',
+    padding: isMobile ? 8 : 4,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: isMobile ? 44 : 32,
+    minHeight: isMobile ? 44 : 32,
+    flexShrink: 0,
+  };
+}
+
+/**
+ * Parse a unified diff to extract which line numbers in the new file are additions.
+ * Returns a Set of 1-based line numbers.
+ */
+function parseDiffAddedLines(diff: string): Set<number> {
+  const added = new Set<number>();
+  if (!diff) return added;
+
+  let currentLine = 0;
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('@@')) {
+      // Parse hunk header: @@ -old,count +new,count @@
+      const match = line.match(/\+(\d+)/);
+      if (match?.[1]) {
+        currentLine = parseInt(match[1], 10);
+      }
+      continue;
+    }
+    if (currentLine === 0) continue; // before first hunk
+
+    if (line.startsWith('+') && !line.startsWith('+++')) {
+      added.add(currentLine);
+      currentLine++;
+    } else if (line.startsWith('-') && !line.startsWith('---')) {
+      // Removed lines don't advance the new-file line counter
+    } else {
+      // Context line
+      currentLine++;
+    }
+  }
+
+  return added;
+}

--- a/apps/web/tests/unit/components/git-changes-button.test.tsx
+++ b/apps/web/tests/unit/components/git-changes-button.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { GitChangesButton } from '../../../src/components/GitChangesButton';
+
+describe('GitChangesButton', () => {
+  it('renders the git branch icon button', () => {
+    render(<GitChangesButton onClick={() => {}} isMobile={false} />);
+    expect(screen.getByLabelText('View git changes')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const onClick = vi.fn();
+    render(<GitChangesButton onClick={onClick} isMobile={false} />);
+    fireEvent.click(screen.getByLabelText('View git changes'));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('shows change count badge when changeCount > 0', () => {
+    render(<GitChangesButton onClick={() => {}} changeCount={5} isMobile={false} />);
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('caps badge at 99+', () => {
+    render(<GitChangesButton onClick={() => {}} changeCount={150} isMobile={false} />);
+    expect(screen.getByText('99+')).toBeInTheDocument();
+  });
+
+  it('does not show badge when changeCount is 0', () => {
+    render(<GitChangesButton onClick={() => {}} changeCount={0} isMobile={false} />);
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
+  it('does not show badge when changeCount is undefined', () => {
+    render(<GitChangesButton onClick={() => {}} isMobile={false} />);
+    // No badge text should be present
+    const button = screen.getByLabelText('View git changes');
+    expect(button.querySelectorAll('span')).toHaveLength(0);
+  });
+
+  it('is disabled when disabled prop is true', () => {
+    const onClick = vi.fn();
+    render(<GitChangesButton onClick={onClick} disabled isMobile={false} />);
+    const button = screen.getByLabelText('View git changes');
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('uses larger touch targets on mobile', () => {
+    render(<GitChangesButton onClick={() => {}} isMobile={true} />);
+    const button = screen.getByLabelText('View git changes');
+    expect(button.style.minWidth).toBe('44px');
+    expect(button.style.minHeight).toBe('44px');
+  });
+
+  it('uses smaller touch targets on desktop', () => {
+    render(<GitChangesButton onClick={() => {}} isMobile={false} />);
+    const button = screen.getByLabelText('View git changes');
+    expect(button.style.minWidth).toBe('32px');
+    expect(button.style.minHeight).toBe('32px');
+  });
+});

--- a/apps/web/tests/unit/components/git-changes-panel.test.tsx
+++ b/apps/web/tests/unit/components/git-changes-panel.test.tsx
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mocks = vi.hoisted(() => ({
+  getGitStatus: vi.fn(),
+}));
+
+vi.mock('../../../src/lib/api', () => ({
+  getGitStatus: mocks.getGitStatus,
+}));
+
+import { GitChangesPanel } from '../../../src/components/GitChangesPanel';
+
+const defaultProps = {
+  workspaceUrl: 'https://ws-test.example.com',
+  workspaceId: 'ws-123',
+  token: 'test-token',
+  isMobile: false,
+  onClose: vi.fn(),
+  onSelectFile: vi.fn(),
+};
+
+describe('GitChangesPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows spinner while loading', () => {
+    mocks.getGitStatus.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<GitChangesPanel {...defaultProps} />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('shows error message on fetch failure', async () => {
+    mocks.getGitStatus.mockRejectedValue(new Error('Network error'));
+    render(<GitChangesPanel {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+  });
+
+  it('shows "No changes detected" when status is clean', async () => {
+    mocks.getGitStatus.mockResolvedValue({
+      staged: [],
+      unstaged: [],
+      untracked: [],
+    });
+    render(<GitChangesPanel {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('No changes detected')).toBeInTheDocument();
+    });
+  });
+
+  it('shows staged files section', async () => {
+    mocks.getGitStatus.mockResolvedValue({
+      staged: [{ path: 'src/index.ts', status: 'M' }],
+      unstaged: [],
+      untracked: [],
+    });
+    render(<GitChangesPanel {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('Staged')).toBeInTheDocument();
+    });
+    expect(screen.getByText('src/')).toBeInTheDocument();
+    expect(screen.getByText('index.ts')).toBeInTheDocument();
+  });
+
+  it('shows unstaged files section', async () => {
+    mocks.getGitStatus.mockResolvedValue({
+      staged: [],
+      unstaged: [{ path: 'README.md', status: 'M' }],
+      untracked: [],
+    });
+    render(<GitChangesPanel {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('Unstaged')).toBeInTheDocument();
+    });
+    expect(screen.getByText('README.md')).toBeInTheDocument();
+  });
+
+  it('shows untracked files section', async () => {
+    mocks.getGitStatus.mockResolvedValue({
+      staged: [],
+      unstaged: [],
+      untracked: [{ path: 'newfile.txt', status: '??' }],
+    });
+    render(<GitChangesPanel {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('Untracked')).toBeInTheDocument();
+    });
+    expect(screen.getByText('newfile.txt')).toBeInTheDocument();
+  });
+
+  it('calls onSelectFile with path and staged=true for staged files', async () => {
+    mocks.getGitStatus.mockResolvedValue({
+      staged: [{ path: 'src/app.ts', status: 'A' }],
+      unstaged: [],
+      untracked: [],
+    });
+    render(<GitChangesPanel {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('app.ts')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('app.ts'));
+    expect(defaultProps.onSelectFile).toHaveBeenCalledWith('src/app.ts', true);
+  });
+
+  it('calls onSelectFile with path and staged=false for unstaged files', async () => {
+    mocks.getGitStatus.mockResolvedValue({
+      staged: [],
+      unstaged: [{ path: 'lib/utils.ts', status: 'M' }],
+      untracked: [],
+    });
+    render(<GitChangesPanel {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('utils.ts')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('utils.ts'));
+    expect(defaultProps.onSelectFile).toHaveBeenCalledWith('lib/utils.ts', false);
+  });
+
+  it('calls onClose when close button is clicked', async () => {
+    mocks.getGitStatus.mockResolvedValue({ staged: [], unstaged: [], untracked: [] });
+    render(<GitChangesPanel {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('No changes detected')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('calls onClose when Escape key is pressed', async () => {
+    mocks.getGitStatus.mockResolvedValue({ staged: [], unstaged: [], untracked: [] });
+    render(<GitChangesPanel {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('No changes detected')).toBeInTheDocument();
+    });
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('shows total change count in header', async () => {
+    mocks.getGitStatus.mockResolvedValue({
+      staged: [{ path: 'a.ts', status: 'M' }],
+      unstaged: [{ path: 'b.ts', status: 'M' }],
+      untracked: [{ path: 'c.ts', status: '??' }],
+    });
+    render(<GitChangesPanel {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('(3)')).toBeInTheDocument();
+    });
+  });
+
+  it('collapses sections when header is clicked', async () => {
+    mocks.getGitStatus.mockResolvedValue({
+      staged: [{ path: 'a.ts', status: 'M' }],
+      unstaged: [],
+      untracked: [],
+    });
+    render(<GitChangesPanel {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('a.ts')).toBeInTheDocument();
+    });
+    // Click the Staged section header to collapse
+    fireEvent.click(screen.getByText('Staged'));
+    expect(screen.queryByText('a.ts')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/unit/components/git-diff-view.test.tsx
+++ b/apps/web/tests/unit/components/git-diff-view.test.tsx
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mocks = vi.hoisted(() => ({
+  getGitDiff: vi.fn(),
+  getGitFile: vi.fn(),
+}));
+
+vi.mock('../../../src/lib/api', () => ({
+  getGitDiff: mocks.getGitDiff,
+  getGitFile: mocks.getGitFile,
+}));
+
+import { GitDiffView } from '../../../src/components/GitDiffView';
+
+const defaultProps = {
+  workspaceUrl: 'https://ws-test.example.com',
+  workspaceId: 'ws-123',
+  token: 'test-token',
+  filePath: 'src/main.ts',
+  staged: false,
+  isMobile: false,
+  onBack: vi.fn(),
+  onClose: vi.fn(),
+};
+
+const sampleDiff = `diff --git a/src/main.ts b/src/main.ts
+index abc1234..def5678 100644
+--- a/src/main.ts
++++ b/src/main.ts
+@@ -1,3 +1,4 @@
+ import { app } from './app';
++import { logger } from './logger';
+
+ app.listen(3000);`;
+
+describe('GitDiffView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows spinner while loading', () => {
+    mocks.getGitDiff.mockReturnValue(new Promise(() => {}));
+    render(<GitDiffView {...defaultProps} />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('shows error message on fetch failure', async () => {
+    mocks.getGitDiff.mockRejectedValue(new Error('Diff fetch failed'));
+    render(<GitDiffView {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('Diff fetch failed')).toBeInTheDocument();
+    });
+  });
+
+  it('shows "No diff available" when diff is empty', async () => {
+    mocks.getGitDiff.mockResolvedValue({ diff: '' });
+    render(<GitDiffView {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('No diff available')).toBeInTheDocument();
+    });
+  });
+
+  it('renders diff content with colored lines', async () => {
+    mocks.getGitDiff.mockResolvedValue({ diff: sampleDiff });
+    render(<GitDiffView {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText(/import \{ logger \}/)).toBeInTheDocument();
+    });
+  });
+
+  it('displays file path in header', async () => {
+    mocks.getGitDiff.mockResolvedValue({ diff: sampleDiff });
+    render(<GitDiffView {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('src/main.ts')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onBack when back button is clicked', async () => {
+    mocks.getGitDiff.mockResolvedValue({ diff: sampleDiff });
+    render(<GitDiffView {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText(/import \{ logger \}/)).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByLabelText('Back to file list'));
+    expect(defaultProps.onBack).toHaveBeenCalled();
+  });
+
+  it('calls onClose when close button is clicked', async () => {
+    mocks.getGitDiff.mockResolvedValue({ diff: sampleDiff });
+    render(<GitDiffView {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText(/import \{ logger \}/)).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('calls onClose when Escape key is pressed', async () => {
+    mocks.getGitDiff.mockResolvedValue({ diff: sampleDiff });
+    render(<GitDiffView {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText(/import \{ logger \}/)).toBeInTheDocument();
+    });
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('shows Diff/Full toggle buttons', async () => {
+    mocks.getGitDiff.mockResolvedValue({ diff: sampleDiff });
+    render(<GitDiffView {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('Diff')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Full')).toBeInTheDocument();
+  });
+
+  it('switches to full file view when Full button is clicked', async () => {
+    mocks.getGitDiff.mockResolvedValue({ diff: sampleDiff });
+    mocks.getGitFile.mockResolvedValue({
+      content: `import { app } from './app';
+import { logger } from './logger';
+
+app.listen(3000);`,
+    });
+    render(<GitDiffView {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('Diff')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('Full'));
+    await waitFor(() => {
+      expect(mocks.getGitFile).toHaveBeenCalledWith(
+        defaultProps.workspaceUrl,
+        defaultProps.workspaceId,
+        defaultProps.token,
+        defaultProps.filePath,
+      );
+    });
+  });
+
+  it('falls back to diff view if full file fetch fails', async () => {
+    mocks.getGitDiff.mockResolvedValue({ diff: sampleDiff });
+    mocks.getGitFile.mockRejectedValue(new Error('File not found'));
+    render(<GitDiffView {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('Diff')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('Full'));
+    // Should still show diff content as fallback
+    await waitFor(() => {
+      expect(screen.getByText(/import \{ logger \}/)).toBeInTheDocument();
+    });
+  });
+
+  it('passes staged flag to getGitDiff', async () => {
+    mocks.getGitDiff.mockResolvedValue({ diff: sampleDiff });
+    render(<GitDiffView {...defaultProps} staged={true} />);
+    await waitFor(() => {
+      expect(mocks.getGitDiff).toHaveBeenCalledWith(
+        defaultProps.workspaceUrl,
+        defaultProps.workspaceId,
+        defaultProps.token,
+        defaultProps.filePath,
+        true,
+      );
+    });
+  });
+});

--- a/apps/web/tests/unit/pages/workspace.test.tsx
+++ b/apps/web/tests/unit/pages/workspace.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   stopAgentSession: vi.fn(),
   updateWorkspace: vi.fn(),
   listAgents: vi.fn(),
+  getGitStatus: vi.fn(),
   useAcpSession: vi.fn(),
 }));
 
@@ -38,6 +39,7 @@ vi.mock('../../../src/lib/api', () => ({
   stopAgentSession: mocks.stopAgentSession,
   updateWorkspace: mocks.updateWorkspace,
   listAgents: mocks.listAgents,
+  getGitStatus: mocks.getGitStatus,
   getTranscribeApiUrl: () => 'https://api.example.com/api/transcribe',
 }));
 
@@ -173,6 +175,7 @@ describe('Workspace page', () => {
       updatedAt: '2026-02-08T00:00:00.000Z',
       url: 'https://ws-ws-123.example.com',
     });
+    mocks.getGitStatus.mockResolvedValue({ staged: [], unstaged: [], untracked: [] });
     mocks.listAgents.mockResolvedValue({
       agents: [
         {

--- a/packages/vm-agent/internal/config/config.go
+++ b/packages/vm-agent/internal/config/config.go
@@ -114,6 +114,10 @@ type Config struct {
 
 	// Persistence settings - configurable per constitution principle XI
 	PersistenceDBPath string // SQLite database path for session state persistence
+
+	// Git integration settings - configurable per constitution principle XI
+	GitExecTimeout time.Duration // Timeout for git commands via docker exec (default: 30s)
+	GitFileMaxSize int           // Max file size in bytes for /git/file (default: 1MB)
 }
 
 // Load reads configuration from environment variables.
@@ -218,6 +222,10 @@ func Load() (*Config, error) {
 
 		// Persistence settings
 		PersistenceDBPath: getEnv("PERSISTENCE_DB_PATH", "/var/lib/vm-agent/state.db"),
+
+		// Git integration settings - configurable per constitution principle XI
+		GitExecTimeout: getEnvDuration("GIT_EXEC_TIMEOUT", 30*time.Second),
+		GitFileMaxSize: getEnvInt("GIT_FILE_MAX_SIZE", 1048576), // 1 MB
 	}
 
 	// Validate required fields

--- a/packages/vm-agent/internal/server/git.go
+++ b/packages/vm-agent/internal/server/git.go
@@ -1,0 +1,419 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ---------- Response types ----------
+
+// GitFileStatus represents a single file in git status output.
+type GitFileStatus struct {
+	Path    string `json:"path"`
+	Status  string `json:"status"`             // "M", "A", "D", "R", "??" etc.
+	OldPath string `json:"oldPath,omitempty"`   // populated for renames
+}
+
+// GitStatusResponse groups files by their git staging state.
+type GitStatusResponse struct {
+	Staged    []GitFileStatus `json:"staged"`
+	Unstaged  []GitFileStatus `json:"unstaged"`
+	Untracked []GitFileStatus `json:"untracked"`
+}
+
+// GitDiffResponse contains a unified diff for a single file.
+type GitDiffResponse struct {
+	Diff     string `json:"diff"`
+	FilePath string `json:"filePath"`
+}
+
+// GitFileResponse contains the full content of a single file.
+type GitFileResponse struct {
+	Content  string `json:"content"`
+	FilePath string `json:"filePath"`
+}
+
+// ---------- Handlers ----------
+
+// handleGitStatus returns the git status for a workspace, grouped by staged/unstaged/untracked.
+// GET /workspaces/{workspaceId}/git/status
+func (s *Server) handleGitStatus(w http.ResponseWriter, r *http.Request) {
+	workspaceID := r.PathValue("workspaceId")
+	if workspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspaceId is required")
+		return
+	}
+
+	if !s.requireWorkspaceRequestAuth(w, r, workspaceID) {
+		return
+	}
+
+	containerID, workDir, user, err := s.resolveContainerForWorkspace(workspaceID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), s.config.GitExecTimeout)
+	defer cancel()
+
+	stdout, _, err := s.execInContainer(ctx, containerID, user, workDir, "git", "status", "--porcelain=v1")
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("git status failed: %v", err))
+		return
+	}
+
+	staged, unstaged, untracked := parseGitStatusPorcelain(stdout)
+	writeJSON(w, http.StatusOK, GitStatusResponse{
+		Staged:    staged,
+		Unstaged:  unstaged,
+		Untracked: untracked,
+	})
+}
+
+// handleGitDiff returns the unified diff for a single file.
+// GET /workspaces/{workspaceId}/git/diff?path=...&staged=true|false
+func (s *Server) handleGitDiff(w http.ResponseWriter, r *http.Request) {
+	workspaceID := r.PathValue("workspaceId")
+	if workspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspaceId is required")
+		return
+	}
+
+	if !s.requireWorkspaceRequestAuth(w, r, workspaceID) {
+		return
+	}
+
+	filePath := r.URL.Query().Get("path")
+	if filePath == "" {
+		writeError(w, http.StatusBadRequest, "path query parameter is required")
+		return
+	}
+	if err := sanitizeFilePath(filePath); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	staged := r.URL.Query().Get("staged") == "true"
+
+	containerID, workDir, user, err := s.resolveContainerForWorkspace(workspaceID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), s.config.GitExecTimeout)
+	defer cancel()
+
+	var diff string
+	if staged {
+		diff, _, err = s.execInContainer(ctx, containerID, user, workDir, "git", "diff", "--cached", "--", filePath)
+	} else {
+		diff, _, err = s.execInContainer(ctx, containerID, user, workDir, "git", "diff", "--", filePath)
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("git diff failed: %v", err))
+		return
+	}
+
+	// For untracked files, git diff returns empty. Show file content as all-additions.
+	if diff == "" {
+		content, _, catErr := s.execInContainer(ctx, containerID, user, workDir, "cat", filePath)
+		if catErr == nil && content != "" {
+			diff = formatAsAdditions(filePath, content)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, GitDiffResponse{
+		Diff:     diff,
+		FilePath: filePath,
+	})
+}
+
+// handleGitFile returns the full content of a single file.
+// GET /workspaces/{workspaceId}/git/file?path=...&ref=HEAD
+func (s *Server) handleGitFile(w http.ResponseWriter, r *http.Request) {
+	workspaceID := r.PathValue("workspaceId")
+	if workspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspaceId is required")
+		return
+	}
+
+	if !s.requireWorkspaceRequestAuth(w, r, workspaceID) {
+		return
+	}
+
+	filePath := r.URL.Query().Get("path")
+	if filePath == "" {
+		writeError(w, http.StatusBadRequest, "path query parameter is required")
+		return
+	}
+	if err := sanitizeFilePath(filePath); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	ref := r.URL.Query().Get("ref")
+
+	containerID, workDir, user, err := s.resolveContainerForWorkspace(workspaceID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), s.config.GitExecTimeout)
+	defer cancel()
+
+	var content string
+	if ref != "" {
+		// Sanitize ref to prevent command injection via git show argument
+		if err := sanitizeGitRef(ref); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		content, _, err = s.execInContainer(ctx, containerID, user, workDir, "git", "show", ref+":"+filePath)
+	} else {
+		content, _, err = s.execInContainer(ctx, containerID, user, workDir, "cat", filePath)
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to read file: %v", err))
+		return
+	}
+
+	// Enforce max file size
+	if len(content) > s.config.GitFileMaxSize {
+		writeError(w, http.StatusRequestEntityTooLarge, fmt.Sprintf("file exceeds maximum size of %d bytes", s.config.GitFileMaxSize))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, GitFileResponse{
+		Content:  content,
+		FilePath: filePath,
+	})
+}
+
+// ---------- Helpers ----------
+
+// sanitizeFilePath validates that a file path is safe for use in git commands.
+// Rejects path traversal, absolute paths, and null bytes.
+func sanitizeFilePath(path string) error {
+	if path == "" {
+		return fmt.Errorf("file path is empty")
+	}
+
+	if strings.ContainsRune(path, 0) {
+		return fmt.Errorf("file path contains null byte")
+	}
+
+	if filepath.IsAbs(path) {
+		return fmt.Errorf("absolute file paths are not allowed")
+	}
+
+	// Check for path traversal
+	cleaned := filepath.Clean(path)
+	if strings.HasPrefix(cleaned, "..") {
+		return fmt.Errorf("path traversal is not allowed")
+	}
+
+	// Also reject any component that is ".."
+	for _, part := range strings.Split(cleaned, string(filepath.Separator)) {
+		if part == ".." {
+			return fmt.Errorf("path traversal is not allowed")
+		}
+	}
+
+	return nil
+}
+
+// sanitizeGitRef validates that a git ref string is safe (no shell metacharacters).
+func sanitizeGitRef(ref string) error {
+	if ref == "" {
+		return fmt.Errorf("git ref is empty")
+	}
+	if strings.ContainsRune(ref, 0) {
+		return fmt.Errorf("git ref contains null byte")
+	}
+	// Allow alphanumeric, -, _, /, ., ~ (standard git ref chars)
+	for _, r := range ref {
+		if !isValidRefChar(r) {
+			return fmt.Errorf("invalid character in git ref: %c", r)
+		}
+	}
+	return nil
+}
+
+func isValidRefChar(r rune) bool {
+	if r >= 'a' && r <= 'z' {
+		return true
+	}
+	if r >= 'A' && r <= 'Z' {
+		return true
+	}
+	if r >= '0' && r <= '9' {
+		return true
+	}
+	switch r {
+	case '-', '_', '/', '.', '~', '^':
+		return true
+	}
+	return false
+}
+
+// resolveContainerForWorkspace looks up the workspace runtime, validates its status,
+// and resolves the devcontainer's container ID, work directory, and user.
+func (s *Server) resolveContainerForWorkspace(workspaceID string) (containerID, workDir, user string, err error) {
+	runtime, ok := s.getWorkspaceRuntime(workspaceID)
+	if !ok {
+		return "", "", "", fmt.Errorf("workspace not found")
+	}
+	if runtime.Status != "running" {
+		return "", "", "", fmt.Errorf("workspace is not running (status: %s)", runtime.Status)
+	}
+
+	resolver := s.ptyManagerContainerResolverForLabel(runtime.ContainerLabelValue)
+	if resolver == nil {
+		return "", "", "", fmt.Errorf("container mode is not enabled")
+	}
+
+	containerID, err = resolver()
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to resolve container: %w", err)
+	}
+
+	workDir = runtime.ContainerWorkDir
+	if workDir == "" {
+		workDir = "/workspaces"
+	}
+
+	user = s.config.ContainerUser
+
+	return containerID, workDir, user, nil
+}
+
+// execInContainer runs a command inside a devcontainer and returns stdout.
+// Uses docker exec with optional user and workdir flags.
+func (s *Server) execInContainer(ctx context.Context, containerID, user, workDir string, args ...string) (stdout string, stderr string, err error) {
+	dockerArgs := []string{"exec", "-i"}
+	if user != "" {
+		dockerArgs = append(dockerArgs, "-u", user)
+	}
+	if workDir != "" {
+		dockerArgs = append(dockerArgs, "-w", workDir)
+	}
+	dockerArgs = append(dockerArgs, containerID)
+	dockerArgs = append(dockerArgs, args...)
+
+	cmd := exec.CommandContext(ctx, "docker", dockerArgs...)
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	if err := cmd.Run(); err != nil {
+		stderrStr := strings.TrimSpace(stderrBuf.String())
+		if stderrStr != "" {
+			log.Printf("[git] exec error: %v, stderr: %s", err, stderrStr)
+		}
+		return "", stderrStr, fmt.Errorf("command failed: %w", err)
+	}
+
+	return stdoutBuf.String(), stderrBuf.String(), nil
+}
+
+// parseGitStatusPorcelain parses the output of `git status --porcelain=v1`
+// into staged, unstaged, and untracked file lists.
+//
+// Porcelain v1 format: XY <path> (or XY <old> -> <new> for renames)
+// X = index (staged) status, Y = worktree (unstaged) status.
+// "??" = untracked, "!!" = ignored (skipped).
+func parseGitStatusPorcelain(output string) (staged, unstaged, untracked []GitFileStatus) {
+	staged = []GitFileStatus{}
+	unstaged = []GitFileStatus{}
+	untracked = []GitFileStatus{}
+
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if len(line) < 3 {
+			continue
+		}
+
+		indexStatus := line[0]
+		worktreeStatus := line[1]
+		rest := line[3:] // skip "XY "
+
+		// Handle renames: "old -> new"
+		var filePath, oldPath string
+		if arrowIdx := strings.Index(rest, " -> "); arrowIdx >= 0 {
+			oldPath = strings.TrimSpace(rest[:arrowIdx])
+			filePath = strings.TrimSpace(rest[arrowIdx+4:])
+		} else {
+			filePath = strings.TrimSpace(rest)
+		}
+
+		if filePath == "" {
+			continue
+		}
+
+		// Untracked
+		if indexStatus == '?' && worktreeStatus == '?' {
+			untracked = append(untracked, GitFileStatus{
+				Path:   filePath,
+				Status: "??",
+			})
+			continue
+		}
+
+		// Ignored
+		if indexStatus == '!' && worktreeStatus == '!' {
+			continue
+		}
+
+		// Staged changes (index status is not space and not '?')
+		if indexStatus != ' ' && indexStatus != '?' {
+			fs := GitFileStatus{
+				Path:   filePath,
+				Status: string(indexStatus),
+			}
+			if oldPath != "" {
+				fs.OldPath = oldPath
+			}
+			staged = append(staged, fs)
+		}
+
+		// Unstaged changes (worktree status is not space and not '?')
+		if worktreeStatus != ' ' && worktreeStatus != '?' {
+			unstaged = append(unstaged, GitFileStatus{
+				Path:   filePath,
+				Status: string(worktreeStatus),
+			})
+		}
+	}
+
+	return staged, unstaged, untracked
+}
+
+// formatAsAdditions converts file content into a unified diff format where all lines are additions.
+// Used for untracked files where `git diff` returns empty.
+func formatAsAdditions(filePath, content string) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("--- /dev/null\n+++ b/%s\n", filePath))
+
+	lines := strings.Split(content, "\n")
+	// Remove trailing empty line from Split
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	b.WriteString(fmt.Sprintf("@@ -0,0 +1,%d @@\n", len(lines)))
+	for _, line := range lines {
+		b.WriteString("+" + line + "\n")
+	}
+
+	return b.String()
+}

--- a/packages/vm-agent/internal/server/git_test.go
+++ b/packages/vm-agent/internal/server/git_test.go
@@ -1,0 +1,266 @@
+package server
+
+import (
+	"testing"
+)
+
+func TestSanitizeFilePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{name: "valid simple file", path: "README.md", wantErr: false},
+		{name: "valid nested path", path: "src/components/App.tsx", wantErr: false},
+		{name: "valid deeply nested", path: "a/b/c/d/e/f.go", wantErr: false},
+		{name: "valid path with spaces", path: "my files/test.txt", wantErr: false},
+		{name: "valid path with dots in name", path: "src/utils.test.ts", wantErr: false},
+		{name: "valid hidden file", path: ".gitignore", wantErr: false},
+		{name: "valid hidden dir", path: ".github/workflows/ci.yml", wantErr: false},
+
+		{name: "empty path", path: "", wantErr: true},
+		{name: "path traversal basic", path: "../etc/passwd", wantErr: true},
+		{name: "path traversal nested", path: "src/../../etc/passwd", wantErr: true},
+		{name: "path traversal middle", path: "a/b/../../../etc/passwd", wantErr: true},
+		{name: "absolute path", path: "/etc/passwd", wantErr: true},
+		{name: "absolute path windows-style", path: "/home/user/secret", wantErr: true},
+		{name: "null byte", path: "file\x00.txt", wantErr: true},
+		{name: "null byte in middle", path: "src/\x00malicious", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := sanitizeFilePath(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("sanitizeFilePath(%q) error = %v, wantErr %v", tt.path, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSanitizeGitRef(t *testing.T) {
+	tests := []struct {
+		name    string
+		ref     string
+		wantErr bool
+	}{
+		{name: "HEAD", ref: "HEAD", wantErr: false},
+		{name: "branch name", ref: "main", wantErr: false},
+		{name: "tag", ref: "v1.0.0", wantErr: false},
+		{name: "short hash", ref: "abc1234", wantErr: false},
+		{name: "long hash", ref: "abc1234def5678", wantErr: false},
+		{name: "relative ref", ref: "HEAD~1", wantErr: false},
+		{name: "parent ref", ref: "HEAD^1", wantErr: false},
+		{name: "branch with slash", ref: "origin/main", wantErr: false},
+
+		{name: "empty", ref: "", wantErr: true},
+		{name: "semicolon", ref: "HEAD;rm -rf /", wantErr: true},
+		{name: "backtick", ref: "HEAD`whoami`", wantErr: true},
+		{name: "dollar", ref: "HEAD$(cmd)", wantErr: true},
+		{name: "pipe", ref: "HEAD|cat", wantErr: true},
+		{name: "ampersand", ref: "HEAD&&cmd", wantErr: true},
+		{name: "null byte", ref: "HEAD\x00", wantErr: true},
+		{name: "space", ref: "HEAD 1", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := sanitizeGitRef(tt.ref)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("sanitizeGitRef(%q) error = %v, wantErr %v", tt.ref, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseGitStatusPorcelain(t *testing.T) {
+	tests := []struct {
+		name          string
+		output        string
+		wantStaged    []GitFileStatus
+		wantUnstaged  []GitFileStatus
+		wantUntracked []GitFileStatus
+	}{
+		{
+			name:          "empty output",
+			output:        "",
+			wantStaged:    []GitFileStatus{},
+			wantUnstaged:  []GitFileStatus{},
+			wantUntracked: []GitFileStatus{},
+		},
+		{
+			name:   "staged modified",
+			output: "M  src/index.ts\n",
+			wantStaged: []GitFileStatus{
+				{Path: "src/index.ts", Status: "M"},
+			},
+			wantUnstaged:  []GitFileStatus{},
+			wantUntracked: []GitFileStatus{},
+		},
+		{
+			name:       "unstaged modified",
+			output:     " M src/index.ts\n",
+			wantStaged: []GitFileStatus{},
+			wantUnstaged: []GitFileStatus{
+				{Path: "src/index.ts", Status: "M"},
+			},
+			wantUntracked: []GitFileStatus{},
+		},
+		{
+			name:   "staged added",
+			output: "A  newfile.ts\n",
+			wantStaged: []GitFileStatus{
+				{Path: "newfile.ts", Status: "A"},
+			},
+			wantUnstaged:  []GitFileStatus{},
+			wantUntracked: []GitFileStatus{},
+		},
+		{
+			name:   "staged deleted",
+			output: "D  oldfile.ts\n",
+			wantStaged: []GitFileStatus{
+				{Path: "oldfile.ts", Status: "D"},
+			},
+			wantUnstaged:  []GitFileStatus{},
+			wantUntracked: []GitFileStatus{},
+		},
+		{
+			name:          "untracked file",
+			output:        "?? newfile.ts\n",
+			wantStaged:    []GitFileStatus{},
+			wantUnstaged:  []GitFileStatus{},
+			wantUntracked: []GitFileStatus{{Path: "newfile.ts", Status: "??"}},
+		},
+		{
+			name:   "renamed file",
+			output: "R  old.ts -> new.ts\n",
+			wantStaged: []GitFileStatus{
+				{Path: "new.ts", Status: "R", OldPath: "old.ts"},
+			},
+			wantUnstaged:  []GitFileStatus{},
+			wantUntracked: []GitFileStatus{},
+		},
+		{
+			name:   "staged and unstaged (AM)",
+			output: "AM newfile.ts\n",
+			wantStaged: []GitFileStatus{
+				{Path: "newfile.ts", Status: "A"},
+			},
+			wantUnstaged: []GitFileStatus{
+				{Path: "newfile.ts", Status: "M"},
+			},
+			wantUntracked: []GitFileStatus{},
+		},
+		{
+			name:   "staged and unstaged (MM)",
+			output: "MM src/app.ts\n",
+			wantStaged: []GitFileStatus{
+				{Path: "src/app.ts", Status: "M"},
+			},
+			wantUnstaged: []GitFileStatus{
+				{Path: "src/app.ts", Status: "M"},
+			},
+			wantUntracked: []GitFileStatus{},
+		},
+		{
+			name:          "ignored files are skipped",
+			output:        "!! node_modules/foo\n",
+			wantStaged:    []GitFileStatus{},
+			wantUnstaged:  []GitFileStatus{},
+			wantUntracked: []GitFileStatus{},
+		},
+		{
+			name: "mixed output",
+			output: "M  src/index.ts\n" +
+				" M README.md\n" +
+				"A  lib/utils.ts\n" +
+				"?? temp.txt\n" +
+				"?? scratch/\n",
+			wantStaged: []GitFileStatus{
+				{Path: "src/index.ts", Status: "M"},
+				{Path: "lib/utils.ts", Status: "A"},
+			},
+			wantUnstaged: []GitFileStatus{
+				{Path: "README.md", Status: "M"},
+			},
+			wantUntracked: []GitFileStatus{
+				{Path: "temp.txt", Status: "??"},
+				{Path: "scratch/", Status: "??"},
+			},
+		},
+		{
+			name:          "short line ignored",
+			output:        "X\n\n",
+			wantStaged:    []GitFileStatus{},
+			wantUnstaged:  []GitFileStatus{},
+			wantUntracked: []GitFileStatus{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStaged, gotUnstaged, gotUntracked := parseGitStatusPorcelain(tt.output)
+
+			assertFileStatusSlice(t, "staged", gotStaged, tt.wantStaged)
+			assertFileStatusSlice(t, "unstaged", gotUnstaged, tt.wantUnstaged)
+			assertFileStatusSlice(t, "untracked", gotUntracked, tt.wantUntracked)
+		})
+	}
+}
+
+func TestFormatAsAdditions(t *testing.T) {
+	result := formatAsAdditions("test.txt", "line1\nline2\nline3\n")
+
+	if !containsSubstring(result, "--- /dev/null") {
+		t.Error("expected /dev/null in diff header")
+	}
+	if !containsSubstring(result, "+++ b/test.txt") {
+		t.Error("expected +++ b/test.txt in diff header")
+	}
+	if !containsSubstring(result, "@@ -0,0 +1,3 @@") {
+		t.Errorf("expected hunk header @@ -0,0 +1,3 @@, got:\n%s", result)
+	}
+	if !containsSubstring(result, "+line1") {
+		t.Error("expected +line1 in output")
+	}
+	if !containsSubstring(result, "+line2") {
+		t.Error("expected +line2 in output")
+	}
+	if !containsSubstring(result, "+line3") {
+		t.Error("expected +line3 in output")
+	}
+}
+
+// ---------- Test helpers ----------
+
+func assertFileStatusSlice(t *testing.T, label string, got, want []GitFileStatus) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%s: got %d files, want %d. got=%+v want=%+v", label, len(got), len(want), got, want)
+		return
+	}
+	for i := range want {
+		if got[i].Path != want[i].Path {
+			t.Errorf("%s[%d].Path = %q, want %q", label, i, got[i].Path, want[i].Path)
+		}
+		if got[i].Status != want[i].Status {
+			t.Errorf("%s[%d].Status = %q, want %q", label, i, got[i].Status, want[i].Status)
+		}
+		if got[i].OldPath != want[i].OldPath {
+			t.Errorf("%s[%d].OldPath = %q, want %q", label, i, got[i].OldPath, want[i].OldPath)
+		}
+	}
+}
+
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+
+func containsStr(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/packages/vm-agent/internal/server/server.go
+++ b/packages/vm-agent/internal/server/server.go
@@ -329,6 +329,12 @@ func (s *Server) setupRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /workspaces/{workspaceId}/agent-sessions", s.handleCreateAgentSession)
 	mux.HandleFunc("POST /workspaces/{workspaceId}/agent-sessions/{sessionId}/stop", s.handleStopAgentSession)
 	mux.HandleFunc("GET /workspaces/{workspaceId}/tabs", s.handleListTabs)
+
+	// Git integration (browser-authenticated via workspace session/token)
+	mux.HandleFunc("GET /workspaces/{workspaceId}/git/status", s.handleGitStatus)
+	mux.HandleFunc("GET /workspaces/{workspaceId}/git/diff", s.handleGitDiff)
+	mux.HandleFunc("GET /workspaces/{workspaceId}/git/file", s.handleGitFile)
+
 	mux.HandleFunc("GET /events", s.handleListNodeEvents)
 	mux.HandleFunc("GET /workspaces/{workspaceId}/ports/{port}", s.handleWorkspacePortProxy)
 

--- a/tasks/active/2026-02-14-git-changes-viewer.md
+++ b/tasks/active/2026-02-14-git-changes-viewer.md
@@ -1,0 +1,80 @@
+# Git Changes Viewer
+
+**Created**: 2026-02-14
+**Priority**: High
+**Relates to**: FR-008 (file browsing requirement)
+
+## Summary
+
+A GitHub PR-style review UI for viewing git changes (staged/unstaged/untracked) within workspaces. Entry point is an icon button in the workspace nav bar. Full-screen overlay with browser back/forward routing support. Read-only in v1.
+
+## Context
+
+FR-008 requires file browsing/editing in workspaces. This is the first step — a focused git changes viewer that lets users review what the agent (or they) have changed. A general file browser will follow later and integrate with this.
+
+## Design Decisions
+
+- **Entry point**: Icon button (GitBranch icon) in workspace nav bar, next to kebab menu
+- **Layout**: Full-screen overlay (same on mobile and desktop)
+- **Routing**: URL search params for browser back/forward (`?git=changes`, `?git=diff&file=...&staged=...`)
+- **Read-only v1**: No stage/unstage actions; refresh button for manual updates
+- **Not reusing `FileDiffView`** from acp-client — it uses Tailwind classes; workspace page uses inline styles with CSS custom properties
+- **zIndex: 60** for git overlay (existing sidebar uses 50/51)
+
+## Implementation Plan
+
+### Phase 1: Backend — VM Agent (Go)
+
+- [ ] Add `GitExecTimeout` (default 30s) and `GitFileMaxSize` (default 1MB) to `config.go`
+- [ ] Create `git.go` with three handlers + helpers:
+  - `GET /workspaces/{workspaceId}/git/status` — parses `git status --porcelain=v1`
+  - `GET /workspaces/{workspaceId}/git/diff?path=...&staged=true|false` — unified diff for one file
+  - `GET /workspaces/{workspaceId}/git/file?path=...&ref=HEAD` — full file content
+  - `sanitizeFilePath()` — rejects `..`, absolute paths, null bytes
+  - `sanitizeGitRef()` — rejects shell metacharacters
+  - `execInContainer()` — `docker exec` wrapper with timeout
+  - `parseGitStatusPorcelain()` — parser for porcelain v1 format
+  - `formatAsAdditions()` — converts untracked file content to diff format
+- [ ] Register 3 routes in `server.go` `setupRoutes()`
+- [ ] Create `git_test.go` with path sanitization, ref sanitization, porcelain parser, and formatAsAdditions tests
+
+### Phase 2: API Client (TypeScript)
+
+- [ ] Add to `apps/web/src/lib/api.ts`:
+  - Types: `GitFileStatus`, `GitStatusData`, `GitDiffData`, `GitFileData`
+  - Functions: `getGitStatus()`, `getGitDiff()`, `getGitFile()`
+  - Pattern: direct fetch to VM agent via `ws-{id}` subdomain with `?token=` auth
+
+### Phase 3: Frontend Components (React)
+
+- [ ] `GitChangesButton.tsx` — nav bar icon with optional change count badge
+- [ ] `GitChangesPanel.tsx` — full-screen overlay with collapsible Staged/Unstaged/Untracked sections
+  - File rows show status letter (color-coded) + path (dir dimmed, filename bright)
+  - Refresh button, close button, Escape key handler
+  - Empty state: "No changes detected"
+- [ ] `GitDiffView.tsx` — full-screen diff viewer for one file
+  - Unified diff with green (added), red (removed), blue (hunk headers), dimmed (context)
+  - Toggle between "Diff" (hunks only) and "Full" (entire file with highlights)
+  - Monospace, horizontal scroll
+- [ ] Integrate into `Workspace.tsx`:
+  - Read `git`, `file`, `staged` search params
+  - Navigation handlers for open/close/navigate-to-diff/back-from-diff
+  - `GitChangesButton` in header (before kebab menu, visible when workspace is running)
+  - Overlay rendering at bottom of JSX
+
+### Phase 4: Documentation
+
+- [ ] Update `CLAUDE.md` + `AGENTS.md`: new VM agent endpoints, new env vars (`GIT_EXEC_TIMEOUT`, `GIT_FILE_MAX_SIZE`)
+- [ ] Add to Recent Changes section
+
+### Phase 5: Verification
+
+- [ ] `go test ./internal/server/...` passes
+- [ ] `pnpm typecheck && pnpm lint` passes
+- [ ] Deploy and Playwright test against live app (file list, diff view, browser back/forward, mobile viewport)
+
+## Work in Progress
+
+Some implementation has already been completed:
+- **Done**: config.go additions, git.go (handlers + helpers), server.go route registration, git_test.go (32 tests passing), api.ts client functions, GitChangesButton.tsx, GitChangesPanel.tsx
+- **Remaining**: GitDiffView.tsx, Workspace.tsx integration, typecheck/lint, documentation updates

--- a/tasks/archive/2026-02-14-agent-slash-commands-positioning.md
+++ b/tasks/archive/2026-02-14-agent-slash-commands-positioning.md
@@ -1,0 +1,32 @@
+# Fix Agent Slash Command Positioning
+
+## Summary
+
+The agent slash command suggestions currently overlay and cover the text input, especially on mobile. They should be positioned above the text input instead, and long command text should wrap correctly rather than being clipped or overflowing.
+
+## Current Behavior
+
+- Slash command suggestions appear on top of the text input, blocking what the user is typing
+- On mobile (the primary use case), this makes the input unusable when suggestions are visible
+- Long command text may not wrap properly
+
+## Desired Behavior
+
+- Slash command suggestions appear **above** the text input, not overlapping it
+- The text input remains fully visible and usable while suggestions are shown
+- Long suggestion text wraps cleanly within the suggestion container
+- Works well on mobile viewports (320px+)
+
+## Implementation Notes
+
+### Key Files
+
+- Look in `apps/web/src/components/` or `packages/vm-agent/ui/` for the ACP chat input and slash command suggestion components
+
+### UI Requirements
+
+- Position suggestions above the input (e.g. `bottom: 100%` or flex column-reverse)
+- Ensure suggestions don't extend off-screen on small viewports
+- Text wrapping: `word-break: break-word` or similar to prevent horizontal overflow
+- Max height with scroll if there are many suggestions
+- Touch-friendly suggestion items (min 44px tap targets per mobile guidelines)

--- a/tasks/archive/2026-02-14-chat-session-numbered-tabs.md
+++ b/tasks/archive/2026-02-14-chat-session-numbered-tabs.md
@@ -1,0 +1,55 @@
+# Chat Session Tabs Should Have Unique Numbered Names
+
+## Summary
+
+When creating a new chat session, it gets the same label as the previous one (e.g. every Claude Code session is labeled "Claude Code Chat"). This makes it impossible to distinguish between tabs. New sessions also appear before older ones in the tab strip, which is confusing.
+
+Sessions should have incrementing numbered names (e.g. "Claude Code Chat 1", "Claude Code Chat 2") and new tabs should appear after existing ones. The tab ordering and naming need to be properly managed across both the web UI and VM agent.
+
+## Current Behavior
+
+- **Duplicate names**: `handleCreateSession()` in `Workspace.tsx:378-414` always passes `{ label: "{AgentName} Chat" }` — every session of the same agent type gets the identical label
+- **Wrong tab order**: New sessions are prepended via `[created, ...remaining]` (line 399), so the newest tab appears first
+- **Label fallback**: The display logic (lines 538-555) falls through: custom label → "{AgentName} Chat" → "Chat {sessionId suffix}" — but since label is always set to the same string, fallback never triggers
+- **API ordering**: `listAgentSessions()` returns `orderBy(desc(createdAt))` — newest first
+- **Two tab systems**: The web UI has its own session list (`agentSessions` state) AND the VM agent has a `tabs` table with `sort_order` — these aren't well synchronized
+
+## Desired Behavior
+
+- New chat sessions get incrementing labels: "Claude Code Chat 1", "Claude Code Chat 2", etc.
+- New tabs appear after existing tabs (append, not prepend)
+- Tab order is consistent between page loads (persisted sort order)
+- Labels are unique within a workspace
+
+## Root Cause Files
+
+| File | Lines | Issue |
+|------|-------|-------|
+| `apps/web/src/pages/Workspace.tsx` | 378-414 | `handleCreateSession()` always uses same label, prepends new session |
+| `apps/web/src/pages/Workspace.tsx` | 538-555 | Tab label display logic |
+| `apps/api/src/routes/workspaces.ts` | 673-684 | `listAgentSessions()` orders by `createdAt DESC` |
+| `apps/api/src/routes/workspaces.ts` | 687-761 | Create session endpoint, stores label |
+| `packages/vm-agent/internal/server/` | tabs persistence | VM agent `tabs` table has `sort_order` but web UI doesn't use it consistently |
+
+## Implementation Notes
+
+### Numbered Labels
+- When creating a session, count existing sessions with the same agent type
+- Generate label: `"{AgentName} Chat {N+1}"` where N is the count of existing sessions of that type
+- OR: query existing labels matching the pattern and find the next number
+
+### Tab Ordering
+- Append new sessions instead of prepending: `[...remaining, created]`
+- Use `orderBy(asc(createdAt))` in API (oldest first = stable tab order)
+- Alternatively, use the VM agent's `sort_order` as the source of truth for tab positioning
+
+### State Synchronization
+- The web UI and VM agent both track tabs independently — changes in one should reflect in the other
+- The VM agent `tabs` table has `sort_order` — consider making this the canonical ordering source
+- Web UI polls `listAgentSessions()` every 5s — this should include consistent ordering
+
+## Open Questions
+
+- Should users be able to rename chat session tabs?
+- Should the numbering restart when old sessions are stopped/closed, or always increment?
+- Should the VM agent `tabs` table be the single source of truth for tab state, replacing the D1 `agentSessions` ordering?

--- a/tasks/archive/2026-02-14-mobile-background-disconnect.md
+++ b/tasks/archive/2026-02-14-mobile-background-disconnect.md
@@ -1,0 +1,46 @@
+# Mobile Background Tab Should Not Disconnect Agent Session
+
+## Summary
+
+On mobile, briefly switching away from the browser (e.g. checking another app for 5 seconds) and returning causes the agent chat to show "waiting for agent" — the WebSocket connection has been dropped and the session appears lost. This is a broken experience. A brief tab/app switch should not disconnect the user from their active agent session.
+
+## Current Behavior
+
+- User is in an active agent chat session on mobile
+- User switches to another app for a few seconds
+- User returns to the browser — sees "waiting for agent" message
+- The WebSocket connection was torn down during the background period
+- User has to re-establish or wait, losing context of what was happening
+
+## Desired Behavior
+
+- Brief background periods (under ~30 seconds) should be invisible to the user — they return and see the current session state
+- The UI should automatically reconnect the WebSocket when the tab regains focus
+- On reconnect, the UI should fetch/replay any missed session updates so the conversation is up to date
+- No "waiting for agent" message unless the agent is genuinely not running
+
+## Root Cause (Likely)
+
+Mobile browsers aggressively suspend background tabs — WebSocket connections are killed almost immediately. The client-side code likely has no reconnection logic or missed-message recovery when the connection drops.
+
+## Implementation Notes
+
+### Reconnection Strategy
+
+- Listen for `visibilitychange` / `focus` events to detect tab becoming active again
+- On re-focus: attempt WebSocket reconnect with backoff
+- After reconnect: fetch current session state to catch up on missed `session/update` notifications
+- Only show "waiting for agent" if the agent process itself is not running (not just because the WS dropped)
+
+### Key Areas to Investigate
+
+- WebSocket client code in `apps/web/` — how connections are managed and what happens on close
+- ACP session update flow — whether missed updates can be replayed from the VM agent
+- VM agent WebSocket handler — whether it supports reconnection to an existing session
+
+### Considerations
+
+- Don't reconnect aggressively in a tight loop — use exponential backoff
+- Distinguish between "WS dropped because mobile background" vs "agent actually crashed"
+- The VM agent already has session persistence (spec 012) — leverage that for state recovery
+- Consider a lightweight HTTP poll fallback if WebSocket reconnect takes too long

--- a/tasks/archive/2026-02-14-voice-input-fix-and-feedback.md
+++ b/tasks/archive/2026-02-14-voice-input-fix-and-feedback.md
@@ -1,0 +1,42 @@
+# Fix Voice Input and Add Visual Audio Feedback
+
+## Summary
+
+Voice input (the microphone button in the agent chat) doesn't appear to be working. Additionally, there's no visual feedback while recording — the user can't tell if the mic is active or if their speech is being picked up. The button should have a dynamic glow effect that responds to the user's voice amplitude.
+
+## Current Behavior
+
+- Tapping the mic button does not produce a transcription (needs investigation — could be permissions, API endpoint, or audio capture issue)
+- While recording, there's no visual indication of audio input level
+- User has no confidence the mic is actually listening
+
+## Desired Behavior
+
+1. **Fix voice input** — Diagnose and fix why transcription isn't working (permissions, API, audio capture, or encoding issue)
+2. **Visual audio feedback** — While recording, the mic button should have a glow/pulse effect that responds to the user's speech:
+   - Idle/silence: subtle steady glow (indicates recording is active)
+   - Speaking: glow gets brighter and larger proportional to voice amplitude
+   - This gives immediate feedback that the mic is working and picking up speech
+
+## Implementation Notes
+
+### Debugging Voice Input
+
+Key files to investigate:
+- `packages/acp-client/src/components/VoiceButton.tsx` — the mic button component
+- `apps/api/src/routes/` — the `POST /api/transcribe` endpoint
+- Check: MediaRecorder permissions, audio format/encoding, API endpoint URL construction, error handling
+
+### Visual Feedback
+
+- Use the Web Audio API (`AudioContext` + `AnalyserNode`) to get real-time amplitude data from the microphone stream
+- Map amplitude to CSS properties on the button (e.g. `box-shadow` size/opacity, or a radial gradient)
+- Use `requestAnimationFrame` for smooth animation
+- The glow should be smooth (not jittery) — apply some smoothing/easing to the amplitude values
+- Color: blue or green glow to indicate active recording (avoid red, which implies error)
+- Must work on mobile (primary platform) — test touch interactions and performance
+
+### Accessibility
+
+- The visual glow is supplementary — the button should still have clear text/icon state changes for recording vs idle
+- Screen readers should announce recording state changes

--- a/tasks/archive/2026-02-14-workspace-branch-selection.md
+++ b/tasks/archive/2026-02-14-workspace-branch-selection.md
@@ -1,0 +1,47 @@
+# Workspace Branch Selection
+
+## Summary
+
+When creating a workspace, users should be able to select which branch to clone from the chosen repository. Currently, workspace creation defaults to the repository's default branch with no option to change it.
+
+The UI should offer a dropdown populated with the repository's branches (fetched via the GitHub API), along with free-text input for typing a branch name directly (useful for repos with many branches or for entering a branch that hasn't been pushed yet).
+
+## User Story
+
+As a user creating a workspace, I want to pick a specific branch from my repository so that I can start working on feature branches, bugfix branches, or any non-default branch without having to manually switch after the workspace is created.
+
+## Requirements
+
+- [ ] Add a branch selector to the workspace creation form (dropdown + free-text combo)
+- [ ] Fetch branches from the GitHub API when a repository is selected
+- [ ] Default to the repository's default branch (pre-selected)
+- [ ] Allow free-text entry for arbitrary branch/ref names
+- [ ] Pass the selected branch to the workspace provisioning flow
+- [ ] Cloud-init / devcontainer setup clones the specified branch instead of default
+
+## Implementation Notes
+
+### API
+
+- Need a new endpoint or extend `GET /api/github/repositories` to return branches for a given repo (or a dedicated `GET /api/github/repositories/:owner/:repo/branches`)
+- GitHub App needs "Contents: Read" permission (likely already granted) to list branches
+- Consider pagination — repos can have hundreds of branches
+
+### UI
+
+- Combobox pattern: dropdown list of branches with type-ahead filtering
+- Only fetch branches after a repository is selected
+- Show loading state while branches are being fetched
+- Graceful fallback if branch listing fails (allow free-text entry)
+
+### Provisioning
+
+- `git clone --branch <branch>` in cloud-init template
+- Verify the branch parameter is passed through: API → cloud-init generator → VM setup
+- Handle edge case: branch doesn't exist (fail fast with clear error)
+
+## Open Questions
+
+- Should we support tags and commit SHAs in addition to branches?
+- Should we cache branch lists (they can change frequently)?
+- Rate limiting considerations for GitHub API branch listing calls?

--- a/tasks/archive/2026-02-14-workspace-repo-name-directory.md
+++ b/tasks/archive/2026-02-14-workspace-repo-name-directory.md
@@ -1,0 +1,40 @@
+# Workspace Clone Directory Should Use Repository Name
+
+## Summary
+
+When a workspace is provisioned, the repository is cloned into a directory named after the workspace ID (a ULID), e.g. `/workspace/01ARZ3NDEKTSV4RRFFQ69G5FAV`. This is confusing — the directory should be named after the repository instead, e.g. `/workspace/my-cool-project`.
+
+## Current Behavior
+
+- `workspaceDirForRuntime()` in `workspace_routing.go:252-269` builds the path as `{baseDir}/{workspaceID}`
+- `git clone` in `bootstrap.go:454` clones directly into that workspace-ID-named directory
+- A `repositoryDirName()` helper already exists in `workspace_provisioning.go:257-312` that extracts the repo name from a URL (strips `.git`, takes last path segment, sanitizes) — but it's only used for legacy directory recovery, not new workspaces
+
+## Desired Behavior
+
+- Clone directory should be named after the repository: `/workspace/my-cool-project`
+- The workspace ID should NOT appear in the directory path visible to the user
+- If two workspaces on the same node use the same repo name, disambiguate (e.g. append a short suffix)
+
+## Implementation Notes
+
+### Key Files
+
+| File | What to Change |
+|------|---------------|
+| `packages/vm-agent/internal/server/workspace_routing.go` | `workspaceDirForRuntime()` — use repo name instead of workspace ID |
+| `packages/vm-agent/internal/bootstrap/bootstrap.go` | Clone target path uses the workspace dir |
+| `packages/vm-agent/internal/server/workspace_provisioning.go` | `repositoryDirName()` already exists — promote from legacy to primary |
+
+### Considerations
+
+- The `repositoryDirName()` function already does URL parsing, `.git` stripping, and sanitization — reuse it
+- Need to handle name collisions when multiple workspaces clone the same repo on one node
+- Devcontainer working directory (`Cwd` in ACP sessions) derives from this path — verify it still works
+- Terminal sessions and file explorer paths will reflect the new directory name
+- Existing running workspaces should not be disrupted (backward compat via `legacyWorkspaceDir()`)
+
+## Open Questions
+
+- Should the directory be `{baseDir}/{repoName}` or `{baseDir}/{workspaceID}/{repoName}`? The former is cleaner but the latter avoids collision issues.
+- What happens if the repository field is empty or malformed?

--- a/tasks/backlog/2026-02-14-file-browser.md
+++ b/tasks/backlog/2026-02-14-file-browser.md
@@ -1,0 +1,208 @@
+# File Browser
+
+**Created**: 2026-02-14
+**Priority**: High
+**Relates to**: FR-008 (file browsing requirement), `2026-02-14-git-changes-viewer.md`
+
+## Summary
+
+A mobile-first file browser for exploring workspace filesystems. Breadcrumb + flat list pattern (not a tree — trees are painful on mobile). Read-only file viewer with syntax highlighting via `prism-react-renderer`. Links to the git changes viewer for files with uncommitted changes.
+
+## Context
+
+FR-008 requires file browsing and editing in workspaces. The git changes viewer (separate task) handles "what changed?". This tool handles "what's here?" — full directory exploration with syntax-highlighted file viewing. The two tools are separate overlays that cross-link to each other via URL routing.
+
+## Design Decisions
+
+- **Separate from git viewer**: Two independent icons in the nav bar, two independent overlays. They link to each other but don't share UI state.
+- **Breadcrumb + flat list**: Not a tree. On mobile, show tappable breadcrumb segments at the top, flat directory listing below. Folders first, then files sorted alphabetically.
+- **Read-only v1**: No file editing. "Edit in terminal" could be a future action menu item.
+- **Syntax highlighting**: `prism-react-renderer` (~5-15KB gzipped). Dark theme matching SAM palette. Languages: TypeScript, JavaScript, Go, Python, CSS, HTML, JSON, YAML, Markdown, Bash, Dockerfile, TOML.
+- **Cross-linking**: File viewer shows "View Diff" button when the file has git changes. Git diff view can link back to "Open File" in the browser.
+- **Mutually exclusive overlays**: Opening the file browser clears `?git=*` params and vice versa.
+
+## Routing
+
+```
+/workspaces/:id?files=browse                       → file browser at repo root
+/workspaces/:id?files=browse&path=src/components    → file browser at specific path
+/workspaces/:id?files=view&path=src/App.tsx         → file viewer for specific file
+```
+
+Cross-links to git viewer:
+```
+/workspaces/:id?git=diff&file=src/App.tsx&staged=false  → git diff (from file viewer "View Diff")
+```
+
+Browser back/forward works naturally — each navigation pushes to history. Workspace stays mounted underneath.
+
+## UI Mockups
+
+### File Browser (breadcrumb + flat list)
+
+```
+┌───────────────────────────────┐
+│ ← Files               ↻    ✕ │  Header
+│ / > src > components >        │  Breadcrumb (tappable segments)
+├───────────────────────────────┤
+│ 📁 hooks/                     │  Folders first (44px touch target)
+│ 📁 utils/                     │
+│ 📄 App.tsx              4.2KB │  Files with size
+│ 📄 index.ts             0.3KB │
+│ 📄 styles.css           1.1KB │
+└───────────────────────────────┘
+```
+
+### File Viewer (syntax highlighted)
+
+```
+┌───────────────────────────────┐
+│ ← App.tsx         [Diff] [✕] │  Header (Diff button if file has changes)
+├───────────────────────────────┤
+│  1  import React from 'react' │  Line numbers + syntax highlighting
+│  2  import { useState } from  │  Monospace, horizontal scroll
+│  3    'react';                 │  Dark theme colors
+│  4                             │
+│  5  export function App() {    │
+│  ...                           │
+└───────────────────────────────┘
+```
+
+## Implementation Plan
+
+### Phase 1: Backend — VM Agent (Go)
+
+- [ ] Add config values to `config.go`:
+  - `FILE_LIST_TIMEOUT` (default: 10s) — timeout for `ls`/`find` commands
+  - `FILE_LIST_MAX_ENTRIES` (default: 1000) — max entries returned per directory listing
+  - `FILE_READ_MAX_SIZE` (default: 1MB) — reuses existing `GIT_FILE_MAX_SIZE` or separate
+- [ ] Create `files.go` with one new handler:
+  - `GET /workspaces/{workspaceId}/files/list?path=...` — directory listing
+  - Runs `ls -la --time-style=long-iso` or custom JSON-producing script in container
+  - Parses output into structured entries: `{ name, type (file|dir|symlink), size, modifiedAt }`
+  - Auth: `requireWorkspaceRequestAuth()` (same as git endpoints)
+  - Path sanitization: reuses `sanitizeFilePath()` from git.go
+  - Container exec: reuses `execInContainer()` from git.go
+- [ ] Reuse existing `GET /workspaces/{workspaceId}/git/file?path=...` for file content reading (no `ref` param = working tree)
+- [ ] Register route in `server.go` `setupRoutes()`
+- [ ] Create `files_test.go` with `ls` output parser tests
+
+**Response type:**
+```go
+type FileEntry struct {
+    Name       string `json:"name"`
+    Type       string `json:"type"`       // "file", "dir", "symlink"
+    Size       int64  `json:"size"`       // bytes, 0 for dirs
+    ModifiedAt string `json:"modifiedAt"` // ISO 8601
+}
+
+type FileListResponse struct {
+    Path    string      `json:"path"`
+    Entries []FileEntry `json:"entries"`
+}
+```
+
+**Implementation approach for directory listing:**
+Rather than parsing `ls -la` output (fragile, locale-dependent), use a small inline script:
+```bash
+find <path> -maxdepth 1 -not -name '.' -printf '%y\t%s\t%T@\t%f\n' | sort -t$'\t' -k1,1 -k4,4
+```
+This produces tab-separated output: type (d/f/l), size, mtime epoch, name. Easy to parse, no locale issues.
+
+### Phase 2: API Client (TypeScript)
+
+- [ ] Add to `apps/web/src/lib/api.ts`:
+  - Types: `FileEntry`, `FileListData`
+  - Function: `getFileList(workspaceUrl, workspaceId, token, path)` → `FileListData`
+  - Reuses existing `getGitFile()` for file content (already reads working tree files)
+
+### Phase 3: Syntax Highlighting Setup
+
+- [ ] Install `prism-react-renderer` in `apps/web`
+- [ ] Create `apps/web/src/components/SyntaxHighlighter.tsx`:
+  - Wraps `prism-react-renderer` `Highlight` component
+  - Dark theme matching SAM palette (`--sam-color-bg-canvas: #0b1110`)
+  - Language detection from file extension
+  - Line numbers column
+  - Horizontal scroll for long lines
+  - Configurable max lines (with "Show more" button for very large files)
+
+### Phase 4: Frontend Components (React)
+
+- [ ] `FileBrowserButton.tsx` — nav bar icon (`Folder` from lucide-react)
+  - Same pattern as `GitChangesButton.tsx`
+  - Only visible when workspace is running
+  - Touch target: 44x44px mobile, 32x32px desktop
+
+- [ ] `FileBrowserPanel.tsx` — full-screen overlay with breadcrumb + file list
+  - **Breadcrumb bar**: Tappable path segments (e.g., `/ > src > components >`)
+    - Each segment navigates to that directory via `?files=browse&path=...`
+    - Horizontal scroll on mobile for deep paths
+  - **Directory listing**: Folders first (📁 icon), then files (📄 icon)
+    - Each row: icon, name, size (files only), modified time (optional, desktop only)
+    - Tapping a folder updates `path` param (drills in)
+    - Tapping a file navigates to `?files=view&path=...`
+    - 44px min-height touch targets on mobile
+  - **Loading state**: Spinner
+  - **Error state**: "Failed to list directory" with retry
+  - **Empty state**: "This directory is empty"
+  - Refresh button, close button, Escape key handler
+  - Styling: inline styles with `var(--sam-color-*)` tokens (matches workspace page)
+
+- [ ] `FileViewerPanel.tsx` — full-screen overlay with syntax-highlighted file content
+  - **Header**: Back arrow, file name, optional "View Diff" button (if file has git changes)
+  - **Content**: `SyntaxHighlighter` component with line numbers
+  - **Language detection**: Map file extensions to Prism language keys
+  - **Large file handling**: If > configurable line count, show first N lines + "Show all" button
+  - **Binary file detection**: If content contains null bytes or isn't valid UTF-8, show "Binary file" placeholder
+  - Back navigates to `?files=browse&path=<parent directory>`
+  - Close removes all `files` params
+
+- [ ] Integrate into `Workspace.tsx`:
+  - Read `files`, `path` search params (alongside existing `git`, `view`, `sessionId`)
+  - Navigation handlers for open/close/drill-in/view-file/back
+  - `FileBrowserButton` in header (next to `GitChangesButton`, before kebab menu)
+  - Overlay rendering: `FileBrowserPanel` when `files=browse`, `FileViewerPanel` when `files=view`
+  - When opening file browser, clear `git` params; when opening git viewer, clear `files` params
+
+### Phase 5: Cross-Linking
+
+- [ ] In `FileViewerPanel`: detect if current file has git changes
+  - On mount, call `getGitStatus()` and check if file path appears in staged/unstaged/untracked
+  - If yes, show "View Diff" button in header → navigates to `?git=diff&file=...&staged=...`
+- [ ] In `GitDiffView` (from git changes viewer): add "Open File" link
+  - Navigates to `?files=view&path=...`
+
+### Phase 6: Documentation
+
+- [ ] Update `CLAUDE.md` + `AGENTS.md`:
+  - New VM agent endpoint: `GET /workspaces/{id}/files/list`
+  - New env vars: `FILE_LIST_TIMEOUT`, `FILE_LIST_MAX_ENTRIES`
+  - Recent Changes entry
+- [ ] Update git changes viewer task to note cross-linking integration
+
+### Phase 7: Verification
+
+- [ ] `go test ./internal/server/...` passes (new + existing tests)
+- [ ] `pnpm typecheck && pnpm lint` passes
+- [ ] Deploy and Playwright test:
+  - Open file browser, navigate directories via breadcrumbs
+  - View a file with syntax highlighting
+  - Cross-link to git diff and back
+  - Browser back/forward through all states
+  - Mobile viewport (375px) — breadcrumbs scroll, touch targets work
+
+## Dependencies
+
+- **Git changes viewer** (`2026-02-14-git-changes-viewer.md`): Must be completed first (or at least the backend + `GitDiffView`), since the file viewer cross-links to it.
+- **`prism-react-renderer`**: New npm dependency in `apps/web`.
+
+## Future Enhancements (Not v1)
+
+- File editing (write-back to container)
+- File search (find in files)
+- File upload/download
+- Image preview for image files
+- Markdown preview for .md files
+- "Open in terminal" action (opens `vim`/`nano` in a terminal tab)
+- Tree view toggle for desktop (alongside breadcrumb + list)


### PR DESCRIPTION
## Summary
- **Git Changes Viewer**: PR-style git changes panel accessible via nav bar icon in workspace view
- **VM Agent Backend**: 3 new Go endpoints (`git/status`, `git/diff`, `git/file`) that run git commands inside devcontainers via `docker exec`, with input sanitization and configurable timeouts/limits
- **Frontend Components**: `GitChangesButton` (badge icon), `GitChangesPanel` (staged/unstaged/untracked file list), `GitDiffView` (unified diff with Diff/Full toggle)
- **Integration**: URL search params for browser back/forward navigation, direct VM Agent API calls via `ws-{id}` subdomain

## Test plan
- [x] Go unit tests for sanitizers, parsers, formatters (14 + 16 + 12 + 1 = 43 test cases)
- [x] Frontend unit tests: `git-changes-button.test.tsx` (9 tests), `git-changes-panel.test.tsx` (12 tests), `git-diff-view.test.tsx` (12 tests)
- [x] Updated `workspace.test.tsx` to mock new `getGitStatus` export (14 tests passing)
- [x] Typecheck passes (16 tasks)
- [x] Lint passes (0 errors)
- [ ] Playwright verification after deployment

## Agent Preflight Evidence

### Change Classification
- `ui-change`: New React components (GitChangesButton, GitChangesPanel, GitDiffView)
- `cross-component-change`: VM Agent Go backend + Web frontend + API client
- `public-surface-change`: 3 new VM Agent API endpoints

### Context Gathered
- Reviewed existing workspace overlay patterns (mobile sidebar menu, agent panel)
- Followed VM Agent HTTP handler patterns (auth middleware, workspace JWT validation)
- Followed existing `api.ts` patterns for direct VM Agent calls via `ws-{id}` subdomain
- Validated against Constitution Principle XI: all limits/timeouts configurable via env vars

### Impact Analysis
- No changes to existing API endpoints or database schema
- Workspace.tsx additions are additive (new overlays, no changes to existing behavior)
- VM Agent routes are new additions to server.go (no modifications to existing handlers)
- CLAUDE.md/AGENTS.md updated with new endpoints and feature description

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)