### PR TITLE
fix: add Workers AI binding to production/staging

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -54,6 +54,9 @@ id = "your-staging-kv-id"
 binding = "R2"
 bucket_name = "workspaces-staging-assets"
 
+[env.staging.ai]
+binding = "AI"
+
 [env.production]
 name = "sam-api-prod"
 vars = { BASE_DOMAIN = "workspaces.example.com", VERSION = "0.1.0", MAX_NODES_PER_USER = "10", MAX_WORKSPACES_PER_USER = "10", MAX_WORKSPACES_PER_NODE = "10", MAX_AGENT_SESSIONS_PER_WORKSPACE = "10", NODE_HEARTBEAT_STALE_SECONDS = "180" }
@@ -78,6 +81,9 @@ id = "your-production-kv-id"
 [[env.production.r2_buckets]]
 binding = "R2"
 bucket_name = "workspaces-assets"
+
+[env.production.ai]
+binding = "AI"
 
 # Cron trigger for provisioning timeout checks (every 5 minutes)
 [triggers]


### PR DESCRIPTION
## Summary
- The `[ai]` binding was only at the top level of `wrangler.toml` — Wrangler env-specific configs don't inherit top-level bindings
- `c.env.AI` was `undefined` in production, causing `POST /api/transcribe` to return 500
- Error: `TypeError: Cannot read properties of undefined (reading 'run')`
- Fix: Add `[env.production.ai]` and `[env.staging.ai]` sections

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [x] infra-change

### External References

Cloudflare Wrangler docs confirm env-specific sections don't inherit top-level bindings. Diagnosed via CF Workers observability logs showing `c.env.AI` undefined at runtime.

### Codebase Impact Analysis

- `apps/api/wrangler.toml` — Added `[env.staging.ai]` and `[env.production.ai]` binding sections (2 lines each)
- No code changes needed — the transcription route already references `c.env.AI` correctly

### Documentation & Specs

N/A: Configuration-only fix, no interface or behavior change — the feature was already documented when voice-to-text was added.

### Constitution & Risk Check

- [x] No hardcoded values — binding name matches existing top-level `[ai]` section
- [x] No security implications — Workers AI is a Cloudflare-managed service binding

<!-- AGENT_PREFLIGHT_END -->

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)