### PR TITLE
fix: devcontainer fallback resilience

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,6 +1,24 @@
 #!/bin/bash
 # Post-create setup script for Simple Agent Manager devcontainer
-set -e
+#
+# IMPORTANT: Do NOT use "set -e" here. A single tool installation failure
+# (network timeout, rate limit, transient error) would abort the entire script,
+# causing the devcontainer CLI to report an error and triggering the VM agent's
+# fallback to the default base image — losing all devcontainer features (Go,
+# Docker-in-Docker, etc.). Each step must be individually fault-tolerant.
+
+FAILURES=0
+
+# Helper: run a command, log failure but continue.
+try_run() {
+	local label="$1"
+	shift
+	echo "--- $label ---"
+	if ! "$@"; then
+		echo "WARNING: $label failed (exit $?), continuing..."
+		FAILURES=$((FAILURES + 1))
+	fi
+}
 
 # Defaults are overridable to avoid hardcoding config.
 : "${CLOUDFLARE_OBSERVABILITY_MCP_URL:=https://observability.mcp.cloudflare.com/mcp}"
@@ -9,37 +27,38 @@ echo "=== Ensuring agent config dirs exist ==="
 mkdir -p "${CODEX_HOME:-$HOME/.codex}"
 
 echo "=== Installing Claude Code (native) ==="
-curl -fsSL https://claude.ai/install.sh | bash
+try_run "Install Claude Code" bash -c 'curl -fsSL https://claude.ai/install.sh | bash'
 
 echo "=== Installing OpenAI Codex ==="
-npm i -g @openai/codex
+try_run "Install OpenAI Codex" npm i -g @openai/codex
 
 echo "=== Installing other global tools ==="
-npm install -g happy-coder
+try_run "Install happy-coder" npm install -g happy-coder
 
 echo "=== Configuring MCP servers ==="
 if ! claude mcp get playwright >/dev/null 2>&1; then
-	claude mcp add playwright npx -- @playwright/mcp@latest --browser chromium
+	try_run "Add Playwright MCP" claude mcp add playwright npx -- @playwright/mcp@latest --browser chromium
 fi
 
 # Install Playwright Chromium for ARM64 compatibility (Chrome not supported on ARM64 Linux)
-npx playwright install chromium
+try_run "Install Playwright Chromium" npx playwright install chromium
+
 if ! claude mcp get sequential-thinking >/dev/null 2>&1; then
-	claude mcp add sequential-thinking npx -- -y @modelcontextprotocol/server-sequential-thinking
+	try_run "Add sequential-thinking MCP" claude mcp add sequential-thinking npx -- -y @modelcontextprotocol/server-sequential-thinking
 fi
 if ! claude mcp get context7 >/dev/null 2>&1; then
-	claude mcp add context7 npx -- -y @upstash/context7-mcp
+	try_run "Add context7 MCP" claude mcp add context7 npx -- -y @upstash/context7-mcp
 fi
 
 echo "=== Adding Cloudflare Observability MCP (Workers logs) ==="
 # Claude Code
 if ! claude mcp get cloudflare-observability >/dev/null 2>&1; then
-	claude mcp add --transport http cloudflare-observability "$CLOUDFLARE_OBSERVABILITY_MCP_URL"
+	try_run "Add CF Observability MCP (Claude)" claude mcp add --transport http cloudflare-observability "$CLOUDFLARE_OBSERVABILITY_MCP_URL"
 fi
 
 # Codex
 if ! codex mcp get cloudflare-observability >/dev/null 2>&1; then
-	codex mcp add cloudflare-observability --url "$CLOUDFLARE_OBSERVABILITY_MCP_URL"
+	try_run "Add CF Observability MCP (Codex)" codex mcp add cloudflare-observability --url "$CLOUDFLARE_OBSERVABILITY_MCP_URL"
 fi
 
 echo "Cloudflare Observability MCP configured (OAuth required per-user)."
