### PR TITLE
fix: render user_message_chunk from LoadSession replay

### DIFF
--- a/packages/acp-client/src/hooks/useAcpMessages.ts
+++ b/packages/acp-client/src/hooks/useAcpMessages.ts
@@ -154,6 +154,19 @@ export function useAcpMessages(): AcpMessagesHandle {
           break;
         }
 
+        case 'user_message_chunk': {
+          // Replayed user messages from LoadSession — render as regular user bubbles
+          const content = update as { content?: { type: string; text?: string } };
+          const text = content.content?.type === 'text' ? (content.content.text ?? '') : '';
+          if (text) {
+            setItems((prev) => [
+              ...prev,
+              { kind: 'user_message', id: nextId(), text, timestamp: now },
+            ]);
+          }
+          break;
+        }
+
         case 'tool_call': {
           const tc = update as {
             toolCallId?: string;


### PR DESCRIPTION
## Summary

- Handle `user_message_chunk` notifications from ACP LoadSession replay
- Previously fell through to `raw_fallback`, showing raw JSON with "Rich rendering unavailable"
- Now renders replayed user messages as proper green chat bubbles matching live-typed messages

## Validation

- [x] `pnpm test` (87 tests pass in acp-client, 15 in useAcpMessages)
- [x] Playwright verified: LoadSession replays conversation after page reload (PR #78)

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [ ] cross-component-change
- [x] business-logic-change
- [ ] public-surface-change
- [ ] docs-sync-change
- [ ] security-sensitive-change
- [x] ui-change
- [ ] infra-change

### External References

N/A: Internal message rendering fix for an already-implemented ACP protocol feature (LoadSession replay).

### Codebase Impact Analysis

- `packages/acp-client/src/hooks/useAcpMessages.ts`: Added `user_message_chunk` case in the `processMessage` switch statement, creating `UserMessage` items from replayed user text content
- `packages/acp-client/src/hooks/useAcpMessages.test.ts`: Added 3 tests for user_message_chunk handling (render, empty content, full replay)

### Documentation & Specs

N/A: No new APIs or user-facing config. Internal message rendering improvement.

### Constitution & Risk Check

- Principle XI: No hardcoded values introduced. Message rendering uses existing `UserMessage` type and `nextId()` generator.
- Risk: Very low. Additive handler for a previously unhandled notification type.

<!-- AGENT_PREFLIGHT_END -->

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)