@@ -48,16 +67,22 @@ echo "  codex mcp login cloudflare-observability"
 
 echo "=== Setting up Simple Agent Manager development environment ==="
 
-# Install project dependencies
+# Install project dependencies — this is critical for the workspace to function.
 echo "Installing project dependencies..."
-pnpm install
+try_run "pnpm install" pnpm install
 
 # Build packages (needed for workspace imports to work)
 echo "Building packages..."
-pnpm build
+try_run "pnpm build" pnpm build
 
 echo ""
-echo "=== Setup complete! ==="
+if [ "$FAILURES" -gt 0 ]; then
+	echo "=== Setup completed with $FAILURES warning(s) ==="
+	echo "Some optional tools failed to install. The workspace is functional."
+	echo "Re-run this script to retry: bash .devcontainer/post-create.sh"
+else
+	echo "=== Setup complete! ==="
+fi
 echo ""
 echo "To start development:"
 echo "  pnpm run dev:mock    # Start API + Web in mock mode"


### PR DESCRIPTION
## Summary
- **post-create.sh**: Remove `set -e` and wrap each step in a `try_run` helper that logs failures but continues. Previously, any single tool install failure (network timeout, rate limit, transient error) would abort the script, causing the devcontainer CLI to report failure, triggering the VM agent's fallback to the default base image — losing all configured features (Go, Docker-in-Docker, GitHub CLI).
- **bootstrap.go**: Write devcontainer build error log into the Docker volume (`writeBuildErrorToVolume()`) so it's visible from inside the fallback container. Previously only written to the host workspace directory, which is unmounted.

### Root cause
Observed in a live SAM workspace: container was running `base:ubuntu` (fallback) instead of `typescript-node:24-bookworm` (repo config). `DEFINITION_ID='base-ubuntu'` in meta.env confirmed the fallback. Go, Docker, and GitHub CLI features were all missing. Most likely trigger: `post-create.sh` uses `set -e` and runs multiple network-dependent installs (`curl claude.ai`, `npm i -g @openai/codex`, `npx playwright install`, etc.) — any transient failure cascades to full script abort.

## Test plan
- [ ] Create a fresh workspace from `simple-agent-manager` repo and verify devcontainer features install (Go, Docker, GitHub CLI)
- [ ] Simulate a tool install failure in post-create.sh and verify the script completes with warnings instead of aborting
- [ ] Verify `.devcontainer-build-error.log` appears at `/workspaces/.devcontainer-build-error.log` inside the container when fallback occurs
- [ ] CI passes (lint, typecheck, build, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [x] cross-component-change
- [ ] business-logic-change
- [ ] public-surface-change
- [ ] docs-sync-change
- [ ] security-sensitive-change
- [ ] ui-change
- [x] infra-change

### External References

N/A: Changes are internal to the VM agent bootstrap and devcontainer post-create script. No external APIs or third-party documentation consulted.

### Codebase Impact Analysis

Modified `packages/vm-agent/internal/bootstrap/bootstrap.go` — added `writeBuildErrorToVolume()` function that writes devcontainer build error output to the Docker volume via a throwaway alpine container, making it visible from inside the fallback container. Modified `.devcontainer/post-create.sh` — removed `set -e`, added `try_run` helper function that wraps each install step, logs failures with exit codes, and continues execution. Both files affect workspace provisioning reliability but have no impact on API routes, UI components, or shared types.

### Documentation & Specs

N/A: No public-facing behavior or API contracts changed. The fixes are internal reliability improvements to the bootstrap process and devcontainer setup script.

### Constitution & Risk Check

Verified Principle XI (No Hardcoded Values): volume name is derived from workspace ID via existing `deriveVolumeName()` function, not hardcoded. The alpine image tag (`alpine:latest`) used for the throwaway volume-write container is consistent with existing usage in `populateVolumeFromHost()`. No new timeouts, limits, or magic strings introduced.

<!-- AGENT_PREFLIGHT_END -->