### PR TITLE
feat: implement worktree context switching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ However, this does NOT excuse stale documentation. The following rule exists to 
 **After writing or modifying ANY code, you MUST update ALL documentation that references the changed behavior IN THE SAME COMMIT.** There are NO exceptions and NO deferrals.
 
 This includes but is not limited to:
+
 - `docs/guides/self-hosting.md` — setup instructions, permissions, configuration
 - `docs/architecture/` — architecture decisions, credential models
 - `specs/` — feature specifications, data models
@@ -70,6 +71,7 @@ This prevents scope drift and ensures the user gets exactly what they asked for.
 ### Quick Testing Gate
 
 Before marking feature work complete:
+
 - [ ] Unit tests added/updated for all changed behavior
 - [ ] Integration tests added where cross-layer behavior exists
 - [ ] E2E coverage added or explicitly justified as not applicable
@@ -94,6 +96,7 @@ Before marking feature work complete:
 ### Quick Compliance Check
 
 Before committing any business logic changes, verify:
+
 - [ ] All URLs derived from `BASE_DOMAIN` or similar env vars
 - [ ] All timeouts have `DEFAULT_*` constants and env var overrides
 - [ ] All limits are configurable via environment
@@ -127,6 +130,7 @@ This workflow avoids deploy-fix-deploy cycles and catches mobile layout bugs tha
 ### Quick Mobile Check
 
 Before deploying any UI changes:
+
 - [ ] Login button visible and large (min 56px height)
 - [ ] Text readable without zooming (responsive sizing)
 - [ ] Grid layouts collapse to single column on mobile
@@ -141,10 +145,10 @@ Before deploying any UI changes:
 
 ### The Two Naming Conventions
 
-| Context | Prefix | Example | Where Used |
-|---------|--------|---------|------------|
-| **GitHub Environment** | `GH_` | `GH_CLIENT_ID` | GitHub Settings -> Environments -> production |
-| **Cloudflare Worker** | `GITHUB_` | `GITHUB_CLIENT_ID` | Worker runtime, local `.env` files |
+| Context                | Prefix    | Example            | Where Used                                    |
+| ---------------------- | --------- | ------------------ | --------------------------------------------- |
+| **GitHub Environment** | `GH_`     | `GH_CLIENT_ID`     | GitHub Settings -> Environments -> production |
+| **Cloudflare Worker**  | `GITHUB_` | `GITHUB_CLIENT_ID` | Worker runtime, local `.env` files            |
 
 ### Why Different Names?
 
@@ -164,6 +168,7 @@ GH_APP_SLUG            ->  GITHUB_APP_SLUG
 ### Documentation Rules
 
 When documenting environment variables:
+
 1. **GitHub Environment config** -> Use `GH_*` prefix
 2. **Cloudflare Worker secrets** -> Use `GITHUB_*` prefix
 3. **Local `.env` files** -> Use `GITHUB_*` prefix (same as Worker)
@@ -182,11 +187,11 @@ When documenting environment variables:
 
 **When constructing URLs using `BASE_DOMAIN`, you MUST use the correct subdomain prefix.** The root domain does NOT serve any application.
 
-| Destination | URL Pattern | Example |
-|-------------|-------------|---------|
-| **Web UI** | `https://app.${BASE_DOMAIN}/...` | `https://app.simple-agent-manager.org/settings` |
-| **API** | `https://api.${BASE_DOMAIN}/...` | `https://api.simple-agent-manager.org/health` |
-| **Workspace** | `https://ws-${id}.${BASE_DOMAIN}` | `https://ws-abc123.simple-agent-manager.org` |
+| Destination   | URL Pattern                       | Example                                         |
+| ------------- | --------------------------------- | ----------------------------------------------- |
+| **Web UI**    | `https://app.${BASE_DOMAIN}/...`  | `https://app.simple-agent-manager.org/settings` |
+| **API**       | `https://api.${BASE_DOMAIN}/...`  | `https://api.simple-agent-manager.org/health`   |
+| **Workspace** | `https://ws-${id}.${BASE_DOMAIN}` | `https://ws-abc123.simple-agent-manager.org`    |
 
 **NEVER** use `https://${BASE_DOMAIN}/...` (bare root domain) for redirects or links. This is always a bug.
 
@@ -219,12 +224,12 @@ When documenting environment variables:
 
 ### Key Architecture Documents
 
-| Document | Contents |
-|----------|----------|
+| Document                                   | Contents                                 |
+| ------------------------------------------ | ---------------------------------------- |
 | `docs/architecture/credential-security.md` | BYOC model, encryption, user credentials |
-| `docs/architecture/secrets-taxonomy.md` | Platform secrets vs user credentials |
-| `docs/adr/002-stateless-architecture.md` | Stateless design principles |
-| `.specify/memory/constitution.md` | Core principles and rules |
+| `docs/architecture/secrets-taxonomy.md`    | Platform secrets vs user credentials     |
+| `docs/adr/002-stateless-architecture.md`   | Stateless design principles              |
+| `.specify/memory/constitution.md`          | Core principles and rules                |
 
 ### Architecture Principles (Quick Reference)
 
@@ -254,12 +259,12 @@ When documenting environment variables:
 
 ### Key Business Logic Documents
 
-| Document | Contents |
-|----------|----------|
-| `specs/003-browser-terminal-saas/spec.md` | Core SaaS features, user stories |
-| `specs/003-browser-terminal-saas/data-model.md` | Entity relationships, state machines |
-| `specs/004-mvp-hardening/spec.md` | Security hardening, access control |
-| `specs/004-mvp-hardening/data-model.md` | Bootstrap tokens, ownership validation |
+| Document                                        | Contents                               |
+| ----------------------------------------------- | -------------------------------------- |
+| `specs/003-browser-terminal-saas/spec.md`       | Core SaaS features, user stories       |
+| `specs/003-browser-terminal-saas/data-model.md` | Entity relationships, state machines   |
+| `specs/004-mvp-hardening/spec.md`               | Security hardening, access control     |
+| `specs/004-mvp-hardening/data-model.md`         | Bootstrap tokens, ownership validation |
 
 ### Business Logic Principles (Quick Reference)
 
@@ -373,6 +378,7 @@ Task file template and conventions are defined in `tasks/README.md`.
 ### Local Dev Limitations (NOT Recommended for Testing)
 
 Running `pnpm dev` starts local emulators but has significant limitations:
+
 - No real GitHub OAuth (callbacks won't work)
 - No real DNS (workspace URLs won't resolve)
 - No real VMs (workspaces can't be created)
@@ -387,6 +393,7 @@ Store all Playwright screenshots from development and verification runs in `.cod
 ### Live Test Resource Cleanup (Required)
 
 When Playwright or manual live-app verification creates test workspaces or nodes:
+
 - Use only newly created test resources for that verification run
 - Do not mutate long-lived/legacy resources
 - Delete test workspaces and test nodes after verification is complete
@@ -411,25 +418,25 @@ pnpm format           # Format
 
 All configuration lives in **GitHub Settings -> Environments -> production**:
 
-| Type | Name | Required |
-|------|------|----------|
-| Variable | `BASE_DOMAIN` | Yes |
-| Variable | `RESOURCE_PREFIX` | No (default: `sam`) |
-| Variable | `PULUMI_STATE_BUCKET` | No (default: `sam-pulumi-state`) |
-| Secret | `CF_API_TOKEN` | Yes |
-| Secret | `CF_ACCOUNT_ID` | Yes |
-| Secret | `CF_ZONE_ID` | Yes |
-| Secret | `R2_ACCESS_KEY_ID` | Yes |
-| Secret | `R2_SECRET_ACCESS_KEY` | Yes |
-| Secret | `PULUMI_CONFIG_PASSPHRASE` | Yes |
-| Secret | `GH_CLIENT_ID` | Yes |
-| Secret | `GH_CLIENT_SECRET` | Yes |
-| Secret | `GH_APP_ID` | Yes |
-| Secret | `GH_APP_PRIVATE_KEY` | Yes |
-| Secret | `GH_APP_SLUG` | Yes |
-| Secret | `ENCRYPTION_KEY` | No (auto-generated) |
-| Secret | `JWT_PRIVATE_KEY` | No (auto-generated) |
-| Secret | `JWT_PUBLIC_KEY` | No (auto-generated) |
+| Type     | Name                       | Required                         |
+| -------- | -------------------------- | -------------------------------- |
+| Variable | `BASE_DOMAIN`              | Yes                              |
+| Variable | `RESOURCE_PREFIX`          | No (default: `sam`)              |
+| Variable | `PULUMI_STATE_BUCKET`      | No (default: `sam-pulumi-state`) |
+| Secret   | `CF_API_TOKEN`             | Yes                              |
+| Secret   | `CF_ACCOUNT_ID`            | Yes                              |
+| Secret   | `CF_ZONE_ID`               | Yes                              |
+| Secret   | `R2_ACCESS_KEY_ID`         | Yes                              |
+| Secret   | `R2_SECRET_ACCESS_KEY`     | Yes                              |
+| Secret   | `PULUMI_CONFIG_PASSPHRASE` | Yes                              |
+| Secret   | `GH_CLIENT_ID`             | Yes                              |
+| Secret   | `GH_CLIENT_SECRET`         | Yes                              |
+| Secret   | `GH_APP_ID`                | Yes                              |
+| Secret   | `GH_APP_PRIVATE_KEY`       | Yes                              |
+| Secret   | `GH_APP_SLUG`              | Yes                              |
+| Secret   | `ENCRYPTION_KEY`           | No (auto-generated)              |
+| Secret   | `JWT_PRIVATE_KEY`          | No (auto-generated)              |
+| Secret   | `JWT_PUBLIC_KEY`           | No (auto-generated)              |
 
 ### GitHub Actions Workflows
 
@@ -449,16 +456,18 @@ All configuration lives in **GitHub Settings -> Environments -> production**:
 ## API Endpoints
 
 ### Node Management
+
 - `POST /api/nodes` — Create node
 - `GET /api/nodes` — List user's nodes
 - `GET /api/nodes/:id` — Get node details
 - `POST /api/nodes/:id/stop` — Stop node
 - `DELETE /api/nodes/:id` — Delete node
-- `GET /api/nodes/:id/events` — List node events (proxied from VM Agent; vm-* DNS lacks SSL)
+- `GET /api/nodes/:id/events` — List node events (proxied from VM Agent; vm-\* DNS lacks SSL)
 - `GET /api/nodes/:id/system-info` — Full system info (proxied from VM Agent; CPU, memory, disk, Docker, versions)
 - `POST /api/nodes/:id/token` — Get node-scoped token for direct VM Agent access
 
 ### Workspace Management
+
 - `POST /api/workspaces` — Create workspace
 - `GET /api/workspaces` — List user's workspaces
 - `GET /api/workspaces/:id` — Get workspace details
@@ -468,17 +477,20 @@ All configuration lives in **GitHub Settings -> Environments -> production**:
 - `DELETE /api/workspaces/:id` — Delete a workspace
 
 ### Agent Sessions
+
 - `GET /api/workspaces/:id/agent-sessions` — List workspace agent sessions
-- `POST /api/workspaces/:id/agent-sessions` — Create agent session
+- `POST /api/workspaces/:id/agent-sessions` — Create agent session (optional `worktreePath` binds session to a worktree)
 - `PATCH /api/workspaces/:id/agent-sessions/:sessionId` — Rename agent session label
 - `POST /api/workspaces/:id/agent-sessions/:sessionId/stop` — Stop agent session
 
 ### Agent Settings
+
 - `GET /api/agent-settings/:agentType` — Get user's agent settings
 - `PUT /api/agent-settings/:agentType` — Upsert agent settings (model, permissionMode)
 - `DELETE /api/agent-settings/:agentType` — Reset agent settings to defaults
 
 ### VM Communication
+
 - `POST /api/nodes/:id/ready` — Node Agent ready callback
 - `POST /api/nodes/:id/heartbeat` — Node Agent heartbeat callback
 - `POST /api/nodes/:id/errors` — VM agent error report (batch, logged to CF Workers observability)
@@ -493,34 +505,45 @@ All configuration lives in **GitHub Settings -> Environments -> production**:
 - `POST /api/agent/activity` — VM agent activity report
 
 ### Terminal Access
+
 - `POST /api/terminal/token` — Get terminal WebSocket token
 
 ### Git Integration (VM Agent direct — browser calls via ws-{id} subdomain)
-- `GET /workspaces/:id/git/status` — Git status (staged, unstaged, untracked files)
-- `GET /workspaces/:id/git/diff?path=...&staged=true|false` — Unified diff for a single file
-- `GET /workspaces/:id/git/file?path=...&ref=HEAD` — Full file content (optional ref for committed version)
+
+- `GET /workspaces/:id/worktrees` — List git worktrees for the workspace
+- `POST /workspaces/:id/worktrees` — Create a git worktree
+- `DELETE /workspaces/:id/worktrees?path=...&force=true|false` — Remove a git worktree
+- `GET /workspaces/:id/git/status?worktree=...` — Git status (staged, unstaged, untracked files) scoped to optional worktree path
+- `GET /workspaces/:id/git/diff?path=...&staged=true|false&worktree=...` — Unified diff for a single file in optional worktree
+- `GET /workspaces/:id/git/file?path=...&ref=HEAD&worktree=...` — Full file content (optional ref + optional worktree)
 
 ### File Browser (VM Agent direct — browser calls via ws-{id} subdomain)
-- `GET /workspaces/:id/files/list?path=.` — Directory listing (type, size, modifiedAt per entry)
-- `GET /workspaces/:id/files/find` — Recursive flat file index (all file paths, excludes node_modules/.git/dist etc.)
+
+- `GET /workspaces/:id/files/list?path=.&worktree=...` — Directory listing (type, size, modifiedAt per entry) scoped to optional worktree
+- `GET /workspaces/:id/files/find?worktree=...` — Recursive flat file index (all file paths, excludes node_modules/.git/dist etc.) scoped to optional worktree
 
 ### Voice Transcription
+
 - `POST /api/transcribe` — Transcribe audio via Workers AI (Whisper)
 
 ### Client Error Reporting
+
 - `POST /api/client-errors` — Receive batched client-side errors for Workers observability logging
 
 ### Authentication (BetterAuth)
+
 - `POST /api/auth/sign-in/social` — GitHub OAuth login
 - `GET /api/auth/session` — Get current session
 - `POST /api/auth/sign-out` — Sign out
 
 ### Credentials
+
 - `GET /api/credentials` — Get user's cloud provider credentials
 - `POST /api/credentials` — Save cloud provider credentials
 - `DELETE /api/credentials/:provider` — Delete stored cloud provider credential
 
 ### GitHub Integration
+
 - `GET /api/github/installations` — List user's GitHub App installations
 - `GET /api/github/repositories` — List accessible repositories
 - `GET /api/github/branches?repository=owner/repo` — List branches for a repository
@@ -528,7 +551,9 @@ All configuration lives in **GitHub Settings -> Environments -> production**:
 ## Troubleshooting
 
 ### Build Errors
+
 Run builds in dependency order:
+
 ```bash
 pnpm --filter @simple-agent-manager/shared build
 pnpm --filter @simple-agent-manager/providers build
@@ -536,9 +561,11 @@ pnpm --filter @simple-agent-manager/api build
 ```
 
 ### Test Failures
+
 Check if Miniflare bindings are configured in `vitest.config.ts`.
 
 ### Type Errors
+
 Run `pnpm typecheck` from root to see all issues.
 
 ## Agent Authentication
@@ -636,7 +663,11 @@ app.onError((err, c) => {
 
 // WRONG — subrouter errors silently bypass this
 app.use('*', async (c, next) => {
-  try { await next(); } catch (err) { /* NEVER REACHED for subrouter errors */ }
+  try {
+    await next();
+  } catch (err) {
+    /* NEVER REACHED for subrouter errors */
+  }
 });
 ```
 
@@ -657,6 +688,7 @@ Local development uses `.dev.vars`.
 ### Development Environment Variables
 
 See `apps/api/.env.example`:
+
 - `WRANGLER_PORT` - Local dev port (default: 8787)
 - `BASE_DOMAIN` - Set automatically by sync scripts
 - `MAX_NODES_PER_USER` - Optional runtime node cap
@@ -674,6 +706,9 @@ See `apps/api/.env.example`:
 - `MAX_CLIENT_ERROR_BATCH_SIZE` - Max errors per client error report request (default: 25)
 - `MAX_CLIENT_ERROR_BODY_BYTES` - Max request body size for client error reports in bytes (default: 65536)
 - `GIT_EXEC_TIMEOUT` - VM Agent: timeout for git commands via docker exec (default: 30s)
+- `GIT_WORKTREE_TIMEOUT` - VM Agent: timeout for git worktree create/remove commands (default: 30s)
+- `WORKTREE_CACHE_TTL` - VM Agent: cache duration for parsed `git worktree list` results (default: 5s)
+- `MAX_WORKTREES_PER_WORKSPACE` - VM Agent: max worktrees allowed per workspace (default: 5)
 - `GIT_FILE_MAX_SIZE` - VM Agent: max file size in bytes for git/file endpoint (default: 1048576)
 - `FILE_LIST_TIMEOUT` - VM Agent: timeout for file listing commands (default: 10s)
 - `FILE_LIST_MAX_ENTRIES` - VM Agent: max entries returned per directory listing (default: 1000)
@@ -725,13 +760,18 @@ For UI changes in `apps/web`, `packages/vm-agent/ui`, or `packages/ui`:
    - document a temporary exception with rationale and expiration.
 
 ## Active Technologies
+
 - **API**: TypeScript 5.x, Hono, Drizzle ORM, BetterAuth, jose, Cloudflare Workers
 - **Web**: TypeScript 5.x, React 18, Vite 5, TailwindCSS, xterm.js 5.3, Radix UI, lucide-react, @dnd-kit
 - **VM Agent**: Go 1.22+, creack/pty, gorilla/websocket, golang-jwt, modernc.org/sqlite
 - **Storage**: Cloudflare D1 (SQLite), KV (sessions/tokens/boot logs), R2 (binaries/Pulumi state)
 - **Infra**: Pulumi, Wrangler, @devcontainers/cli, pnpm 9.0+, Cloudflare Pages
+- TypeScript 5.x (API + Web), Go 1.22+ (VM Agent) + Hono (API), React 18 + Vite 5 (Web), creack/pty + gorilla/websocket (VM Agent), ACP SDK (agent sessions) (015-worktree-context)
+- Cloudflare D1 (agent session worktree metadata), SQLite on VM (terminal session metadata), Docker named volumes (worktree directories) (015-worktree-context)
 
 ## Recent Changes
+
+- worktree-context: Added deep git worktree integration across VM agent, API, shared types, terminal package, and workspace UI; new VM agent worktree endpoints (`GET/POST/DELETE /workspaces/:id/worktrees`), optional `worktree` scoping for git/file endpoints, and worktree-aware terminal/chat session creation (`workDir`/`worktree` path propagation); agent sessions now persist optional `worktreePath` in D1 via `0010_agent_sessions_worktree_path.sql`; new `WorktreeSelector` UI supports list/create/remove/switch with URL persistence and tab badges; added env vars `GIT_WORKTREE_TIMEOUT`, `WORKTREE_CACHE_TTL`, `MAX_WORKTREES_PER_WORKSPACE`
 - node-system-info: VM Agent sysinfo package collects system metrics from Linux procfs (`/proc/loadavg`, `/proc/meminfo`, `/proc/uptime`, `/proc/net/dev`) and Docker CLI (`docker stats`, `docker version`); two-tier collection: `CollectQuick()` (procfs only, microseconds) enriches heartbeat with `metrics: { cpuLoadAvg1, memoryPercent, diskPercent }`, `Collect()` (full, including Docker/versions) powers new `GET /system-info` endpoint; control plane stores heartbeat metrics in D1 `last_metrics` column, proxies full system info via `GET /api/nodes/:id/system-info`; Node detail page redesigned with composed section components (NodeOverviewSection, SystemResourcesSection, DockerSection, SoftwareSection, NodeWorkspacesSection, NodeEventsSection) replacing monolithic inline JSX; ResourceBar gauge with color-coded thresholds and `role="meter"` accessibility; Nodes list page enriched with MiniMetricBadge pills (load/mem/disk) and workspace count; configurable `SYSINFO_DOCKER_TIMEOUT`, `SYSINFO_VERSION_TIMEOUT`, `SYSINFO_CACHE_TTL`; build-time ldflags inject version/build date/Go version into agent binary
 - devcontainer-named-volumes: Replaced bind-mount devcontainer storage with named Docker volumes (`sam-ws-<workspaceId>`); host clone preserved for devcontainer CLI config discovery, then populated into volume via throwaway `alpine` container; `workspaceMount` property in override config replaces default bind-mount (NOT `--mount` CLI flag which only adds supplementary mounts); repos with own devcontainer config get mount-only override, repos without config get full default config with volume mount; eliminated permission normalization dance (`ensureWorkspaceWritablePreDevcontainer`, `ensureWorkspaceWritable`, `getContainerUserIDs`, `getContainerCurrentUserIDs` removed); workspace deletion now removes container and volume; `config.DeriveRepoDirName` exported for cross-package use
 - command-palette-search: Enhanced command palette (Cmd+K) with fuzzy file search and tab switching; VS Code-style camelCase-aware fuzzy matching (fuzzy-match.ts) with word boundary scoring, consecutive bonuses, and space-skipping; categorized results (Tabs, Files, Commands) with HighlightedText match visualization; lazy file index loading via new VM Agent `GET /files/find` endpoint (recursive flat file list with noise exclusion); filename-vs-path best-score matching; file results capped at 20; configurable FILE_FIND_TIMEOUT and FILE_FIND_MAX_ENTRIES
@@ -748,7 +788,7 @@ For UI changes in `apps/web`, `packages/vm-agent/ui`, or `packages/ui`:
 - file-browser: File browser with directory listing and syntax-highlighted file viewer; VM Agent endpoint `GET /files/list` via docker exec `find -printf`; breadcrumb navigation, mobile-first full-screen overlays, cross-link to git diff viewer; configurable FILE_LIST_TIMEOUT and FILE_LIST_MAX_ENTRIES
 - git-changes-viewer: GitHub PR-style git changes viewer accessible via nav bar icon; VM Agent endpoints for git status/diff/file via docker exec; full-screen overlay with staged/unstaged/untracked sections, unified diff view with green/red coloring, Diff/Full toggle; URL search params for browser back/forward navigation
 - voice-to-text: Voice input button for agent chat with Workers AI Whisper transcription, VoiceButton component in acp-client, POST /api/transcribe endpoint, configurable model/limits
-- node-data-ownership: Workspace events fetched directly from VM Agent (browser -> VM Agent via ws-{id} proxy); node events proxied through control plane (vm-* DNS records lack SSL termination); new `POST /api/nodes/:id/token` for node-scoped auth tokens; VM Agent event handlers accept browser workspace/session auth
+- node-data-ownership: Workspace events fetched directly from VM Agent (browser -> VM Agent via ws-{id} proxy); node events proxied through control plane (vm-\* DNS records lack SSL termination); new `POST /api/nodes/:id/token` for node-scoped auth tokens; VM Agent event handlers accept browser workspace/session auth
 - 014-multi-workspace-nodes: First-class Nodes with multi-workspace hosting, async provisioning (callback-driven `/ready` + `/provisioning-failed`), workspace recovery on attach, session tab UX with `+` dropdown, node-scoped routing/auth, explicit lifecycle control
 - 014-multi-workspace-nodes: Default fallback devcontainer image changed to `mcr.microsoft.com/devcontainers/base:ubuntu`; fresh-node readiness probing with hard timeouts
 - 014-auth-profile-sync: GitHub primary email resolved at login, propagated into workspace bootstrap for git commit identity

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ However, this does NOT excuse stale documentation. The following rule exists to 
 **After writing or modifying ANY code, you MUST update ALL documentation that references the changed behavior IN THE SAME COMMIT.** There are NO exceptions and NO deferrals.
 
 This includes but is not limited to:
+
 - `docs/guides/self-hosting.md` — setup instructions, permissions, configuration
 - `docs/architecture/` — architecture decisions, credential models
 - `specs/` — feature specifications, data models
@@ -70,6 +71,7 @@ This prevents scope drift and ensures the user gets exactly what they asked for.
 ### Quick Testing Gate
 
 Before marking feature work complete:
+
 - [ ] Unit tests added/updated for all changed behavior
 - [ ] Integration tests added where cross-layer behavior exists
 - [ ] E2E coverage added or explicitly justified as not applicable
@@ -94,6 +96,7 @@ Before marking feature work complete:
 ### Quick Compliance Check
 
 Before committing any business logic changes, verify:
+
 - [ ] All URLs derived from `BASE_DOMAIN` or similar env vars
 - [ ] All timeouts have `DEFAULT_*` constants and env var overrides
 - [ ] All limits are configurable via environment
@@ -127,6 +130,7 @@ This workflow avoids deploy-fix-deploy cycles and catches mobile layout bugs tha
 ### Quick Mobile Check
 
 Before deploying any UI changes:
+
 - [ ] Login button visible and large (min 56px height)
 - [ ] Text readable without zooming (responsive sizing)
 - [ ] Grid layouts collapse to single column on mobile
@@ -141,10 +145,10 @@ Before deploying any UI changes:
 
 ### The Two Naming Conventions
 
-| Context | Prefix | Example | Where Used |
-|---------|--------|---------|------------|
-| **GitHub Environment** | `GH_` | `GH_CLIENT_ID` | GitHub Settings -> Environments -> production |
-| **Cloudflare Worker** | `GITHUB_` | `GITHUB_CLIENT_ID` | Worker runtime, local `.env` files |
+| Context                | Prefix    | Example            | Where Used                                    |
+| ---------------------- | --------- | ------------------ | --------------------------------------------- |
+| **GitHub Environment** | `GH_`     | `GH_CLIENT_ID`     | GitHub Settings -> Environments -> production |
+| **Cloudflare Worker**  | `GITHUB_` | `GITHUB_CLIENT_ID` | Worker runtime, local `.env` files            |
 
 ### Why Different Names?
 
@@ -164,6 +168,7 @@ GH_APP_SLUG            ->  GITHUB_APP_SLUG
 ### Documentation Rules
 
 When documenting environment variables:
+
 1. **GitHub Environment config** -> Use `GH_*` prefix
 2. **Cloudflare Worker secrets** -> Use `GITHUB_*` prefix
 3. **Local `.env` files** -> Use `GITHUB_*` prefix (same as Worker)
@@ -182,11 +187,11 @@ When documenting environment variables:
 
 **When constructing URLs using `BASE_DOMAIN`, you MUST use the correct subdomain prefix.** The root domain does NOT serve any application.
 
-| Destination | URL Pattern | Example |
-|-------------|-------------|---------|
-| **Web UI** | `https://app.${BASE_DOMAIN}/...` | `https://app.simple-agent-manager.org/settings` |
-| **API** | `https://api.${BASE_DOMAIN}/...` | `https://api.simple-agent-manager.org/health` |
-| **Workspace** | `https://ws-${id}.${BASE_DOMAIN}` | `https://ws-abc123.simple-agent-manager.org` |
+| Destination   | URL Pattern                       | Example                                         |
+| ------------- | --------------------------------- | ----------------------------------------------- |
+| **Web UI**    | `https://app.${BASE_DOMAIN}/...`  | `https://app.simple-agent-manager.org/settings` |
+| **API**       | `https://api.${BASE_DOMAIN}/...`  | `https://api.simple-agent-manager.org/health`   |
+| **Workspace** | `https://ws-${id}.${BASE_DOMAIN}` | `https://ws-abc123.simple-agent-manager.org`    |
 
 **NEVER** use `https://${BASE_DOMAIN}/...` (bare root domain) for redirects or links. This is always a bug.
 
@@ -219,12 +224,12 @@ When documenting environment variables:
 
 ### Key Architecture Documents
 
-| Document | Contents |
-|----------|----------|
+| Document                                   | Contents                                 |
+| ------------------------------------------ | ---------------------------------------- |
 | `docs/architecture/credential-security.md` | BYOC model, encryption, user credentials |
-| `docs/architecture/secrets-taxonomy.md` | Platform secrets vs user credentials |
-| `docs/adr/002-stateless-architecture.md` | Stateless design principles |
-| `.specify/memory/constitution.md` | Core principles and rules |
+| `docs/architecture/secrets-taxonomy.md`    | Platform secrets vs user credentials     |
+| `docs/adr/002-stateless-architecture.md`   | Stateless design principles              |
+| `.specify/memory/constitution.md`          | Core principles and rules                |
 
 ### Architecture Principles (Quick Reference)
 
@@ -254,12 +259,12 @@ When documenting environment variables:
 
 ### Key Business Logic Documents
 
-| Document | Contents |
-|----------|----------|
-| `specs/003-browser-terminal-saas/spec.md` | Core SaaS features, user stories |
-| `specs/003-browser-terminal-saas/data-model.md` | Entity relationships, state machines |
-| `specs/004-mvp-hardening/spec.md` | Security hardening, access control |
-| `specs/004-mvp-hardening/data-model.md` | Bootstrap tokens, ownership validation |
+| Document                                        | Contents                               |
+| ----------------------------------------------- | -------------------------------------- |
+| `specs/003-browser-terminal-saas/spec.md`       | Core SaaS features, user stories       |
+| `specs/003-browser-terminal-saas/data-model.md` | Entity relationships, state machines   |
+| `specs/004-mvp-hardening/spec.md`               | Security hardening, access control     |
+| `specs/004-mvp-hardening/data-model.md`         | Bootstrap tokens, ownership validation |
 
 ### Business Logic Principles (Quick Reference)
 
@@ -373,6 +378,7 @@ Task file template and conventions are defined in `tasks/README.md`.
 ### Local Dev Limitations (NOT Recommended for Testing)
 
 Running `pnpm dev` starts local emulators but has significant limitations:
+
 - No real GitHub OAuth (callbacks won't work)
 - No real DNS (workspace URLs won't resolve)
 - No real VMs (workspaces can't be created)
@@ -387,6 +393,7 @@ Store all Playwright screenshots from development and verification runs in `.cod
 ### Live Test Resource Cleanup (Required)
 
 When Playwright or manual live-app verification creates test workspaces or nodes:
+
 - Use only newly created test resources for that verification run
 - Do not mutate long-lived/legacy resources
 - Delete test workspaces and test nodes after verification is complete
@@ -411,25 +418,25 @@ pnpm format           # Format
 
 All configuration lives in **GitHub Settings -> Environments -> production**:
 
-| Type | Name | Required |
-|------|------|----------|
-| Variable | `BASE_DOMAIN` | Yes |
-| Variable | `RESOURCE_PREFIX` | No (default: `sam`) |
-| Variable | `PULUMI_STATE_BUCKET` | No (default: `sam-pulumi-state`) |
-| Secret | `CF_API_TOKEN` | Yes |
-| Secret | `CF_ACCOUNT_ID` | Yes |
-| Secret | `CF_ZONE_ID` | Yes |
-| Secret | `R2_ACCESS_KEY_ID` | Yes |
-| Secret | `R2_SECRET_ACCESS_KEY` | Yes |
-| Secret | `PULUMI_CONFIG_PASSPHRASE` | Yes |
-| Secret | `GH_CLIENT_ID` | Yes |
-| Secret | `GH_CLIENT_SECRET` | Yes |
-| Secret | `GH_APP_ID` | Yes |
-| Secret | `GH_APP_PRIVATE_KEY` | Yes |
-| Secret | `GH_APP_SLUG` | Yes |
-| Secret | `ENCRYPTION_KEY` | No (auto-generated) |
-| Secret | `JWT_PRIVATE_KEY` | No (auto-generated) |
-| Secret | `JWT_PUBLIC_KEY` | No (auto-generated) |
+| Type     | Name                       | Required                         |
+| -------- | -------------------------- | -------------------------------- |
+| Variable | `BASE_DOMAIN`              | Yes                              |
+| Variable | `RESOURCE_PREFIX`          | No (default: `sam`)              |
+| Variable | `PULUMI_STATE_BUCKET`      | No (default: `sam-pulumi-state`) |
+| Secret   | `CF_API_TOKEN`             | Yes                              |
+| Secret   | `CF_ACCOUNT_ID`            | Yes                              |
+| Secret   | `CF_ZONE_ID`               | Yes                              |
+| Secret   | `R2_ACCESS_KEY_ID`         | Yes                              |
+| Secret   | `R2_SECRET_ACCESS_KEY`     | Yes                              |
+| Secret   | `PULUMI_CONFIG_PASSPHRASE` | Yes                              |
+| Secret   | `GH_CLIENT_ID`             | Yes                              |
+| Secret   | `GH_CLIENT_SECRET`         | Yes                              |
+| Secret   | `GH_APP_ID`                | Yes                              |
+| Secret   | `GH_APP_PRIVATE_KEY`       | Yes                              |
+| Secret   | `GH_APP_SLUG`              | Yes                              |
+| Secret   | `ENCRYPTION_KEY`           | No (auto-generated)              |
+| Secret   | `JWT_PRIVATE_KEY`          | No (auto-generated)              |
+| Secret   | `JWT_PUBLIC_KEY`           | No (auto-generated)              |
 
 ### GitHub Actions Workflows
 
@@ -449,16 +456,18 @@ All configuration lives in **GitHub Settings -> Environments -> production**:
 ## API Endpoints
 
 ### Node Management
+
 - `POST /api/nodes` — Create node
 - `GET /api/nodes` — List user's nodes
 - `GET /api/nodes/:id` — Get node details
 - `POST /api/nodes/:id/stop` — Stop node
 - `DELETE /api/nodes/:id` — Delete node
-- `GET /api/nodes/:id/events` — List node events (proxied from VM Agent; vm-* DNS lacks SSL)
+- `GET /api/nodes/:id/events` — List node events (proxied from VM Agent; vm-\* DNS lacks SSL)
 - `GET /api/nodes/:id/system-info` — Full system info (proxied from VM Agent; CPU, memory, disk, Docker, versions)
 - `POST /api/nodes/:id/token` — Get node-scoped token for direct VM Agent access
 
 ### Workspace Management
+
 - `POST /api/workspaces` — Create workspace
 - `GET /api/workspaces` — List user's workspaces
 - `GET /api/workspaces/:id` — Get workspace details
@@ -468,17 +477,20 @@ All configuration lives in **GitHub Settings -> Environments -> production**:
 - `DELETE /api/workspaces/:id` — Delete a workspace
 
 ### Agent Sessions
+
 - `GET /api/workspaces/:id/agent-sessions` — List workspace agent sessions
-- `POST /api/workspaces/:id/agent-sessions` — Create agent session
+- `POST /api/workspaces/:id/agent-sessions` — Create agent session (optional `worktreePath` binds session to a worktree)
 - `PATCH /api/workspaces/:id/agent-sessions/:sessionId` — Rename agent session label
 - `POST /api/workspaces/:id/agent-sessions/:sessionId/stop` — Stop agent session
 
 ### Agent Settings
+
 - `GET /api/agent-settings/:agentType` — Get user's agent settings
 - `PUT /api/agent-settings/:agentType` — Upsert agent settings (model, permissionMode)
 - `DELETE /api/agent-settings/:agentType` — Reset agent settings to defaults
 
 ### VM Communication
+
 - `POST /api/nodes/:id/ready` — Node Agent ready callback
 - `POST /api/nodes/:id/heartbeat` — Node Agent heartbeat callback
 - `POST /api/nodes/:id/errors` — VM agent error report (batch, logged to CF Workers observability)
@@ -493,34 +505,45 @@ All configuration lives in **GitHub Settings -> Environments -> production**:
 - `POST /api/agent/activity` — VM agent activity report
 
 ### Terminal Access
+
 - `POST /api/terminal/token` — Get terminal WebSocket token
 
 ### Git Integration (VM Agent direct — browser calls via ws-{id} subdomain)
-- `GET /workspaces/:id/git/status` — Git status (staged, unstaged, untracked files)
-- `GET /workspaces/:id/git/diff?path=...&staged=true|false` — Unified diff for a single file
-- `GET /workspaces/:id/git/file?path=...&ref=HEAD` — Full file content (optional ref for committed version)
+
+- `GET /workspaces/:id/worktrees` — List git worktrees for the workspace
+- `POST /workspaces/:id/worktrees` — Create a git worktree
+- `DELETE /workspaces/:id/worktrees?path=...&force=true|false` — Remove a git worktree
+- `GET /workspaces/:id/git/status?worktree=...` — Git status (staged, unstaged, untracked files) scoped to optional worktree path
+- `GET /workspaces/:id/git/diff?path=...&staged=true|false&worktree=...` — Unified diff for a single file in optional worktree
+- `GET /workspaces/:id/git/file?path=...&ref=HEAD&worktree=...` — Full file content (optional ref + optional worktree)
 
 ### File Browser (VM Agent direct — browser calls via ws-{id} subdomain)
-- `GET /workspaces/:id/files/list?path=.` — Directory listing (type, size, modifiedAt per entry)
-- `GET /workspaces/:id/files/find` — Recursive flat file index (all file paths, excludes node_modules/.git/dist etc.)
+
+- `GET /workspaces/:id/files/list?path=.&worktree=...` — Directory listing (type, size, modifiedAt per entry) scoped to optional worktree
+- `GET /workspaces/:id/files/find?worktree=...` — Recursive flat file index (all file paths, excludes node_modules/.git/dist etc.) scoped to optional worktree
 
 ### Voice Transcription
+
 - `POST /api/transcribe` — Transcribe audio via Workers AI (Whisper)
 
 ### Client Error Reporting
+
 - `POST /api/client-errors` — Receive batched client-side errors for Workers observability logging
 
 ### Authentication (BetterAuth)
+
 - `POST /api/auth/sign-in/social` — GitHub OAuth login
 - `GET /api/auth/session` — Get current session
 - `POST /api/auth/sign-out` — Sign out
 
 ### Credentials
+
 - `GET /api/credentials` — Get user's cloud provider credentials
 - `POST /api/credentials` — Save cloud provider credentials
 - `DELETE /api/credentials/:provider` — Delete stored cloud provider credential
 
 ### GitHub Integration
+
 - `GET /api/github/installations` — List user's GitHub App installations
 - `GET /api/github/repositories` — List accessible repositories
 - `GET /api/github/branches?repository=owner/repo` — List branches for a repository
@@ -528,7 +551,9 @@ All configuration lives in **GitHub Settings -> Environments -> production**:
 ## Troubleshooting
 
 ### Build Errors
+
 Run builds in dependency order:
+
 ```bash
 pnpm --filter @simple-agent-manager/shared build
 pnpm --filter @simple-agent-manager/providers build
@@ -536,9 +561,11 @@ pnpm --filter @simple-agent-manager/api build
 ```
 
 ### Test Failures
+
 Check if Miniflare bindings are configured in `vitest.config.ts`.
 
 ### Type Errors
+
 Run `pnpm typecheck` from root to see all issues.
 
 ## Agent Authentication
@@ -636,7 +663,11 @@ app.onError((err, c) => {
 
 // WRONG — subrouter errors silently bypass this
 app.use('*', async (c, next) => {
-  try { await next(); } catch (err) { /* NEVER REACHED for subrouter errors */ }
+  try {
+    await next();
+  } catch (err) {
+    /* NEVER REACHED for subrouter errors */
+  }
 });
 ```
 
@@ -657,6 +688,7 @@ Local development uses `.dev.vars`.
 ### Development Environment Variables
 
 See `apps/api/.env.example`:
+
 - `WRANGLER_PORT` - Local dev port (default: 8787)
 - `BASE_DOMAIN` - Set automatically by sync scripts
 - `MAX_NODES_PER_USER` - Optional runtime node cap
@@ -674,6 +706,9 @@ See `apps/api/.env.example`:
 - `MAX_CLIENT_ERROR_BATCH_SIZE` - Max errors per client error report request (default: 25)
 - `MAX_CLIENT_ERROR_BODY_BYTES` - Max request body size for client error reports in bytes (default: 65536)
 - `GIT_EXEC_TIMEOUT` - VM Agent: timeout for git commands via docker exec (default: 30s)
+- `GIT_WORKTREE_TIMEOUT` - VM Agent: timeout for git worktree create/remove commands (default: 30s)
+- `WORKTREE_CACHE_TTL` - VM Agent: cache duration for parsed `git worktree list` results (default: 5s)
+- `MAX_WORKTREES_PER_WORKSPACE` - VM Agent: max worktrees allowed per workspace (default: 5)
 - `GIT_FILE_MAX_SIZE` - VM Agent: max file size in bytes for git/file endpoint (default: 1048576)
 - `FILE_LIST_TIMEOUT` - VM Agent: timeout for file listing commands (default: 10s)
 - `FILE_LIST_MAX_ENTRIES` - VM Agent: max entries returned per directory listing (default: 1000)
@@ -725,13 +760,18 @@ For UI changes in `apps/web`, `packages/vm-agent/ui`, or `packages/ui`:
    - document a temporary exception with rationale and expiration.
 
 ## Active Technologies
+
 - **API**: TypeScript 5.x, Hono, Drizzle ORM, BetterAuth, jose, Cloudflare Workers
 - **Web**: TypeScript 5.x, React 18, Vite 5, TailwindCSS, xterm.js 5.3, Radix UI, lucide-react, @dnd-kit
 - **VM Agent**: Go 1.22+, creack/pty, gorilla/websocket, golang-jwt, modernc.org/sqlite
 - **Storage**: Cloudflare D1 (SQLite), KV (sessions/tokens/boot logs), R2 (binaries/Pulumi state)
 - **Infra**: Pulumi, Wrangler, @devcontainers/cli, pnpm 9.0+, Cloudflare Pages
+- TypeScript 5.x (API + Web), Go 1.22+ (VM Agent) + Hono (API), React 18 + Vite 5 (Web), creack/pty + gorilla/websocket (VM Agent), ACP SDK (agent sessions) (015-worktree-context)
+- Cloudflare D1 (agent session worktree metadata), SQLite on VM (terminal session metadata), Docker named volumes (worktree directories) (015-worktree-context)
 
 ## Recent Changes
+
+- worktree-context: Added deep git worktree integration across VM agent, API, shared types, terminal package, and workspace UI; new VM agent worktree endpoints (`GET/POST/DELETE /workspaces/:id/worktrees`), optional `worktree` scoping for git/file endpoints, and worktree-aware terminal/chat session creation (`workDir`/`worktree` path propagation); agent sessions now persist optional `worktreePath` in D1 via `0010_agent_sessions_worktree_path.sql`; new `WorktreeSelector` UI supports list/create/remove/switch with URL persistence and tab badges; added env vars `GIT_WORKTREE_TIMEOUT`, `WORKTREE_CACHE_TTL`, `MAX_WORKTREES_PER_WORKSPACE`
 - node-system-info: VM Agent sysinfo package collects system metrics from Linux procfs (`/proc/loadavg`, `/proc/meminfo`, `/proc/uptime`, `/proc/net/dev`) and Docker CLI (`docker stats`, `docker version`); two-tier collection: `CollectQuick()` (procfs only, microseconds) enriches heartbeat with `metrics: { cpuLoadAvg1, memoryPercent, diskPercent }`, `Collect()` (full, including Docker/versions) powers new `GET /system-info` endpoint; control plane stores heartbeat metrics in D1 `last_metrics` column, proxies full system info via `GET /api/nodes/:id/system-info`; Node detail page redesigned with composed section components (NodeOverviewSection, SystemResourcesSection, DockerSection, SoftwareSection, NodeWorkspacesSection, NodeEventsSection) replacing monolithic inline JSX; ResourceBar gauge with color-coded thresholds and `role="meter"` accessibility; Nodes list page enriched with MiniMetricBadge pills (load/mem/disk) and workspace count; configurable `SYSINFO_DOCKER_TIMEOUT`, `SYSINFO_VERSION_TIMEOUT`, `SYSINFO_CACHE_TTL`; build-time ldflags inject version/build date/Go version into agent binary
 - devcontainer-named-volumes: Replaced bind-mount devcontainer storage with named Docker volumes (`sam-ws-<workspaceId>`); host clone preserved for devcontainer CLI config discovery, then populated into volume via throwaway `alpine` container; `workspaceMount` property in override config replaces default bind-mount (NOT `--mount` CLI flag which only adds supplementary mounts); repos with own devcontainer config get mount-only override, repos without config get full default config with volume mount; eliminated permission normalization dance (`ensureWorkspaceWritablePreDevcontainer`, `ensureWorkspaceWritable`, `getContainerUserIDs`, `getContainerCurrentUserIDs` removed); workspace deletion now removes container and volume; `config.DeriveRepoDirName` exported for cross-package use
 - command-palette-search: Enhanced command palette (Cmd+K) with fuzzy file search and tab switching; VS Code-style camelCase-aware fuzzy matching (fuzzy-match.ts) with word boundary scoring, consecutive bonuses, and space-skipping; categorized results (Tabs, Files, Commands) with HighlightedText match visualization; lazy file index loading via new VM Agent `GET /files/find` endpoint (recursive flat file list with noise exclusion); filename-vs-path best-score matching; file results capped at 20; configurable FILE_FIND_TIMEOUT and FILE_FIND_MAX_ENTRIES
@@ -748,7 +788,7 @@ For UI changes in `apps/web`, `packages/vm-agent/ui`, or `packages/ui`:
 - file-browser: File browser with directory listing and syntax-highlighted file viewer; VM Agent endpoint `GET /files/list` via docker exec `find -printf`; breadcrumb navigation, mobile-first full-screen overlays, cross-link to git diff viewer; configurable FILE_LIST_TIMEOUT and FILE_LIST_MAX_ENTRIES
 - git-changes-viewer: GitHub PR-style git changes viewer accessible via nav bar icon; VM Agent endpoints for git status/diff/file via docker exec; full-screen overlay with staged/unstaged/untracked sections, unified diff view with green/red coloring, Diff/Full toggle; URL search params for browser back/forward navigation
 - voice-to-text: Voice input button for agent chat with Workers AI Whisper transcription, VoiceButton component in acp-client, POST /api/transcribe endpoint, configurable model/limits
-- node-data-ownership: Workspace events fetched directly from VM Agent (browser -> VM Agent via ws-{id} proxy); node events proxied through control plane (vm-* DNS records lack SSL termination); new `POST /api/nodes/:id/token` for node-scoped auth tokens; VM Agent event handlers accept browser workspace/session auth
+- node-data-ownership: Workspace events fetched directly from VM Agent (browser -> VM Agent via ws-{id} proxy); node events proxied through control plane (vm-\* DNS records lack SSL termination); new `POST /api/nodes/:id/token` for node-scoped auth tokens; VM Agent event handlers accept browser workspace/session auth
 - 014-multi-workspace-nodes: First-class Nodes with multi-workspace hosting, async provisioning (callback-driven `/ready` + `/provisioning-failed`), workspace recovery on attach, session tab UX with `+` dropdown, node-scoped routing/auth, explicit lifecycle control
 - 014-multi-workspace-nodes: Default fallback devcontainer image changed to `mcr.microsoft.com/devcontainers/base:ubuntu`; fresh-node readiness probing with hard timeouts
 - 014-auth-profile-sync: GitHub primary email resolved at login, propagated into workspace bootstrap for git commit identity

--- a/apps/api/src/db/migrations/0010_agent_sessions_worktree_path.sql
+++ b/apps/api/src/db/migrations/0010_agent_sessions_worktree_path.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agent_sessions ADD COLUMN worktree_path TEXT;

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -26,331 +26,480 @@ export const users = sqliteTable('users', {
 // =============================================================================
 // Sessions (BetterAuth)
 // =============================================================================
-export const sessions = sqliteTable('sessions', {
-  id: text('id').primaryKey(),
-  expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
-  token: text('token').notNull().unique(),
-  createdAt: integer('created_at', { mode: 'timestamp_ms' })
-    .notNull()
-    .default(sql`(cast(unixepoch() * 1000 as integer))`),
-  updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
-    .notNull()
-    .default(sql`(cast(unixepoch() * 1000 as integer))`),
-  ipAddress: text('ip_address'),
-  userAgent: text('user_agent'),
-  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
-}, (table) => ({
-  userIdIdx: index('idx_sessions_user_id').on(table.userId),
-}));
+export const sessions = sqliteTable(
+  'sessions',
+  {
+    id: text('id').primaryKey(),
+    expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
+    token: text('token').notNull().unique(),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .notNull()
+      .default(sql`(cast(unixepoch() * 1000 as integer))`),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+      .notNull()
+      .default(sql`(cast(unixepoch() * 1000 as integer))`),
+    ipAddress: text('ip_address'),
+    userAgent: text('user_agent'),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+  },
+  (table) => ({
+    userIdIdx: index('idx_sessions_user_id').on(table.userId),
+  })
+);
 
 // =============================================================================
 // Accounts (BetterAuth OAuth providers)
 // =============================================================================
-export const accounts = sqliteTable('accounts', {
-  id: text('id').primaryKey(),
-  accountId: text('account_id').notNull(),
-  providerId: text('provider_id').notNull(),
-  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
-  accessToken: text('access_token'),
-  refreshToken: text('refresh_token'),
-  idToken: text('id_token'),
-  accessTokenExpiresAt: integer('access_token_expires_at', { mode: 'timestamp_ms' }),
-  refreshTokenExpiresAt: integer('refresh_token_expires_at', { mode: 'timestamp_ms' }),
-  scope: text('scope'),
-  password: text('password'),
-  createdAt: integer('created_at', { mode: 'timestamp_ms' })
-    .notNull()
-    .default(sql`(cast(unixepoch() * 1000 as integer))`),
-  updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
-    .notNull()
-    .default(sql`(cast(unixepoch() * 1000 as integer))`),
-}, (table) => ({
-  userIdIdx: index('idx_accounts_user_id').on(table.userId),
-}));
+export const accounts = sqliteTable(
+  'accounts',
+  {
+    id: text('id').primaryKey(),
+    accountId: text('account_id').notNull(),
+    providerId: text('provider_id').notNull(),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    accessToken: text('access_token'),
+    refreshToken: text('refresh_token'),
+    idToken: text('id_token'),
+    accessTokenExpiresAt: integer('access_token_expires_at', { mode: 'timestamp_ms' }),
+    refreshTokenExpiresAt: integer('refresh_token_expires_at', { mode: 'timestamp_ms' }),
+    scope: text('scope'),
+    password: text('password'),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .notNull()
+      .default(sql`(cast(unixepoch() * 1000 as integer))`),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+      .notNull()
+      .default(sql`(cast(unixepoch() * 1000 as integer))`),
+  },
+  (table) => ({
+    userIdIdx: index('idx_accounts_user_id').on(table.userId),
+  })
+);
 
 // =============================================================================
 // Verifications (BetterAuth)
 // =============================================================================
-export const verifications = sqliteTable('verifications', {
-  id: text('id').primaryKey(),
-  identifier: text('identifier').notNull(),
-  value: text('value').notNull(),
-  expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
-  createdAt: integer('created_at', { mode: 'timestamp_ms' })
-    .notNull()
-    .default(sql`(cast(unixepoch() * 1000 as integer))`),
-  updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
-    .notNull()
-    .default(sql`(cast(unixepoch() * 1000 as integer))`),
-}, (table) => ({
-  identifierIdx: index('idx_verifications_identifier').on(table.identifier),
-}));
+export const verifications = sqliteTable(
+  'verifications',
+  {
+    id: text('id').primaryKey(),
+    identifier: text('identifier').notNull(),
+    value: text('value').notNull(),
+    expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .notNull()
+      .default(sql`(cast(unixepoch() * 1000 as integer))`),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+      .notNull()
+      .default(sql`(cast(unixepoch() * 1000 as integer))`),
+  },
+  (table) => ({
+    identifierIdx: index('idx_verifications_identifier').on(table.identifier),
+  })
+);
 
 // =============================================================================
 // Credentials (encrypted cloud provider tokens and agent API keys)
 // =============================================================================
-export const credentials = sqliteTable('credentials', {
-  id: text('id').primaryKey(),
-  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
-  provider: text('provider').notNull(),
-  credentialType: text('credential_type').notNull().default('cloud-provider'),
-  agentType: text('agent_type'),
-  credentialKind: text('credential_kind').notNull().default('api-key'), // 'api-key' | 'oauth-token'
-  isActive: integer('is_active', { mode: 'boolean' }).notNull().default(true),
-  encryptedToken: text('encrypted_token').notNull(),
-  iv: text('iv').notNull(),
-  createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-  updatedAt: text('updated_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-}, (table) => ({
-  userAgentKind: uniqueIndex('idx_credentials_user_agent_kind')
-    .on(table.userId, table.agentType, table.credentialKind)
-    .where(sql`credential_type = 'agent-api-key'`),
-  activeCredential: index('idx_credentials_active')
-    .on(table.userId, table.agentType, table.isActive)
-    .where(sql`credential_type = 'agent-api-key' AND is_active = 1`),
-}));
+export const credentials = sqliteTable(
+  'credentials',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    provider: text('provider').notNull(),
+    credentialType: text('credential_type').notNull().default('cloud-provider'),
+    agentType: text('agent_type'),
+    credentialKind: text('credential_kind').notNull().default('api-key'), // 'api-key' | 'oauth-token'
+    isActive: integer('is_active', { mode: 'boolean' }).notNull().default(true),
+    encryptedToken: text('encrypted_token').notNull(),
+    iv: text('iv').notNull(),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text('updated_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    userAgentKind: uniqueIndex('idx_credentials_user_agent_kind')
+      .on(table.userId, table.agentType, table.credentialKind)
+      .where(sql`credential_type = 'agent-api-key'`),
+    activeCredential: index('idx_credentials_active')
+      .on(table.userId, table.agentType, table.isActive)
+      .where(sql`credential_type = 'agent-api-key' AND is_active = 1`),
+  })
+);
 
 // =============================================================================
 // GitHub App Installations
 // =============================================================================
 export const githubInstallations = sqliteTable('github_installations', {
   id: text('id').primaryKey(),
-  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  userId: text('user_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
   installationId: text('installation_id').notNull().unique(),
   accountType: text('account_type').notNull(),
   accountName: text('account_name').notNull(),
-  createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-  updatedAt: text('updated_at').notNull().default(sql`CURRENT_TIMESTAMP`),
+  createdAt: text('created_at')
+    .notNull()
+    .default(sql`CURRENT_TIMESTAMP`),
+  updatedAt: text('updated_at')
+    .notNull()
+    .default(sql`CURRENT_TIMESTAMP`),
 });
 
 // =============================================================================
 // Nodes
 // =============================================================================
-export const nodes = sqliteTable('nodes', {
-  id: text('id').primaryKey(),
-  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
-  name: text('name').notNull(),
-  status: text('status').notNull().default('pending'),
-  vmSize: text('vm_size').notNull().default('medium'),
-  vmLocation: text('vm_location').notNull().default('nbg1'),
-  providerInstanceId: text('provider_instance_id'),
-  ipAddress: text('ip_address'),
-  backendDnsRecordId: text('backend_dns_record_id'),
-  lastHeartbeatAt: text('last_heartbeat_at'),
-  healthStatus: text('health_status').notNull().default('unhealthy'),
-  heartbeatStaleAfterSeconds: integer('heartbeat_stale_after_seconds').notNull().default(180),
-  lastMetrics: text('last_metrics'),
-  errorMessage: text('error_message'),
-  createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-  updatedAt: text('updated_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-}, (table) => ({
-  userIdIdx: index('idx_nodes_user_id').on(table.userId),
-}));
+export const nodes = sqliteTable(
+  'nodes',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    status: text('status').notNull().default('pending'),
+    vmSize: text('vm_size').notNull().default('medium'),
+    vmLocation: text('vm_location').notNull().default('nbg1'),
+    providerInstanceId: text('provider_instance_id'),
+    ipAddress: text('ip_address'),
+    backendDnsRecordId: text('backend_dns_record_id'),
+    lastHeartbeatAt: text('last_heartbeat_at'),
+    healthStatus: text('health_status').notNull().default('unhealthy'),
+    heartbeatStaleAfterSeconds: integer('heartbeat_stale_after_seconds').notNull().default(180),
+    lastMetrics: text('last_metrics'),
+    errorMessage: text('error_message'),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text('updated_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    userIdIdx: index('idx_nodes_user_id').on(table.userId),
+  })
+);
 
 // =============================================================================
 // Workspaces
 // =============================================================================
-export const workspaces = sqliteTable('workspaces', {
-  id: text('id').primaryKey(),
-  nodeId: text('node_id').references(() => nodes.id, { onDelete: 'set null' }),
-  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
-  installationId: text('installation_id').references(() => githubInstallations.id),
-  displayName: text('display_name'),
-  normalizedDisplayName: text('normalized_display_name'),
-  name: text('name').notNull(),
-  repository: text('repository').notNull(),
-  branch: text('branch').notNull().default('main'),
-  status: text('status').notNull().default('pending'),
-  vmSize: text('vm_size').notNull(),
-  vmLocation: text('vm_location').notNull(),
-  hetznerServerId: text('hetzner_server_id'),
-  vmIp: text('vm_ip'),
-  dnsRecordId: text('dns_record_id'),
-  lastActivityAt: text('last_activity_at'),
-  errorMessage: text('error_message'),
-  shutdownDeadline: text('shutdown_deadline'),
-  idleTimeoutSeconds: integer('idle_timeout_seconds').notNull().default(1800), // Default 30 minutes
-  createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-  updatedAt: text('updated_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-}, (table) => ({
-  userIdIdx: index('idx_workspaces_user_id').on(table.userId),
-  nodeIdIdx: index('idx_workspaces_node_id').on(table.nodeId),
-  nodeDisplayNameUnique: uniqueIndex('idx_workspaces_node_display_name_unique')
-    .on(table.nodeId, table.normalizedDisplayName)
-    .where(sql`node_id is not null and normalized_display_name is not null`),
-  // Compound indexes for filtered listing queries (P2 fix).
-  userStatusIdx: index('idx_workspaces_user_status').on(table.userId, table.status),
-  nodeStatusIdx: index('idx_workspaces_node_status').on(table.nodeId, table.status),
-}));
+export const workspaces = sqliteTable(
+  'workspaces',
+  {
+    id: text('id').primaryKey(),
+    nodeId: text('node_id').references(() => nodes.id, { onDelete: 'set null' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    installationId: text('installation_id').references(() => githubInstallations.id),
+    displayName: text('display_name'),
+    normalizedDisplayName: text('normalized_display_name'),
+    name: text('name').notNull(),
+    repository: text('repository').notNull(),
+    branch: text('branch').notNull().default('main'),
+    status: text('status').notNull().default('pending'),
+    vmSize: text('vm_size').notNull(),
+    vmLocation: text('vm_location').notNull(),
+    hetznerServerId: text('hetzner_server_id'),
+    vmIp: text('vm_ip'),
+    dnsRecordId: text('dns_record_id'),
+    lastActivityAt: text('last_activity_at'),
+    errorMessage: text('error_message'),
+    shutdownDeadline: text('shutdown_deadline'),
+    idleTimeoutSeconds: integer('idle_timeout_seconds').notNull().default(1800), // Default 30 minutes
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text('updated_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    userIdIdx: index('idx_workspaces_user_id').on(table.userId),
+    nodeIdIdx: index('idx_workspaces_node_id').on(table.nodeId),
+    nodeDisplayNameUnique: uniqueIndex('idx_workspaces_node_display_name_unique')
+      .on(table.nodeId, table.normalizedDisplayName)
+      .where(sql`node_id is not null and normalized_display_name is not null`),
+    // Compound indexes for filtered listing queries (P2 fix).
+    userStatusIdx: index('idx_workspaces_user_status').on(table.userId, table.status),
+    nodeStatusIdx: index('idx_workspaces_node_status').on(table.nodeId, table.status),
+  })
+);
 
 // =============================================================================
 // Agent Sessions
 // =============================================================================
-export const agentSessions = sqliteTable('agent_sessions', {
-  id: text('id').primaryKey(),
-  workspaceId: text('workspace_id').notNull().references(() => workspaces.id, { onDelete: 'cascade' }),
-  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
-  status: text('status').notNull().default('running'),
-  label: text('label'),
-  stoppedAt: text('stopped_at'),
-  errorMessage: text('error_message'),
-  createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-  updatedAt: text('updated_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-}, (table) => ({
-  workspaceIdIdx: index('idx_agent_sessions_workspace_id').on(table.workspaceId),
-  userIdIdx: index('idx_agent_sessions_user_id').on(table.userId),
-  // Compound index for filtered session queries (P2 fix).
-  workspaceUserStatusIdx: index('idx_agent_sessions_ws_user_status')
-    .on(table.workspaceId, table.userId, table.status),
-}));
-
+export const agentSessions = sqliteTable(
+  'agent_sessions',
+  {
+    id: text('id').primaryKey(),
+    workspaceId: text('workspace_id')
+      .notNull()
+      .references(() => workspaces.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    status: text('status').notNull().default('running'),
+    label: text('label'),
+    worktreePath: text('worktree_path'),
+    stoppedAt: text('stopped_at'),
+    errorMessage: text('error_message'),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text('updated_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    workspaceIdIdx: index('idx_agent_sessions_workspace_id').on(table.workspaceId),
+    userIdIdx: index('idx_agent_sessions_user_id').on(table.userId),
+    // Compound index for filtered session queries (P2 fix).
+    workspaceUserStatusIdx: index('idx_agent_sessions_ws_user_status').on(
+      table.workspaceId,
+      table.userId,
+      table.status
+    ),
+  })
+);
 
 // =============================================================================
 // Agent Settings (per-user, per-agent configuration)
 // =============================================================================
-export const agentSettings = sqliteTable('agent_settings', {
-  id: text('id').primaryKey(),
-  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
-  agentType: text('agent_type').notNull(),
-  model: text('model'),
-  permissionMode: text('permission_mode'),
-  allowedTools: text('allowed_tools'),
-  deniedTools: text('denied_tools'),
-  additionalEnv: text('additional_env'),
-  createdAt: integer('created_at', { mode: 'timestamp_ms' })
-    .notNull()
-    .default(sql`(cast(unixepoch() * 1000 as integer))`),
-  updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
-    .notNull()
-    .default(sql`(cast(unixepoch() * 1000 as integer))`),
-}, (table) => ({
-  userIdIdx: index('idx_agent_settings_user_id').on(table.userId),
-  userAgentTypeUnique: uniqueIndex('idx_agent_settings_user_agent_type')
-    .on(table.userId, table.agentType),
-}));
+export const agentSettings = sqliteTable(
+  'agent_settings',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    agentType: text('agent_type').notNull(),
+    model: text('model'),
+    permissionMode: text('permission_mode'),
+    allowedTools: text('allowed_tools'),
+    deniedTools: text('denied_tools'),
+    additionalEnv: text('additional_env'),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .notNull()
+      .default(sql`(cast(unixepoch() * 1000 as integer))`),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+      .notNull()
+      .default(sql`(cast(unixepoch() * 1000 as integer))`),
+  },
+  (table) => ({
+    userIdIdx: index('idx_agent_settings_user_id').on(table.userId),
+    userAgentTypeUnique: uniqueIndex('idx_agent_settings_user_agent_type').on(
+      table.userId,
+      table.agentType
+    ),
+  })
+);
 
 // =============================================================================
 // UI Governance
 // =============================================================================
-export const uiStandards = sqliteTable('ui_standards', {
-  id: text('id').primaryKey(),
-  version: text('version').notNull().unique(),
-  status: text('status').notNull(),
-  name: text('name').notNull(),
-  visualDirection: text('visual_direction').notNull(),
-  mobileFirstRulesRef: text('mobile_first_rules_ref').notNull(),
-  accessibilityRulesRef: text('accessibility_rules_ref').notNull(),
-  ownerRole: text('owner_role').notNull(),
-  createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-  updatedAt: text('updated_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-}, (table) => ({
-  statusIdx: index('idx_ui_standards_status').on(table.status),
-}));
+export const uiStandards = sqliteTable(
+  'ui_standards',
+  {
+    id: text('id').primaryKey(),
+    version: text('version').notNull().unique(),
+    status: text('status').notNull(),
+    name: text('name').notNull(),
+    visualDirection: text('visual_direction').notNull(),
+    mobileFirstRulesRef: text('mobile_first_rules_ref').notNull(),
+    accessibilityRulesRef: text('accessibility_rules_ref').notNull(),
+    ownerRole: text('owner_role').notNull(),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text('updated_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    statusIdx: index('idx_ui_standards_status').on(table.status),
+  })
+);
 
-export const themeTokens = sqliteTable('theme_tokens', {
-  id: text('id').primaryKey(),
-  standardId: text('standard_id').notNull().references(() => uiStandards.id, { onDelete: 'cascade' }),
-  tokenNamespace: text('token_namespace').notNull(),
-  tokenName: text('token_name').notNull(),
-  tokenValue: text('token_value').notNull(),
-  mode: text('mode').notNull().default('default'),
-  isDeprecated: integer('is_deprecated', { mode: 'boolean' }).notNull().default(false),
-  replacementToken: text('replacement_token'),
-  createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-}, (table) => ({
-  standardIdIdx: index('idx_theme_tokens_standard_id').on(table.standardId),
-}));
+export const themeTokens = sqliteTable(
+  'theme_tokens',
+  {
+    id: text('id').primaryKey(),
+    standardId: text('standard_id')
+      .notNull()
+      .references(() => uiStandards.id, { onDelete: 'cascade' }),
+    tokenNamespace: text('token_namespace').notNull(),
+    tokenName: text('token_name').notNull(),
+    tokenValue: text('token_value').notNull(),
+    mode: text('mode').notNull().default('default'),
+    isDeprecated: integer('is_deprecated', { mode: 'boolean' }).notNull().default(false),
+    replacementToken: text('replacement_token'),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    standardIdIdx: index('idx_theme_tokens_standard_id').on(table.standardId),
+  })
+);
 
-export const componentDefinitions = sqliteTable('component_definitions', {
-  id: text('id').primaryKey(),
-  standardId: text('standard_id').notNull().references(() => uiStandards.id, { onDelete: 'cascade' }),
-  name: text('name').notNull(),
-  category: text('category').notNull(),
-  supportedSurfacesJson: text('supported_surfaces_json').notNull(),
-  requiredStatesJson: text('required_states_json').notNull(),
-  usageGuidance: text('usage_guidance').notNull(),
-  accessibilityNotes: text('accessibility_notes').notNull(),
-  mobileBehavior: text('mobile_behavior').notNull(),
-  desktopBehavior: text('desktop_behavior').notNull(),
-  status: text('status').notNull(),
-  createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-  updatedAt: text('updated_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-}, (table) => ({
-  standardIdIdx: index('idx_component_defs_standard_id').on(table.standardId),
-}));
+export const componentDefinitions = sqliteTable(
+  'component_definitions',
+  {
+    id: text('id').primaryKey(),
+    standardId: text('standard_id')
+      .notNull()
+      .references(() => uiStandards.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    category: text('category').notNull(),
+    supportedSurfacesJson: text('supported_surfaces_json').notNull(),
+    requiredStatesJson: text('required_states_json').notNull(),
+    usageGuidance: text('usage_guidance').notNull(),
+    accessibilityNotes: text('accessibility_notes').notNull(),
+    mobileBehavior: text('mobile_behavior').notNull(),
+    desktopBehavior: text('desktop_behavior').notNull(),
+    status: text('status').notNull(),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text('updated_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    standardIdIdx: index('idx_component_defs_standard_id').on(table.standardId),
+  })
+);
 
-export const complianceChecklists = sqliteTable('compliance_checklists', {
-  id: text('id').primaryKey(),
-  standardId: text('standard_id').notNull().references(() => uiStandards.id, { onDelete: 'cascade' }),
-  version: text('version').notNull(),
-  itemsJson: text('items_json').notNull(),
-  appliesToJson: text('applies_to_json').notNull(),
-  isActive: integer('is_active', { mode: 'boolean' }).notNull().default(false),
-  publishedAt: text('published_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-}, (table) => ({
-  standardIdIdx: index('idx_checklists_standard_id').on(table.standardId),
-}));
+export const complianceChecklists = sqliteTable(
+  'compliance_checklists',
+  {
+    id: text('id').primaryKey(),
+    standardId: text('standard_id')
+      .notNull()
+      .references(() => uiStandards.id, { onDelete: 'cascade' }),
+    version: text('version').notNull(),
+    itemsJson: text('items_json').notNull(),
+    appliesToJson: text('applies_to_json').notNull(),
+    isActive: integer('is_active', { mode: 'boolean' }).notNull().default(false),
+    publishedAt: text('published_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    standardIdIdx: index('idx_checklists_standard_id').on(table.standardId),
+  })
+);
 
-export const agentInstructionSets = sqliteTable('agent_instruction_sets', {
-  id: text('id').primaryKey(),
-  standardId: text('standard_id').notNull().references(() => uiStandards.id, { onDelete: 'cascade' }),
-  version: text('version').notNull(),
-  instructionBlocksJson: text('instruction_blocks_json').notNull(),
-  examplesRef: text('examples_ref'),
-  requiredChecklistVersion: text('required_checklist_version').notNull(),
-  isActive: integer('is_active', { mode: 'boolean' }).notNull().default(false),
-  createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-  updatedAt: text('updated_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-}, (table) => ({
-  standardIdIdx: index('idx_instruction_sets_standard_id').on(table.standardId),
-}));
+export const agentInstructionSets = sqliteTable(
+  'agent_instruction_sets',
+  {
+    id: text('id').primaryKey(),
+    standardId: text('standard_id')
+      .notNull()
+      .references(() => uiStandards.id, { onDelete: 'cascade' }),
+    version: text('version').notNull(),
+    instructionBlocksJson: text('instruction_blocks_json').notNull(),
+    examplesRef: text('examples_ref'),
+    requiredChecklistVersion: text('required_checklist_version').notNull(),
+    isActive: integer('is_active', { mode: 'boolean' }).notNull().default(false),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text('updated_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    standardIdIdx: index('idx_instruction_sets_standard_id').on(table.standardId),
+  })
+);
 
-export const exceptionRequests = sqliteTable('exception_requests', {
-  id: text('id').primaryKey(),
-  standardId: text('standard_id').notNull().references(() => uiStandards.id, { onDelete: 'cascade' }),
-  requestedBy: text('requested_by').notNull(),
-  rationale: text('rationale').notNull(),
-  scope: text('scope').notNull(),
-  expirationDate: text('expiration_date').notNull(),
-  approver: text('approver'),
-  status: text('status').notNull(),
-  createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-  updatedAt: text('updated_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-}, (table) => ({
-  standardIdIdx: index('idx_exception_requests_standard_id').on(table.standardId),
-}));
+export const exceptionRequests = sqliteTable(
+  'exception_requests',
+  {
+    id: text('id').primaryKey(),
+    standardId: text('standard_id')
+      .notNull()
+      .references(() => uiStandards.id, { onDelete: 'cascade' }),
+    requestedBy: text('requested_by').notNull(),
+    rationale: text('rationale').notNull(),
+    scope: text('scope').notNull(),
+    expirationDate: text('expiration_date').notNull(),
+    approver: text('approver'),
+    status: text('status').notNull(),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text('updated_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    standardIdIdx: index('idx_exception_requests_standard_id').on(table.standardId),
+  })
+);
 
-export const complianceRuns = sqliteTable('compliance_runs', {
-  id: text('id').primaryKey(),
-  standardId: text('standard_id').notNull().references(() => uiStandards.id, { onDelete: 'cascade' }),
-  checklistVersion: text('checklist_version').notNull(),
-  authorType: text('author_type').notNull(),
-  changeRef: text('change_ref').notNull(),
-  status: text('status').notNull(),
-  findingsJson: text('findings_json'),
-  reviewedBy: text('reviewed_by'),
-  exceptionRequestId: text('exception_request_id').references(() => exceptionRequests.id, { onDelete: 'set null' }),
-  completedAt: text('completed_at'),
-  createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-}, (table) => ({
-  standardIdIdx: index('idx_compliance_runs_standard_id').on(table.standardId),
-}));
+export const complianceRuns = sqliteTable(
+  'compliance_runs',
+  {
+    id: text('id').primaryKey(),
+    standardId: text('standard_id')
+      .notNull()
+      .references(() => uiStandards.id, { onDelete: 'cascade' }),
+    checklistVersion: text('checklist_version').notNull(),
+    authorType: text('author_type').notNull(),
+    changeRef: text('change_ref').notNull(),
+    status: text('status').notNull(),
+    findingsJson: text('findings_json'),
+    reviewedBy: text('reviewed_by'),
+    exceptionRequestId: text('exception_request_id').references(() => exceptionRequests.id, {
+      onDelete: 'set null',
+    }),
+    completedAt: text('completed_at'),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    standardIdIdx: index('idx_compliance_runs_standard_id').on(table.standardId),
+  })
+);
 
-export const migrationWorkItems = sqliteTable('migration_work_items', {
-  id: text('id').primaryKey(),
-  standardId: text('standard_id').notNull().references(() => uiStandards.id, { onDelete: 'cascade' }),
-  surface: text('surface').notNull(),
-  targetRef: text('target_ref').notNull(),
-  priority: text('priority').notNull(),
-  status: text('status').notNull(),
-  owner: text('owner').notNull(),
-  dueMilestone: text('due_milestone'),
-  notes: text('notes'),
-  createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-  updatedAt: text('updated_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-}, (table) => ({
-  standardIdIdx: index('idx_migration_items_standard_id').on(table.standardId),
-}));
+export const migrationWorkItems = sqliteTable(
+  'migration_work_items',
+  {
+    id: text('id').primaryKey(),
+    standardId: text('standard_id')
+      .notNull()
+      .references(() => uiStandards.id, { onDelete: 'cascade' }),
+    surface: text('surface').notNull(),
+    targetRef: text('target_ref').notNull(),
+    priority: text('priority').notNull(),
+    status: text('status').notNull(),
+    owner: text('owner').notNull(),
+    dueMilestone: text('due_milestone'),
+    notes: text('notes'),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text('updated_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    standardIdIdx: index('idx_migration_items_standard_id').on(table.standardId),
+  })
+);
 
 // Type exports for inference
 export type User = typeof users.$inferSelect;

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -90,6 +90,7 @@ function toAgentSessionResponse(session: schema.AgentSession): AgentSession {
     stoppedAt: session.stoppedAt,
     errorMessage: session.errorMessage,
     label: session.label,
+    worktreePath: session.worktreePath,
   };
 }
 
@@ -605,7 +606,9 @@ workspacesRoutes.post('/:id/rebuild', async (c) => {
     throw errors.badRequest('Workspace is not attached to a node');
   }
   if (workspace.status !== 'running' && workspace.status !== 'error') {
-    throw errors.badRequest(`Workspace must be running or in error state to rebuild, currently ${workspace.status}`);
+    throw errors.badRequest(
+      `Workspace must be running or in error state to rebuild, currently ${workspace.status}`
+    );
   }
 
   const node = await getOwnedNode(db, workspace.nodeId, userId);
@@ -729,6 +732,7 @@ workspacesRoutes.post('/:id/agent-sessions', async (c) => {
     userId,
     status: 'running',
     label: body.label?.trim() || null,
+    worktreePath: body.worktreePath?.trim() || null,
     createdAt: now,
     updatedAt: now,
   });
@@ -903,8 +907,7 @@ workspacesRoutes.post('/:id/provisioning-failed', async (c) => {
   await verifyWorkspaceCallbackAuth(c, workspaceId);
 
   const body = await c.req.json<{ errorMessage?: string }>().catch(() => null);
-  const providedMessage =
-    typeof body?.errorMessage === 'string' ? body.errorMessage.trim() : '';
+  const providedMessage = typeof body?.errorMessage === 'string' ? body.errorMessage.trim() : '';
   const errorMessage = providedMessage || 'Workspace provisioning failed';
 
   const rows = await db
@@ -1002,7 +1005,6 @@ workspacesRoutes.post('/:id/agent-key', async (c) => {
     credentialKind: credentialData.credentialKind,
   });
 });
-
 
 /**
  * POST /:id/agent-settings — VM agent callback to fetch user's agent settings.

--- a/apps/api/tests/integration/multi-workspace-nodes.test.ts
+++ b/apps/api/tests/integration/multi-workspace-nodes.test.ts
@@ -18,4 +18,9 @@ describe('multi-workspace nodes integration wiring', () => {
     expect(workspacesRoute).toContain('stopWorkspaceOnNode');
     expect(nodesRoute).toContain('stopWorkspaceOnNode');
   });
+
+  it('includes worktreePath handling for agent sessions', () => {
+    expect(workspacesRoute).toContain('worktreePath: body.worktreePath?.trim() || null');
+    expect(workspacesRoute).toContain('worktreePath: session.worktreePath');
+  });
 });

--- a/apps/web/src/components/ChatSession.tsx
+++ b/apps/web/src/components/ChatSession.tsx
@@ -1,9 +1,26 @@
-import React, { useState, useEffect, useMemo, useCallback, useRef, useImperativeHandle } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  useRef,
+  useImperativeHandle,
+} from 'react';
 import { useAcpSession, useAcpMessages, AgentPanel } from '@simple-agent-manager/acp-client';
-import type { AgentPanelHandle, ChatSettingsData, AcpLifecycleEvent, TokenUsage } from '@simple-agent-manager/acp-client';
+import type {
+  AgentPanelHandle,
+  ChatSettingsData,
+  AcpLifecycleEvent,
+  TokenUsage,
+} from '@simple-agent-manager/acp-client';
 import type { AgentInfo } from '@simple-agent-manager/shared';
 import { VALID_PERMISSION_MODES, AGENT_PERMISSION_MODE_LABELS } from '@simple-agent-manager/shared';
-import { getTerminalToken, getTranscribeApiUrl, getAgentSettings, saveAgentSettings } from '../lib/api';
+import {
+  getTerminalToken,
+  getTranscribeApiUrl,
+  getAgentSettings,
+  saveAgentSettings,
+} from '../lib/api';
 import { reportError } from '../lib/error-reporter';
 
 interface ChatSessionProps {
@@ -15,6 +32,8 @@ interface ChatSessionProps {
   sessionId: string;
   /** Preferred agent type for this session */
   preferredAgentId?: string;
+  /** Bound worktree path for this chat session */
+  worktreePath?: string | null;
   /** All configured agents */
   configuredAgents: AgentInfo[];
   /** Whether this tab is currently visible */
@@ -33,266 +52,282 @@ export type ChatSessionHandle = AgentPanelHandle;
  * Each instance owns its own ACP WebSocket connection, message history,
  * and agent selection — fully independent of other chat tabs.
  */
-export const ChatSession = React.forwardRef<ChatSessionHandle, ChatSessionProps>(function ChatSession({
-  workspaceId,
-  workspaceUrl,
-  sessionId,
-  preferredAgentId,
-  active,
-  onActivity,
-  onUsageChange,
-}, ref) {
-  const agentPanelRef = useRef<AgentPanelHandle>(null);
-
-  useImperativeHandle(ref, () => ({
-    focusInput: () => agentPanelRef.current?.focusInput(),
-  }));
-  const [resolvedWsUrl, setResolvedWsUrl] = useState<string | null>(null);
-
-  // Resolve transcription API URL once (stable across renders)
-  const transcribeApiUrl = useMemo(() => getTranscribeApiUrl(), []);
-
-  // Parse workspace URL once
-  const wsHostInfo = useMemo(() => {
-    if (!workspaceUrl) return null;
-    try {
-      const url = new URL(workspaceUrl);
-      const wsProtocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
-      return `${wsProtocol}//${url.host}`;
-    } catch {
-      return null;
-    }
-  }, [workspaceUrl]);
-
-  // Lifecycle event callback — routes ACP lifecycle events to the error reporter
-  // for CF Workers observability. Enriches with workspaceId/sessionId context.
-  const handleLifecycleEvent = useCallback(
-    (event: AcpLifecycleEvent) => {
-      reportError({
-        level: event.level,
-        message: event.message,
-        source: event.source,
-        context: {
-          ...event.context,
-          workspaceId,
-          sessionId,
-        },
-      });
+export const ChatSession = React.forwardRef<ChatSessionHandle, ChatSessionProps>(
+  function ChatSession(
+    {
+      workspaceId,
+      workspaceUrl,
+      sessionId,
+      preferredAgentId,
+      worktreePath,
+      active,
+      onActivity,
+      onUsageChange,
     },
-    [workspaceId, sessionId]
-  );
+    ref
+  ) {
+    const agentPanelRef = useRef<AgentPanelHandle>(null);
 
-  // Fetch token and build full WS URL
-  useEffect(() => {
-    if (!wsHostInfo) {
-      setResolvedWsUrl(null);
-      return;
-    }
+    useImperativeHandle(ref, () => ({
+      focusInput: () => agentPanelRef.current?.focusInput(),
+    }));
+    const [resolvedWsUrl, setResolvedWsUrl] = useState<string | null>(null);
 
-    let cancelled = false;
+    // Resolve transcription API URL once (stable across renders)
+    const transcribeApiUrl = useMemo(() => getTranscribeApiUrl(), []);
 
-    const fetchToken = async () => {
-      reportError({
-        level: 'info',
-        message: 'Fetching terminal token',
-        source: 'acp-chat',
-        context: { workspaceId, sessionId },
-      });
-
+    // Parse workspace URL once
+    const wsHostInfo = useMemo(() => {
+      if (!workspaceUrl) return null;
       try {
-        const { token } = await getTerminalToken(workspaceId);
-        if (cancelled) return;
+        const url = new URL(workspaceUrl);
+        const wsProtocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+        return `${wsProtocol}//${url.host}`;
+      } catch {
+        return null;
+      }
+    }, [workspaceUrl]);
 
+    // Lifecycle event callback — routes ACP lifecycle events to the error reporter
+    // for CF Workers observability. Enriches with workspaceId/sessionId context.
+    const handleLifecycleEvent = useCallback(
+      (event: AcpLifecycleEvent) => {
+        reportError({
+          level: event.level,
+          message: event.message,
+          source: event.source,
+          context: {
+            ...event.context,
+            workspaceId,
+            sessionId,
+          },
+        });
+      },
+      [workspaceId, sessionId]
+    );
+
+    // Fetch token and build full WS URL
+    useEffect(() => {
+      if (!wsHostInfo) {
+        setResolvedWsUrl(null);
+        return;
+      }
+
+      let cancelled = false;
+
+      const fetchToken = async () => {
         reportError({
           level: 'info',
-          message: 'Terminal token fetched',
-          source: 'acp-chat',
-          context: { workspaceId, sessionId, tokenLength: token.length },
-        });
-
-        const sessionQuery = `&sessionId=${encodeURIComponent(sessionId)}`;
-        setResolvedWsUrl(
-          `${wsHostInfo}/agent/ws?token=${encodeURIComponent(token)}${sessionQuery}`
-        );
-      } catch (err) {
-        if (cancelled) return;
-        reportError({
-          level: 'error',
-          message: `Terminal token fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+          message: 'Fetching terminal token',
           source: 'acp-chat',
           context: { workspaceId, sessionId },
         });
+
+        try {
+          const { token } = await getTerminalToken(workspaceId);
+          if (cancelled) return;
+
+          reportError({
+            level: 'info',
+            message: 'Terminal token fetched',
+            source: 'acp-chat',
+            context: { workspaceId, sessionId, tokenLength: token.length },
+          });
+
+          const sessionQuery = `&sessionId=${encodeURIComponent(sessionId)}`;
+          const worktreeQuery = worktreePath ? `&worktree=${encodeURIComponent(worktreePath)}` : '';
+          setResolvedWsUrl(
+            `${wsHostInfo}/agent/ws?token=${encodeURIComponent(token)}${sessionQuery}${worktreeQuery}`
+          );
+        } catch (err) {
+          if (cancelled) return;
+          reportError({
+            level: 'error',
+            message: `Terminal token fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+            source: 'acp-chat',
+            context: { workspaceId, sessionId },
+          });
+        }
+      };
+
+      void fetchToken();
+      return () => {
+        cancelled = true;
+      };
+    }, [wsHostInfo, workspaceId, sessionId, worktreePath]);
+
+    // Each chat session gets its own message store.
+    // No client-side persistence — on reconnect, LoadSession replays the full
+    // conversation from the agent via session/update notifications.
+    const acpMessages = useAcpMessages();
+
+    // Own ACP session hook — separate WebSocket per chat tab
+    const acpSession = useAcpSession({
+      wsUrl: resolvedWsUrl,
+      onAcpMessage: acpMessages.processMessage,
+      onLifecycleEvent: handleLifecycleEvent,
+      onPrepareForReplay: acpMessages.prepareForReplay,
+    });
+
+    const { connected, agentType, state, switchAgent } = acpSession;
+    const { clear: clearMessages } = acpMessages;
+
+    // Clear messages when no agent session exists (idle SessionHost).
+    // Replay clearing is now handled synchronously by onPrepareForReplay
+    // (called from useAcpSession when session_state arrives with replayCount > 0)
+    // which avoids the race where this useEffect fires after replay messages
+    // have already been appended.
+    useEffect(() => {
+      if (state === 'no_session') {
+        reportError({
+          level: 'info',
+          message: 'Clearing messages on no_session',
+          source: 'acp-chat',
+          context: { workspaceId, sessionId },
+        });
+        clearMessages();
       }
-    };
+    }, [state, clearMessages, workspaceId, sessionId]);
 
-    void fetchToken();
-    return () => {
-      cancelled = true;
-    };
-  }, [wsHostInfo, workspaceId, sessionId]);
+    // Auto-select preferred agent when connected.
+    // Skip if the server's session_state already indicates the agent is running
+    // (e.g., reconnecting to a session where the agent kept working).
+    useEffect(() => {
+      if (!preferredAgentId) return;
+      if (!connected) return;
+      if (agentType === preferredAgentId) return;
+      // Don't send select_agent while still connecting, reconnecting, initializing,
+      // or replaying buffered messages from a running session.
+      if (
+        state === 'connecting' ||
+        state === 'reconnecting' ||
+        state === 'initializing' ||
+        state === 'replaying'
+      )
+        return;
 
-  // Each chat session gets its own message store.
-  // No client-side persistence — on reconnect, LoadSession replays the full
-  // conversation from the agent via session/update notifications.
-  const acpMessages = useAcpMessages();
-
-  // Own ACP session hook — separate WebSocket per chat tab
-  const acpSession = useAcpSession({
-    wsUrl: resolvedWsUrl,
-    onAcpMessage: acpMessages.processMessage,
-    onLifecycleEvent: handleLifecycleEvent,
-    onPrepareForReplay: acpMessages.prepareForReplay,
-  });
-
-  const { connected, agentType, state, switchAgent } = acpSession;
-  const { clear: clearMessages } = acpMessages;
-
-  // Clear messages when no agent session exists (idle SessionHost).
-  // Replay clearing is now handled synchronously by onPrepareForReplay
-  // (called from useAcpSession when session_state arrives with replayCount > 0)
-  // which avoids the race where this useEffect fires after replay messages
-  // have already been appended.
-  useEffect(() => {
-    if (state === 'no_session') {
       reportError({
         level: 'info',
-        message: 'Clearing messages on no_session',
+        message: `Auto-selecting agent: ${preferredAgentId}`,
         source: 'acp-chat',
-        context: { workspaceId, sessionId },
+        context: { workspaceId, sessionId, preferredAgentId, currentAgentType: agentType, state },
       });
-      clearMessages();
-    }
-  }, [state, clearMessages, workspaceId, sessionId]);
+      switchAgent(preferredAgentId);
+    }, [preferredAgentId, connected, agentType, state, switchAgent, workspaceId, sessionId]);
 
-  // Auto-select preferred agent when connected.
-  // Skip if the server's session_state already indicates the agent is running
-  // (e.g., reconnecting to a session where the agent kept working).
-  useEffect(() => {
-    if (!preferredAgentId) return;
-    if (!connected) return;
-    if (agentType === preferredAgentId) return;
-    // Don't send select_agent while still connecting, reconnecting, initializing,
-    // or replaying buffered messages from a running session.
-    if (state === 'connecting' || state === 'reconnecting' || state === 'initializing' || state === 'replaying') return;
+    // Report activity
+    const handleActivity = useCallback(() => {
+      onActivity?.();
+    }, [onActivity]);
 
-    reportError({
-      level: 'info',
-      message: `Auto-selecting agent: ${preferredAgentId}`,
-      source: 'acp-chat',
-      context: { workspaceId, sessionId, preferredAgentId, currentAgentType: agentType, state },
-    });
-    switchAgent(preferredAgentId);
-  }, [preferredAgentId, connected, agentType, state, switchAgent, workspaceId, sessionId]);
+    useEffect(() => {
+      if (acpMessages.items.length > 0) {
+        handleActivity();
+      }
+    }, [acpMessages.items.length, handleActivity]);
 
-  // Report activity
-  const handleActivity = useCallback(() => {
-    onActivity?.();
-  }, [onActivity]);
+    // Report token usage changes to parent for sidebar aggregation
+    useEffect(() => {
+      if (acpMessages.usage.totalTokens > 0) {
+        onUsageChange?.(sessionId, acpMessages.usage);
+      }
+    }, [acpMessages.usage, sessionId, onUsageChange]);
 
-  useEffect(() => {
-    if (acpMessages.items.length > 0) {
-      handleActivity();
-    }
-  }, [acpMessages.items.length, handleActivity]);
+    // ── Agent settings ──
+    const [agentSettings, setAgentSettings] = useState<ChatSettingsData | null>(null);
+    const [agentSettingsLoading, setAgentSettingsLoading] = useState(false);
 
-  // Report token usage changes to parent for sidebar aggregation
-  useEffect(() => {
-    if (acpMessages.usage.totalTokens > 0) {
-      onUsageChange?.(sessionId, acpMessages.usage);
-    }
-  }, [acpMessages.usage, sessionId, onUsageChange]);
+    // Build permission mode options from shared constants
+    const permissionModes = useMemo(
+      () =>
+        VALID_PERMISSION_MODES.map((mode) => ({
+          value: mode,
+          label: AGENT_PERMISSION_MODE_LABELS[mode] ?? mode,
+        })),
+      []
+    );
 
-  // ── Agent settings ──
-  const [agentSettings, setAgentSettings] = useState<ChatSettingsData | null>(null);
-  const [agentSettingsLoading, setAgentSettingsLoading] = useState(false);
+    // Fetch settings when agent type is known
+    const activeAgentType = agentType ?? preferredAgentId;
+    useEffect(() => {
+      if (!activeAgentType) return;
+      let cancelled = false;
+      setAgentSettingsLoading(true);
 
-  // Build permission mode options from shared constants
-  const permissionModes = useMemo(
-    () =>
-      VALID_PERMISSION_MODES.map((mode) => ({
-        value: mode,
-        label: AGENT_PERMISSION_MODE_LABELS[mode] ?? mode,
-      })),
-    []
-  );
+      getAgentSettings(activeAgentType)
+        .then((result) => {
+          if (cancelled) return;
+          setAgentSettings({
+            model: result.model,
+            permissionMode: result.permissionMode,
+          });
+        })
+        .catch(() => {
+          if (cancelled) return;
+          // No saved settings — use defaults
+          setAgentSettings({ model: null, permissionMode: null });
+        })
+        .finally(() => {
+          if (!cancelled) setAgentSettingsLoading(false);
+        });
 
-  // Fetch settings when agent type is known
-  const activeAgentType = agentType ?? preferredAgentId;
-  useEffect(() => {
-    if (!activeAgentType) return;
-    let cancelled = false;
-    setAgentSettingsLoading(true);
+      return () => {
+        cancelled = true;
+      };
+    }, [activeAgentType]);
 
-    getAgentSettings(activeAgentType)
-      .then((result) => {
-        if (cancelled) return;
+    const handleSaveSettings = useCallback(
+      async (data: { model?: string | null; permissionMode?: string | null }) => {
+        if (!activeAgentType) return;
+        const result = await saveAgentSettings(activeAgentType, {
+          model: data.model,
+          permissionMode: data.permissionMode as
+            | import('@simple-agent-manager/shared').AgentPermissionMode
+            | null
+            | undefined,
+        });
         setAgentSettings({
           model: result.model,
           permissionMode: result.permissionMode,
         });
-      })
-      .catch(() => {
-        if (cancelled) return;
-        // No saved settings — use defaults
-        setAgentSettings({ model: null, permissionMode: null });
-      })
-      .finally(() => {
-        if (!cancelled) setAgentSettingsLoading(false);
-      });
+      },
+      [activeAgentType]
+    );
 
-    return () => {
-      cancelled = true;
-    };
-  }, [activeAgentType]);
+    const handleError = useCallback(
+      (info: { message: string; source: string; context?: Record<string, unknown> }) => {
+        reportError({
+          level: 'error',
+          message: info.message,
+          source: info.source,
+          context: info.context,
+        });
+      },
+      []
+    );
 
-  const handleSaveSettings = useCallback(
-    async (data: { model?: string | null; permissionMode?: string | null }) => {
-      if (!activeAgentType) return;
-      const result = await saveAgentSettings(activeAgentType, {
-        model: data.model,
-        permissionMode: data.permissionMode as import('@simple-agent-manager/shared').AgentPermissionMode | null | undefined,
-      });
-      setAgentSettings({
-        model: result.model,
-        permissionMode: result.permissionMode,
-      });
-    },
-    [activeAgentType]
-  );
-
-  const handleError = useCallback(
-    (info: { message: string; source: string; context?: Record<string, unknown> }) => {
-      reportError({
-        level: 'error',
-        message: info.message,
-        source: info.source,
-        context: info.context,
-      });
-    },
-    []
-  );
-
-  return (
-    <div
-      style={{
-        height: '100%',
-        overflow: 'hidden',
-        display: active ? 'flex' : 'none',
-        flexDirection: 'column',
-      }}
-    >
-      <AgentPanel
-        ref={agentPanelRef}
-        session={acpSession}
-        messages={acpMessages}
-        availableCommands={acpMessages.availableCommands}
-        transcribeApiUrl={transcribeApiUrl}
-        agentSettings={agentSettings}
-        agentSettingsLoading={agentSettingsLoading}
-        permissionModes={permissionModes}
-        onSaveSettings={handleSaveSettings}
-        onError={handleError}
-      />
-    </div>
-  );
-});
+    return (
+      <div
+        style={{
+          height: '100%',
+          overflow: 'hidden',
+          display: active ? 'flex' : 'none',
+          flexDirection: 'column',
+        }}
+      >
+        <AgentPanel
+          ref={agentPanelRef}
+          session={acpSession}
+          messages={acpMessages}
+          availableCommands={acpMessages.availableCommands}
+          transcribeApiUrl={transcribeApiUrl}
+          agentSettings={agentSettings}
+          agentSettingsLoading={agentSettingsLoading}
+          permissionModes={permissionModes}
+          onSaveSettings={handleSaveSettings}
+          onError={handleError}
+        />
+      </div>
+    );
+  }
+);

--- a/apps/web/src/components/FileViewerPanel.tsx
+++ b/apps/web/src/components/FileViewerPanel.tsx
@@ -8,6 +8,7 @@ interface FileViewerPanelProps {
   workspaceUrl: string;
   workspaceId: string;
   token: string;
+  worktree?: string | null;
   filePath: string;
   isMobile: boolean;
   /** If the file has git changes, show a "View Diff" button */
@@ -74,6 +75,7 @@ export const FileViewerPanel: FC<FileViewerPanelProps> = ({
   workspaceUrl,
   workspaceId,
   token,
+  worktree,
   filePath,
   isMobile,
   hasGitChanges,
@@ -90,14 +92,21 @@ export const FileViewerPanel: FC<FileViewerPanelProps> = ({
     setLoading(true);
     setError(null);
     try {
-      const result = await getGitFile(workspaceUrl, workspaceId, token, filePath);
+      const result = await getGitFile(
+        workspaceUrl,
+        workspaceId,
+        token,
+        filePath,
+        undefined,
+        worktree ?? undefined
+      );
       setContent(result.content);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load file');
     } finally {
       setLoading(false);
     }
-  }, [workspaceUrl, workspaceId, token, filePath]);
+  }, [workspaceUrl, workspaceId, token, filePath, worktree]);
 
   useEffect(() => {
     fetchFile();
@@ -139,18 +148,19 @@ export const FileViewerPanel: FC<FileViewerPanelProps> = ({
     <div style={overlayStyle}>
       {/* Header */}
       <header style={headerStyle}>
-        <button
-          onClick={onBack}
-          aria-label="Back to file list"
-          style={iconBtnStyle(isMobile)}
-        >
+        <button onClick={onBack} aria-label="Back to file list" style={iconBtnStyle(isMobile)}>
           <svg
             style={{ height: isMobile ? 18 : 16, width: isMobile ? 18 : 16 }}
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
           >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
           </svg>
         </button>
 
@@ -189,11 +199,7 @@ export const FileViewerPanel: FC<FileViewerPanelProps> = ({
           </button>
         )}
 
-        <button
-          onClick={onClose}
-          aria-label="Close"
-          style={iconBtnStyle(isMobile)}
-        >
+        <button onClick={onClose} aria-label="Close" style={iconBtnStyle(isMobile)}>
           <X size={isMobile ? 18 : 16} />
         </button>
       </header>
@@ -250,11 +256,7 @@ const SyntaxHighlightedCode: FC<{ content: string; language: string }> = ({
   language,
 }) => {
   return (
-    <Highlight
-      theme={themes.nightOwl}
-      code={content}
-      language={language || 'text'}
-    >
+    <Highlight theme={themes.nightOwl} code={content} language={language || 'text'}>
       {({ tokens, getLineProps, getTokenProps }) => (
         <pre
           style={{

--- a/apps/web/src/components/GitChangesPanel.tsx
+++ b/apps/web/src/components/GitChangesPanel.tsx
@@ -7,6 +7,7 @@ interface GitChangesPanelProps {
   workspaceUrl: string;
   workspaceId: string;
   token: string;
+  worktree?: string | null;
   isMobile: boolean;
   onClose: () => void;
   onSelectFile: (filePath: string, staged: boolean) => void;
@@ -44,6 +45,7 @@ export const GitChangesPanel: FC<GitChangesPanelProps> = ({
   workspaceUrl,
   workspaceId,
   token,
+  worktree,
   isMobile,
   onClose,
   onSelectFile,
@@ -61,14 +63,14 @@ export const GitChangesPanel: FC<GitChangesPanelProps> = ({
     setLoading(true);
     setError(null);
     try {
-      const result = await getGitStatus(workspaceUrl, workspaceId, token);
+      const result = await getGitStatus(workspaceUrl, workspaceId, token, worktree ?? undefined);
       setData(result);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch git status');
     } finally {
       setLoading(false);
     }
-  }, [workspaceUrl, workspaceId, token]);
+  }, [workspaceUrl, workspaceId, token, worktree]);
 
   useEffect(() => {
     fetchStatus();
@@ -86,9 +88,7 @@ export const GitChangesPanel: FC<GitChangesPanelProps> = ({
     setExpandedSections((prev) => ({ ...prev, [section]: !prev[section] }));
   };
 
-  const totalChanges = data
-    ? data.staged.length + data.unstaged.length + data.untracked.length
-    : 0;
+  const totalChanges = data ? data.staged.length + data.unstaged.length + data.untracked.length : 0;
 
   const overlayStyle: CSSProperties = {
     position: 'fixed',
@@ -114,18 +114,19 @@ export const GitChangesPanel: FC<GitChangesPanelProps> = ({
     <div style={overlayStyle}>
       {/* Header */}
       <header style={headerStyle}>
-        <button
-          onClick={onClose}
-          aria-label="Close git changes"
-          style={iconButtonStyle(isMobile)}
-        >
+        <button onClick={onClose} aria-label="Close git changes" style={iconButtonStyle(isMobile)}>
           <svg
             style={{ height: isMobile ? 18 : 16, width: isMobile ? 18 : 16 }}
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
           >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
           </svg>
         </button>
 
@@ -154,14 +155,13 @@ export const GitChangesPanel: FC<GitChangesPanelProps> = ({
             opacity: loading ? 0.5 : 1,
           }}
         >
-          <RefreshCw size={isMobile ? 16 : 14} style={loading ? { animation: 'spin 1s linear infinite' } : undefined} />
+          <RefreshCw
+            size={isMobile ? 16 : 14}
+            style={loading ? { animation: 'spin 1s linear infinite' } : undefined}
+          />
         </button>
 
-        <button
-          onClick={onClose}
-          aria-label="Close"
-          style={iconButtonStyle(isMobile)}
-        >
+        <button onClick={onClose} aria-label="Close" style={iconButtonStyle(isMobile)}>
           <X size={isMobile ? 18 : 16} />
         </button>
       </header>
@@ -409,9 +409,7 @@ const FileRow: FC<FileRowProps> = ({ file, onClick, isMobile }) => {
           minWidth: 0,
         }}
       >
-        {dir && (
-          <span style={{ color: 'var(--sam-color-fg-muted)' }}>{dir}</span>
-        )}
+        {dir && <span style={{ color: 'var(--sam-color-fg-muted)' }}>{dir}</span>}
         {name}
       </span>
       {file.oldPath && (

--- a/apps/web/src/components/WorkspaceTabStrip.tsx
+++ b/apps/web/src/components/WorkspaceTabStrip.tsx
@@ -10,11 +10,7 @@ import {
   type DragStartEvent,
   type DragEndEvent,
 } from '@dnd-kit/core';
-import {
-  SortableContext,
-  horizontalListSortingStrategy,
-  useSortable,
-} from '@dnd-kit/sortable';
+import { SortableContext, horizontalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
 export interface WorkspaceTabItem {
@@ -23,6 +19,7 @@ export interface WorkspaceTabItem {
   sessionId: string;
   title: string;
   statusColor: string;
+  badge?: string;
 }
 
 interface WorkspaceTabStripProps {
@@ -241,9 +238,7 @@ export function WorkspaceTabStrip({
         </SortableContext>
 
         <DragOverlay>
-          {dragActiveTab ? (
-            <DragOverlayTab tab={dragActiveTab} isMobile={isMobile} />
-          ) : null}
+          {dragActiveTab ? <DragOverlayTab tab={dragActiveTab} isMobile={isMobile} /> : null}
         </DragOverlay>
       </DndContext>
 
@@ -297,14 +292,10 @@ function SortableTabWrapper({
   onEditKeyDown,
   onEditBlur,
 }: SortableTabWrapperProps) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id: tab.id, disabled: dragDisabled });
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: tab.id,
+    disabled: dragDisabled,
+  });
 
   const sortableStyle = {
     transform: CSS.Transform.toString(transform),
@@ -420,14 +411,39 @@ function SortableTabWrapper({
       ) : (
         <span
           style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
             flex: 1,
             minWidth: 0,
             overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
           }}
         >
-          {tab.title}
+          <span
+            style={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {tab.title}
+          </span>
+          {tab.badge && (
+            <span
+              style={{
+                fontSize: 10,
+                lineHeight: 1,
+                border: '1px solid #33467c',
+                borderRadius: 6,
+                padding: '2px 5px',
+                color: '#7aa2f7',
+                whiteSpace: 'nowrap',
+                flexShrink: 0,
+              }}
+            >
+              {tab.badge}
+            </span>
+          )}
         </span>
       )}
 

--- a/apps/web/src/components/WorktreeSelector.tsx
+++ b/apps/web/src/components/WorktreeSelector.tsx
@@ -1,0 +1,231 @@
+import { useMemo, useState } from 'react';
+import type { WorktreeInfo } from '@simple-agent-manager/shared';
+
+interface WorktreeSelectorProps {
+  worktrees: WorktreeInfo[];
+  activeWorktree: string | null;
+  loading?: boolean;
+  onSelect: (worktreePath: string | null) => void;
+  onCreate: (request: {
+    branch: string;
+    createBranch: boolean;
+    baseBranch?: string;
+  }) => Promise<void>;
+  onRemove: (path: string, force: boolean) => Promise<void>;
+}
+
+function worktreeLabel(worktree: WorktreeInfo): string {
+  if (worktree.branch && !/^[0-9a-f]{7,40}$/i.test(worktree.branch)) {
+    return worktree.branch;
+  }
+  return worktree.headCommit || worktree.branch || 'detached';
+}
+
+export function WorktreeSelector({
+  worktrees,
+  activeWorktree,
+  loading = false,
+  onSelect,
+  onCreate,
+  onRemove,
+}: WorktreeSelectorProps) {
+  const [open, setOpen] = useState(false);
+  const [branch, setBranch] = useState('');
+  const [createBranch, setCreateBranch] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const active = useMemo(
+    () =>
+      worktrees.find((w) => w.path === activeWorktree) ??
+      worktrees.find((w) => w.isPrimary) ??
+      null,
+    [activeWorktree, worktrees]
+  );
+
+  const handleCreate = async () => {
+    const nextBranch = branch.trim();
+    if (!nextBranch) return;
+    try {
+      setBusy(true);
+      setError(null);
+      await onCreate({ branch: nextBranch, createBranch });
+      setBranch('');
+      setCreateBranch(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create worktree');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRemove = async (worktree: WorktreeInfo) => {
+    if (worktree.isPrimary) return;
+    const force = worktree.isDirty
+      ? window.confirm(`Worktree has ${worktree.dirtyFileCount} dirty files. Force remove?`)
+      : window.confirm(`Remove worktree '${worktreeLabel(worktree)}'?`);
+    if (!force && worktree.isDirty) return;
+    if (!worktree.isDirty && !window.confirm(`Confirm remove '${worktreeLabel(worktree)}'.`))
+      return;
+
+    try {
+      setBusy(true);
+      setError(null);
+      await onRemove(worktree.path, worktree.isDirty ? true : false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to remove worktree');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <button
+        id="worktree-selector-trigger"
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        disabled={loading || busy}
+        style={{
+          minHeight: 56,
+          borderRadius: 10,
+          border: '1px solid var(--sam-color-border-default)',
+          background: 'var(--sam-color-bg-surface)',
+          color: 'var(--sam-color-fg-primary)',
+          padding: '0 14px',
+          fontSize: 13,
+          cursor: 'pointer',
+        }}
+      >
+        Worktree: {active ? worktreeLabel(active) : 'primary'}
+      </button>
+
+      {open && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '100%',
+            right: 0,
+            zIndex: 80,
+            width: 320,
+            marginTop: 8,
+            borderRadius: 10,
+            border: '1px solid var(--sam-color-border-default)',
+            background: 'var(--sam-color-bg-surface)',
+            padding: 10,
+            maxHeight: 420,
+            overflow: 'auto',
+          }}
+        >
+          <div style={{ display: 'grid', gap: 6 }}>
+            {worktrees.map((wt) => (
+              <div
+                key={wt.path}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 8,
+                }}
+              >
+                <button
+                  type="button"
+                  onClick={() => {
+                    onSelect(wt.isPrimary ? null : wt.path);
+                    setOpen(false);
+                  }}
+                  style={{
+                    flex: 1,
+                    textAlign: 'left',
+                    minHeight: 44,
+                    borderRadius: 8,
+                    border: '1px solid var(--sam-color-border-default)',
+                    background:
+                      wt.path === activeWorktree || (wt.isPrimary && !activeWorktree)
+                        ? 'var(--sam-color-accent-primary)'
+                        : 'transparent',
+                    color:
+                      wt.path === activeWorktree || (wt.isPrimary && !activeWorktree)
+                        ? '#fff'
+                        : 'var(--sam-color-fg-primary)',
+                    padding: '8px 10px',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {worktreeLabel(wt)} {wt.isPrimary ? '(primary)' : ''}{' '}
+                  {wt.isPrunable ? '(prunable)' : ''}
+                </button>
+                {!wt.isPrimary && (
+                  <button
+                    type="button"
+                    onClick={() => void handleRemove(wt)}
+                    style={{
+                      minHeight: 44,
+                      borderRadius: 8,
+                      border: '1px solid #f7768e',
+                      color: '#f7768e',
+                      background: 'transparent',
+                      padding: '0 10px',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+
+          <div
+            style={{
+              marginTop: 10,
+              borderTop: '1px solid var(--sam-color-border-default)',
+              paddingTop: 10,
+            }}
+          >
+            <div style={{ display: 'grid', gap: 8 }}>
+              <input
+                value={branch}
+                onChange={(e) => setBranch(e.target.value)}
+                placeholder="branch name"
+                style={{
+                  minHeight: 44,
+                  borderRadius: 8,
+                  border: '1px solid var(--sam-color-border-default)',
+                  background: 'var(--sam-color-bg-canvas)',
+                  color: 'var(--sam-color-fg-primary)',
+                  padding: '0 10px',
+                }}
+              />
+              <label style={{ display: 'flex', gap: 8, alignItems: 'center', fontSize: 12 }}>
+                <input
+                  type="checkbox"
+                  checked={createBranch}
+                  onChange={(e) => setCreateBranch(e.target.checked)}
+                />
+                Create new branch
+              </label>
+              <button
+                type="button"
+                onClick={() => void handleCreate()}
+                disabled={busy || !branch.trim()}
+                style={{
+                  minHeight: 56,
+                  borderRadius: 8,
+                  border: 'none',
+                  background: 'var(--sam-color-accent-primary)',
+                  color: '#fff',
+                  cursor: 'pointer',
+                  fontWeight: 600,
+                }}
+              >
+                New Worktree
+              </button>
+            </div>
+            {error && <div style={{ marginTop: 8, color: '#f7768e', fontSize: 12 }}>{error}</div>}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/keyboard-shortcuts.ts
+++ b/apps/web/src/lib/keyboard-shortcuts.ts
@@ -24,8 +24,7 @@ export interface ShortcutDefinition {
 
 /** Detect macOS once at module load */
 const IS_MAC =
-  typeof navigator !== 'undefined' &&
-  /mac/i.test(navigator.platform ?? navigator.userAgent ?? '');
+  typeof navigator !== 'undefined' && /mac/i.test(navigator.platform ?? navigator.userAgent ?? '');
 
 /**
  * Returns the platform-appropriate modifier symbol.
@@ -115,6 +114,13 @@ export const SHORTCUTS: ShortcutDefinition[] = [
     key: '`',
     modifiers: { meta: true },
     description: 'Focus terminal',
+    category: 'Navigation',
+  },
+  {
+    id: 'switch-worktree',
+    key: 'w',
+    modifiers: { meta: true, shift: true },
+    description: 'Switch worktree',
     category: 'Navigation',
   },
 

--- a/apps/web/tests/unit/components/git-diff-view.test.tsx
+++ b/apps/web/tests/unit/components/git-diff-view.test.tsx
@@ -135,6 +135,8 @@ app.listen(3000);`,
         defaultProps.workspaceId,
         defaultProps.token,
         defaultProps.filePath,
+        undefined,
+        undefined,
       );
     });
   });
@@ -163,6 +165,7 @@ app.listen(3000);`,
         defaultProps.token,
         defaultProps.filePath,
         true,
+        undefined,
       );
     });
   });

--- a/apps/web/tests/unit/components/workspace-tab-strip.test.tsx
+++ b/apps/web/tests/unit/components/workspace-tab-strip.test.tsx
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { WorkspaceTabStrip, type WorkspaceTabItem } from '../../../src/components/WorkspaceTabStrip';
+import {
+  WorkspaceTabStrip,
+  type WorkspaceTabItem,
+} from '../../../src/components/WorkspaceTabStrip';
 
 function makeTabs(...specs: Array<[string, string, 'terminal' | 'chat']>): WorkspaceTabItem[] {
   return specs.map(([id, title, kind]) => ({
@@ -64,9 +67,7 @@ describe('WorkspaceTabStrip', () => {
     fireEvent.click(screen.getByText('Claude Code 1'));
 
     expect(defaultProps.onSelect).toHaveBeenCalledTimes(1);
-    expect(defaultProps.onSelect).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'chat:c1' })
-    );
+    expect(defaultProps.onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 'chat:c1' }));
   });
 
   it('calls onSelect when Enter is pressed on a tab', () => {
@@ -88,9 +89,7 @@ describe('WorkspaceTabStrip', () => {
   });
 
   it('does not render close button for unclosable tab', () => {
-    render(
-      <WorkspaceTabStrip {...defaultProps} unclosableTabId="terminal:t1" />
-    );
+    render(<WorkspaceTabStrip {...defaultProps} unclosableTabId="terminal:t1" />);
 
     // The terminal tab should not have a close button
     const closeButtons = screen.queryAllByRole('button', { name: /Close Terminal 1/ });
@@ -210,6 +209,19 @@ describe('WorkspaceTabStrip', () => {
     // Each tab should have a status dot (●)
     const dots = screen.getAllByText('●');
     expect(dots).toHaveLength(3);
+  });
+
+  it('renders worktree badges when provided', () => {
+    const tabsWithBadges: WorkspaceTabItem[] = [
+      { ...defaultTabs[0]!, badge: 'main' },
+      { ...defaultTabs[1]!, badge: 'feature-auth' },
+      defaultTabs[2]!,
+    ];
+
+    render(<WorkspaceTabStrip {...defaultProps} tabs={tabsWithBadges} />);
+
+    expect(screen.getByText('main')).toBeInTheDocument();
+    expect(screen.getByText('feature-auth')).toBeInTheDocument();
   });
 
   it('has correct tablist role on the container', () => {

--- a/apps/web/tests/unit/components/worktree-selector.test.tsx
+++ b/apps/web/tests/unit/components/worktree-selector.test.tsx
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { WorktreeSelector } from '../../../src/components/WorktreeSelector';
+
+describe('WorktreeSelector', () => {
+  const baseWorktrees = [
+    {
+      path: '/workspaces/repo',
+      branch: 'main',
+      headCommit: 'abc1234',
+      isPrimary: true,
+      isDirty: false,
+      dirtyFileCount: 0,
+    },
+    {
+      path: '/workspaces/repo-wt-feature-auth',
+      branch: 'feature/auth',
+      headCommit: 'def5678',
+      isPrimary: false,
+      isDirty: true,
+      dirtyFileCount: 3,
+    },
+  ];
+
+  const props = {
+    worktrees: baseWorktrees,
+    activeWorktree: null as string | null,
+    onSelect: vi.fn(),
+    onCreate: vi.fn().mockResolvedValue(undefined),
+    onRemove: vi.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  it('renders current active worktree label', () => {
+    render(<WorktreeSelector {...props} />);
+    expect(screen.getByRole('button', { name: /Worktree: main/i })).toBeInTheDocument();
+  });
+
+  it('calls onSelect with worktree path for non-primary entry', async () => {
+    render(<WorktreeSelector {...props} activeWorktree="/workspaces/repo-wt-feature-auth" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Worktree: feature\/auth/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^feature\/auth/i }));
+
+    expect(props.onSelect).toHaveBeenCalledWith('/workspaces/repo-wt-feature-auth');
+  });
+
+  it('calls onCreate with branch and createBranch option', async () => {
+    render(<WorktreeSelector {...props} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Worktree: main/i }));
+    fireEvent.change(screen.getByPlaceholderText('branch name'), {
+      target: { value: 'feature/new-panel' },
+    });
+    fireEvent.click(screen.getByLabelText('Create new branch'));
+    fireEvent.click(screen.getByRole('button', { name: 'New Worktree' }));
+
+    await waitFor(() => {
+      expect(props.onCreate).toHaveBeenCalledWith({
+        branch: 'feature/new-panel',
+        createBranch: true,
+      });
+    });
+  });
+
+  it('calls onRemove with force=true for dirty non-primary worktree', async () => {
+    render(<WorktreeSelector {...props} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Worktree: main/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      expect(props.onRemove).toHaveBeenCalledWith('/workspaces/repo-wt-feature-auth', true);
+    });
+  });
+
+  it('shows commit hash for detached-head worktree labels', () => {
+    render(
+      <WorktreeSelector
+        {...props}
+        worktrees={[
+          {
+            path: '/workspaces/repo',
+            branch: '',
+            headCommit: '7f9aa21',
+            isPrimary: true,
+            isDirty: false,
+            dirtyFileCount: 0,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /Worktree: 7f9aa21/i })).toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -100,23 +100,11 @@ export interface GitHubConnection {
 // =============================================================================
 // Workspace
 // =============================================================================
-export type NodeStatus =
-  | 'pending'
-  | 'creating'
-  | 'running'
-  | 'stopping'
-  | 'stopped'
-  | 'error';
+export type NodeStatus = 'pending' | 'creating' | 'running' | 'stopping' | 'stopped' | 'error';
 
 export type NodeHealthStatus = 'healthy' | 'stale' | 'unhealthy';
 
-export type WorkspaceStatus =
-  | 'pending'
-  | 'creating'
-  | 'running'
-  | 'stopping'
-  | 'stopped'
-  | 'error';
+export type WorkspaceStatus = 'pending' | 'creating' | 'running' | 'stopping' | 'stopped' | 'error';
 
 export type VMSize = 'small' | 'medium' | 'large';
 
@@ -310,6 +298,30 @@ export interface Event {
 
 export type AgentSessionStatus = 'running' | 'stopped' | 'error';
 
+export interface WorktreeInfo {
+  path: string;
+  branch: string;
+  headCommit: string;
+  isPrimary: boolean;
+  isDirty: boolean;
+  dirtyFileCount: number;
+  isPrunable?: boolean;
+}
+
+export interface WorktreeListResponse {
+  worktrees: WorktreeInfo[];
+}
+
+export interface CreateWorktreeRequest {
+  branch: string;
+  createBranch?: boolean;
+  baseBranch?: string;
+}
+
+export interface RemoveWorktreeResponse {
+  removed: string;
+}
+
 export interface AgentSession {
   id: string;
   workspaceId: string;
@@ -319,10 +331,12 @@ export interface AgentSession {
   stoppedAt?: string | null;
   errorMessage?: string | null;
   label?: string | null;
+  worktreePath?: string | null;
 }
 
 export interface CreateAgentSessionRequest {
   label?: string;
+  worktreePath?: string;
 }
 
 export interface UpdateAgentSessionRequest {
@@ -417,7 +431,12 @@ export interface ApiError {
 // =============================================================================
 
 /** Valid permission modes for agent sessions */
-export type AgentPermissionMode = 'default' | 'acceptEdits' | 'plan' | 'dontAsk' | 'bypassPermissions';
+export type AgentPermissionMode =
+  | 'default'
+  | 'acceptEdits'
+  | 'plan'
+  | 'dontAsk'
+  | 'bypassPermissions';
 
 /** Agent settings stored per-user, per-agent in D1 */
 export interface AgentSettings {

--- a/packages/terminal/src/MultiTerminal.tsx
+++ b/packages/terminal/src/MultiTerminal.tsx
@@ -49,6 +49,7 @@ export const MultiTerminal = React.forwardRef<MultiTerminalHandle, MultiTerminal
   (props, ref) => {
     const {
       wsUrl,
+      defaultWorkDir,
       onActivity,
       className = '',
       config,
@@ -197,7 +198,7 @@ export const MultiTerminal = React.forwardRef<MultiTerminalHandle, MultiTerminal
       createTerminalInstance(sessionId);
       const ws = wsRef.current;
       if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(encodeTerminalWsCreateSession(sessionId, 24, 80));
+        ws.send(encodeTerminalWsCreateSession(sessionId, 24, 80, undefined, defaultWorkDir));
       }
       return sessionId;
     }, [createTerminalInstance]);
@@ -322,7 +323,9 @@ export const MultiTerminal = React.forwardRef<MultiTerminalHandle, MultiTerminal
               if (pendingLocalSessions.length === 0 && serverSessions.length === 0) {
                 const sessionId = latestRef.current.createSession();
                 createTerminalInstance(sessionId);
-                ws.send(encodeTerminalWsCreateSession(sessionId, 24, 80));
+                ws.send(
+                  encodeTerminalWsCreateSession(sessionId, 24, 80, undefined, defaultWorkDir)
+                );
               } else {
                 for (const localSession of pendingLocalSessions) {
                   const serverId = localSession.serverSessionId;
@@ -343,7 +346,13 @@ export const MultiTerminal = React.forwardRef<MultiTerminalHandle, MultiTerminal
                     serverMap.delete(serverId);
                   } else {
                     ws.send(
-                      encodeTerminalWsCreateSession(localSession.localId, 24, 80, localSession.name)
+                      encodeTerminalWsCreateSession(
+                        localSession.localId,
+                        24,
+                        80,
+                        localSession.name,
+                        defaultWorkDir
+                      )
                     );
                   }
                 }
@@ -560,7 +569,14 @@ export const MultiTerminal = React.forwardRef<MultiTerminalHandle, MultiTerminal
           }
         },
       }),
-      [activeSessionId, activateSession, canCreateSession, handleCloseTab, handleNewTab, handleRenameTab]
+      [
+        activeSessionId,
+        activateSession,
+        canCreateSession,
+        handleCloseTab,
+        handleNewTab,
+        handleRenameTab,
+      ]
     );
 
     useEffect(() => {

--- a/packages/terminal/src/protocol.test.ts
+++ b/packages/terminal/src/protocol.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  encodeTerminalWsCreateSession,
   encodeTerminalWsListSessions,
   encodeTerminalWsReattachSession,
   isSessionReattachedMessage,
@@ -13,6 +14,29 @@ describe('encodeTerminalWsListSessions', () => {
     const encoded = encodeTerminalWsListSessions();
     const parsed = JSON.parse(encoded);
     expect(parsed).toEqual({ type: 'list_sessions' });
+  });
+});
+
+describe('encodeTerminalWsCreateSession', () => {
+  it('encodes create_session with workDir when provided', () => {
+    const encoded = encodeTerminalWsCreateSession(
+      'session-1',
+      24,
+      80,
+      'Terminal 1',
+      '/workspaces/repo-wt-feature'
+    );
+    const parsed = JSON.parse(encoded);
+    expect(parsed).toEqual({
+      type: 'create_session',
+      data: {
+        sessionId: 'session-1',
+        rows: 24,
+        cols: 80,
+        name: 'Terminal 1',
+        workDir: '/workspaces/repo-wt-feature',
+      },
+    });
   });
 });
 
@@ -63,9 +87,7 @@ describe('isScrollbackMessage', () => {
   });
 
   it('returns false for other message types', () => {
-    const msg = parseTerminalWsServerMessage(
-      JSON.stringify({ type: 'pong' })
-    );
+    const msg = parseTerminalWsServerMessage(JSON.stringify({ type: 'pong' }));
     expect(msg).not.toBeNull();
     expect(isScrollbackMessage(msg!)).toBe(false);
   });

--- a/packages/terminal/src/types/multi-terminal.ts
+++ b/packages/terminal/src/types/multi-terminal.ts
@@ -112,6 +112,7 @@ export interface CreateSessionData {
   rows: number;
   cols: number;
   name?: string;
+  workDir?: string;
 }
 
 export interface SessionCreatedData {
@@ -271,6 +272,9 @@ export interface MultiTerminalProps {
 
   /** Callback when user activity is detected */
   onActivity?: () => void;
+
+  /** Default working directory for new sessions. */
+  defaultWorkDir?: string;
 
   /** Optional CSS class name */
   className?: string;

--- a/packages/vm-agent/internal/acp/session_host.go
+++ b/packages/vm-agent/internal/acp/session_host.go
@@ -23,12 +23,12 @@ import (
 type SessionHostStatus string
 
 const (
-	HostIdle     SessionHostStatus = "idle"      // No agent selected yet
-	HostStarting SessionHostStatus = "starting"  // Agent being initialized
-	HostReady    SessionHostStatus = "ready"      // Agent ready for prompts
+	HostIdle      SessionHostStatus = "idle"      // No agent selected yet
+	HostStarting  SessionHostStatus = "starting"  // Agent being initialized
+	HostReady     SessionHostStatus = "ready"     // Agent ready for prompts
 	HostPrompting SessionHostStatus = "prompting" // Prompt in progress
-	HostError    SessionHostStatus = "error"      // Agent in error state
-	HostStopped  SessionHostStatus = "stopped"    // Explicitly stopped
+	HostError     SessionHostStatus = "error"     // Agent in error state
+	HostStopped   SessionHostStatus = "stopped"   // Explicitly stopped
 )
 
 // DefaultMessageBufferSize is the default maximum number of messages buffered
@@ -149,6 +149,11 @@ func (h *SessionHost) AgentType() string {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	return h.agentType
+}
+
+// ContainerWorkDir returns the configured working directory for this session host.
+func (h *SessionHost) ContainerWorkDir() string {
+	return h.config.ContainerWorkDir
 }
 
 // ViewerCount returns the number of active viewers.

--- a/packages/vm-agent/internal/pty/manager_test.go
+++ b/packages/vm-agent/internal/pty/manager_test.go
@@ -375,3 +375,28 @@ func TestGetActiveSessionsForUser(t *testing.T) {
 		t.Fatalf("expected 1 session for user2, got %d", len(user2Sessions))
 	}
 }
+
+func TestCreateSessionWithID_UsesProvidedWorkDir(t *testing.T) {
+	customDir := t.TempDir()
+	m := NewManager(ManagerConfig{
+		DefaultShell: "/bin/sh",
+		DefaultRows:  24,
+		DefaultCols:  80,
+		WorkDir:      "/workspaces/default",
+		GracePeriod:  1 * time.Minute,
+		BufferSize:   1024,
+	})
+
+	session, err := m.CreateSessionWithID("sess-workdir", "user1", 24, 80, customDir)
+	if err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+	defer m.CloseAllSessions()
+
+	if session.Cmd == nil {
+		t.Fatalf("expected session command to be initialized")
+	}
+	if session.Cmd.Dir != customDir {
+		t.Fatalf("expected custom workdir, got %q", session.Cmd.Dir)
+	}
+}

--- a/packages/vm-agent/internal/server/agent_ws_test.go
+++ b/packages/vm-agent/internal/server/agent_ws_test.go
@@ -17,6 +17,7 @@ func TestAgentWebSocketSourceContract(t *testing.T) {
 
 	for _, needle := range []string{
 		"sessionId",
+		"worktree",
 		"hostKey",
 		"agentSessions",
 		"idempotencyKey",

--- a/packages/vm-agent/internal/server/files.go
+++ b/packages/vm-agent/internal/server/files.go
@@ -58,6 +58,11 @@ func (s *Server) handleFileList(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusInternalServerError)
 		return
 	}
+	workDir, err = s.resolveWorktreeWorkDir(r, workspaceID, containerID, user, workDir)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusBadRequest)
+		return
+	}
 
 	// Use find with -maxdepth 1 to list directory contents.
 	// Output format: type\tsize\tmtime_epoch\tname (tab-separated)
@@ -122,6 +127,11 @@ func (s *Server) handleFileFind(w http.ResponseWriter, r *http.Request) {
 	containerID, workDir, user, err := s.resolveContainerForWorkspace(workspaceID)
 	if err != nil {
 		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	workDir, err = s.resolveWorktreeWorkDir(r, workspaceID, containerID, user, workDir)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusBadRequest)
 		return
 	}
 

--- a/packages/vm-agent/internal/server/git.go
+++ b/packages/vm-agent/internal/server/git.go
@@ -16,8 +16,8 @@ import (
 // GitFileStatus represents a single file in git status output.
 type GitFileStatus struct {
 	Path    string `json:"path"`
-	Status  string `json:"status"`             // "M", "A", "D", "R", "??" etc.
-	OldPath string `json:"oldPath,omitempty"`   // populated for renames
+	Status  string `json:"status"`            // "M", "A", "D", "R", "??" etc.
+	OldPath string `json:"oldPath,omitempty"` // populated for renames
 }
 
 // GitStatusResponse groups files by their git staging state.
@@ -57,6 +57,11 @@ func (s *Server) handleGitStatus(w http.ResponseWriter, r *http.Request) {
 	containerID, workDir, user, err := s.resolveContainerForWorkspace(workspaceID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	workDir, err = s.resolveWorktreeWorkDir(r, workspaceID, containerID, user, workDir)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -105,6 +110,11 @@ func (s *Server) handleGitDiff(w http.ResponseWriter, r *http.Request) {
 	containerID, workDir, user, err := s.resolveContainerForWorkspace(workspaceID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	workDir, err = s.resolveWorktreeWorkDir(r, workspaceID, containerID, user, workDir)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -164,6 +174,11 @@ func (s *Server) handleGitFile(w http.ResponseWriter, r *http.Request) {
 	containerID, workDir, user, err := s.resolveContainerForWorkspace(workspaceID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	workDir, err = s.resolveWorktreeWorkDir(r, workspaceID, containerID, user, workDir)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/packages/vm-agent/internal/server/websocket_test.go
+++ b/packages/vm-agent/internal/server/websocket_test.go
@@ -358,7 +358,7 @@ func TestMultiTerminalWS_ListSessionsIsUserScoped(t *testing.T) {
 	s, ts, authSessionID := newTestServer(t)
 
 	// Create a session for another user directly in the manager.
-	_, err := s.ptyManager.CreateSessionWithID("sess-other-user", "other-user", 24, 80)
+	_, err := s.ptyManager.CreateSessionWithID("sess-other-user", "other-user", 24, 80, "")
 	if err != nil {
 		t.Fatalf("failed to create other-user session: %v", err)
 	}
@@ -396,7 +396,7 @@ func TestMultiTerminalWS_CloseSessionRejectsOtherUserSession(t *testing.T) {
 	s, ts, authSessionID := newTestServer(t)
 
 	// Create a session for another user directly in the manager.
-	_, err := s.ptyManager.CreateSessionWithID("sess-other-user", "other-user", 24, 80)
+	_, err := s.ptyManager.CreateSessionWithID("sess-other-user", "other-user", 24, 80, "")
 	if err != nil {
 		t.Fatalf("failed to create other-user session: %v", err)
 	}

--- a/packages/vm-agent/internal/server/worktrees.go
+++ b/packages/vm-agent/internal/server/worktrees.go
@@ -1,0 +1,428 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type WorktreeInfo struct {
+	Path           string `json:"path"`
+	Branch         string `json:"branch"`
+	HeadCommit     string `json:"headCommit"`
+	IsPrimary      bool   `json:"isPrimary"`
+	IsDirty        bool   `json:"isDirty"`
+	DirtyFileCount int    `json:"dirtyFileCount"`
+	IsPrunable     bool   `json:"isPrunable,omitempty"`
+}
+
+type createWorktreeRequest struct {
+	Branch       string `json:"branch"`
+	CreateBranch bool   `json:"createBranch"`
+	BaseBranch   string `json:"baseBranch"`
+}
+
+func parseWorktreeList(output, primaryPath string) []WorktreeInfo {
+	lines := strings.Split(output, "\n")
+	worktrees := make([]WorktreeInfo, 0)
+
+	var current *WorktreeInfo
+	flush := func() {
+		if current != nil && current.Path != "" {
+			current.IsPrimary = current.Path == primaryPath
+			if current.Branch == "" && current.HeadCommit != "" {
+				current.Branch = current.HeadCommit
+			}
+			worktrees = append(worktrees, *current)
+		}
+		current = nil
+	}
+
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			flush()
+			continue
+		}
+		if strings.HasPrefix(line, "worktree ") {
+			flush()
+			current = &WorktreeInfo{Path: strings.TrimSpace(strings.TrimPrefix(line, "worktree "))}
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		if strings.HasPrefix(line, "branch ") {
+			branchRef := strings.TrimSpace(strings.TrimPrefix(line, "branch "))
+			current.Branch = strings.TrimPrefix(branchRef, "refs/heads/")
+			continue
+		}
+		if strings.HasPrefix(line, "HEAD ") {
+			head := strings.TrimSpace(strings.TrimPrefix(line, "HEAD "))
+			if len(head) > 7 {
+				head = head[:7]
+			}
+			current.HeadCommit = head
+			continue
+		}
+		if strings.HasPrefix(line, "prunable") {
+			current.IsPrunable = true
+		}
+	}
+	flush()
+
+	return worktrees
+}
+
+func sanitizeBranchToDirectoryName(branch string) string {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return "worktree"
+	}
+	var b strings.Builder
+	b.Grow(len(branch))
+	lastDash := false
+	for _, r := range branch {
+		valid := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_'
+		if valid {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteRune('-')
+			lastDash = true
+		}
+	}
+	clean := strings.Trim(b.String(), "-_")
+	if clean == "" {
+		return "worktree"
+	}
+	return clean
+}
+
+func (s *Server) getCachedWorktrees(workspaceID string) ([]WorktreeInfo, bool) {
+	s.worktreeCacheMu.RLock()
+	entry, ok := s.worktreeCache[workspaceID]
+	s.worktreeCacheMu.RUnlock()
+	if !ok || time.Now().After(entry.expiresAt) {
+		return nil, false
+	}
+	return entry.worktrees, true
+}
+
+func (s *Server) setCachedWorktrees(workspaceID string, worktrees []WorktreeInfo) {
+	s.worktreeCacheMu.Lock()
+	s.worktreeCache[workspaceID] = cachedWorktreeList{
+		worktrees: worktrees,
+		expiresAt: time.Now().Add(s.config.WorktreeCacheTTL),
+	}
+	s.worktreeCacheMu.Unlock()
+}
+
+func (s *Server) invalidateWorktreeCache(workspaceID string) {
+	s.worktreeCacheMu.Lock()
+	delete(s.worktreeCache, workspaceID)
+	s.worktreeCacheMu.Unlock()
+}
+
+func (s *Server) listWorktrees(ctx context.Context, workspaceID, containerID, user, primaryWorkDir string, bypassCache bool) ([]WorktreeInfo, error) {
+	if !bypassCache {
+		if cached, ok := s.getCachedWorktrees(workspaceID); ok {
+			return cached, nil
+		}
+	}
+
+	stdout, _, err := s.execInContainer(ctx, containerID, user, primaryWorkDir, "git", "worktree", "list", "--porcelain")
+	if err != nil {
+		return nil, fmt.Errorf("git worktree list failed: %w", err)
+	}
+
+	worktrees := parseWorktreeList(stdout, primaryWorkDir)
+	for i := range worktrees {
+		wt := &worktrees[i]
+		if wt.IsPrunable {
+			continue
+		}
+		statusOut, _, statusErr := s.execInContainer(ctx, containerID, user, primaryWorkDir, "git", "-C", wt.Path, "status", "--porcelain")
+		if statusErr != nil {
+			continue
+		}
+		trimmed := strings.TrimSpace(statusOut)
+		if trimmed == "" {
+			continue
+		}
+		wt.IsDirty = true
+		wt.DirtyFileCount = len(strings.Split(trimmed, "\n"))
+	}
+
+	s.setCachedWorktrees(workspaceID, worktrees)
+	return worktrees, nil
+}
+
+func (s *Server) validateWorktreePath(ctx context.Context, workspaceID, containerID, user, primaryWorkDir, requestedPath string) (*WorktreeInfo, error) {
+	requestedPath = strings.TrimSpace(requestedPath)
+	if requestedPath == "" {
+		return nil, fmt.Errorf("not a valid worktree path")
+	}
+	if strings.ContainsRune(requestedPath, 0) || strings.Contains(requestedPath, "..") {
+		return nil, fmt.Errorf("invalid worktree path")
+	}
+	if !strings.HasPrefix(requestedPath, "/workspaces/") {
+		return nil, fmt.Errorf("invalid worktree path")
+	}
+
+	worktrees, err := s.listWorktrees(ctx, workspaceID, containerID, user, primaryWorkDir, false)
+	if err != nil {
+		return nil, err
+	}
+	for _, wt := range worktrees {
+		if wt.Path == requestedPath {
+			copy := wt
+			return &copy, nil
+		}
+	}
+	return nil, fmt.Errorf("not a valid worktree path")
+}
+
+func (s *Server) resolveWorktreeWorkDir(r *http.Request, workspaceID, containerID, user, defaultWorkDir string) (string, error) {
+	requested := strings.TrimSpace(r.URL.Query().Get("worktree"))
+	return s.resolveExplicitWorktreeWorkDir(r.Context(), workspaceID, containerID, user, defaultWorkDir, requested)
+}
+
+func (s *Server) resolveExplicitWorktreeWorkDir(ctx context.Context, workspaceID, containerID, user, defaultWorkDir, requested string) (string, error) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		return defaultWorkDir, nil
+	}
+	validateCtx, cancel := context.WithTimeout(ctx, s.config.GitExecTimeout)
+	defer cancel()
+	wt, err := s.validateWorktreePath(validateCtx, workspaceID, containerID, user, defaultWorkDir, requested)
+	if err != nil {
+		return "", err
+	}
+	return wt.Path, nil
+}
+
+func (s *Server) handleListWorktrees(w http.ResponseWriter, r *http.Request) {
+	workspaceID := r.PathValue("workspaceId")
+	if workspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspaceId is required")
+		return
+	}
+	if !s.requireWorkspaceRequestAuth(w, r, workspaceID) {
+		return
+	}
+
+	containerID, workDir, user, err := s.resolveContainerForWorkspace(workspaceID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), s.config.GitExecTimeout)
+	defer cancel()
+	worktrees, err := s.listWorktrees(ctx, workspaceID, containerID, user, workDir, false)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{"worktrees": worktrees})
+}
+
+func (s *Server) handleCreateWorktree(w http.ResponseWriter, r *http.Request) {
+	workspaceID := r.PathValue("workspaceId")
+	if workspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspaceId is required")
+		return
+	}
+	if !s.requireWorkspaceRequestAuth(w, r, workspaceID) {
+		return
+	}
+
+	var req createWorktreeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	req.Branch = strings.TrimSpace(req.Branch)
+	if req.Branch == "" {
+		writeError(w, http.StatusBadRequest, "branch is required")
+		return
+	}
+
+	containerID, workDir, user, err := s.resolveContainerForWorkspace(workspaceID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), s.config.GitWorktreeTimeout)
+	defer cancel()
+
+	if _, _, err := s.execInContainer(ctx, containerID, user, workDir, "git", "check-ref-format", "--branch", req.Branch); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid branch name")
+		return
+	}
+
+	worktrees, err := s.listWorktrees(ctx, workspaceID, containerID, user, workDir, true)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if len(worktrees) >= s.config.MaxWorktreesPerWorkspace {
+		writeError(w, http.StatusUnprocessableEntity, fmt.Sprintf("maximum of %d worktrees per workspace reached", s.config.MaxWorktreesPerWorkspace))
+		return
+	}
+	for _, wt := range worktrees {
+		if wt.Branch == req.Branch {
+			writeError(w, http.StatusConflict, fmt.Sprintf("branch '%s' is already checked out in worktree at %s", req.Branch, wt.Path))
+			return
+		}
+	}
+
+	repoDirName := filepath.Base(workDir)
+	targetPath := filepath.Join("/workspaces", fmt.Sprintf("%s-wt-%s", repoDirName, sanitizeBranchToDirectoryName(req.Branch)))
+
+	if req.CreateBranch {
+		base := strings.TrimSpace(req.BaseBranch)
+		if base == "" {
+			base = "HEAD"
+		}
+		if _, _, err := s.execInContainer(ctx, containerID, user, workDir, "git", "worktree", "add", "-b", req.Branch, targetPath, base); err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("failed to create worktree: %v", err))
+			return
+		}
+	} else {
+		if _, _, err := s.execInContainer(ctx, containerID, user, workDir, "git", "rev-parse", "--verify", req.Branch); err != nil {
+			writeError(w, http.StatusNotFound, fmt.Sprintf("branch '%s' does not exist", req.Branch))
+			return
+		}
+		if _, _, err := s.execInContainer(ctx, containerID, user, workDir, "git", "worktree", "add", targetPath, req.Branch); err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("failed to create worktree: %v", err))
+			return
+		}
+	}
+
+	s.invalidateWorktreeCache(workspaceID)
+	refreshed, err := s.listWorktrees(ctx, workspaceID, containerID, user, workDir, true)
+	if err != nil {
+		writeError(w, http.StatusCreated, "worktree created")
+		return
+	}
+	for _, wt := range refreshed {
+		if wt.Path == targetPath {
+			writeJSON(w, http.StatusCreated, wt)
+			return
+		}
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]interface{}{
+		"path":           targetPath,
+		"branch":         req.Branch,
+		"headCommit":     "",
+		"isPrimary":      false,
+		"isDirty":        false,
+		"dirtyFileCount": 0,
+	})
+}
+
+func (s *Server) stopAgentSessionsBoundToWorktree(workspaceID, worktreePath string) {
+	type stopTarget struct {
+		hostKey   string
+		sessionID string
+	}
+	targets := make([]stopTarget, 0)
+
+	s.sessionHostMu.Lock()
+	for hostKey, host := range s.sessionHosts {
+		if !strings.HasPrefix(hostKey, workspaceID+":") {
+			continue
+		}
+		if host == nil || host.ContainerWorkDir() != worktreePath {
+			continue
+		}
+		sessionID := strings.TrimPrefix(hostKey, workspaceID+":")
+		targets = append(targets, stopTarget{hostKey: hostKey, sessionID: sessionID})
+	}
+	for _, target := range targets {
+		if host := s.sessionHosts[target.hostKey]; host != nil {
+			host.Stop()
+		}
+		delete(s.sessionHosts, target.hostKey)
+	}
+	s.sessionHostMu.Unlock()
+
+	for _, target := range targets {
+		if s.agentSessions != nil {
+			_, _ = s.agentSessions.Stop(workspaceID, target.sessionID)
+		}
+		if s.store != nil {
+			_ = s.store.DeleteTab(target.sessionID)
+		}
+	}
+}
+
+func (s *Server) handleRemoveWorktree(w http.ResponseWriter, r *http.Request) {
+	workspaceID := r.PathValue("workspaceId")
+	if workspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspaceId is required")
+		return
+	}
+	if !s.requireWorkspaceRequestAuth(w, r, workspaceID) {
+		return
+	}
+
+	removePath := strings.TrimSpace(r.URL.Query().Get("path"))
+	if removePath == "" {
+		writeError(w, http.StatusBadRequest, "path query parameter is required")
+		return
+	}
+	force, _ := strconv.ParseBool(strings.TrimSpace(r.URL.Query().Get("force")))
+
+	containerID, workDir, user, err := s.resolveContainerForWorkspace(workspaceID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), s.config.GitWorktreeTimeout)
+	defer cancel()
+	wt, err := s.validateWorktreePath(ctx, workspaceID, containerID, user, workDir, removePath)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	if wt.IsPrimary {
+		writeError(w, http.StatusBadRequest, "cannot remove the primary worktree")
+		return
+	}
+	if wt.IsDirty && !force {
+		writeJSON(w, http.StatusConflict, map[string]interface{}{
+			"error":          "WORKTREE_DIRTY",
+			"message":        "Worktree has uncommitted changes",
+			"dirtyFileCount": wt.DirtyFileCount,
+		})
+		return
+	}
+
+	s.stopAgentSessionsBoundToWorktree(workspaceID, wt.Path)
+
+	args := []string{"git", "worktree", "remove"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, wt.Path)
+	if _, _, err := s.execInContainer(ctx, containerID, user, workDir, args...); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("failed to remove worktree: %v", err))
+		return
+	}
+
+	s.invalidateWorktreeCache(workspaceID)
+	writeJSON(w, http.StatusOK, map[string]interface{}{"removed": wt.Path})
+}

--- a/packages/vm-agent/internal/server/worktrees_test.go
+++ b/packages/vm-agent/internal/server/worktrees_test.go
@@ -1,0 +1,167 @@
+package server
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/workspace/vm-agent/internal/config"
+)
+
+func TestParseWorktreeList(t *testing.T) {
+	output := "worktree /workspaces/repo\nHEAD 0123456789abcdef\nbranch refs/heads/main\n\nworktree /workspaces/repo-wt-feature\nHEAD abcdef0123456789\nbranch refs/heads/feature/auth\n\nworktree /workspaces/repo-old\nHEAD fedcba9876543210\nprunable gitdir file points to non-existent location\n"
+	items := parseWorktreeList(output, "/workspaces/repo")
+	if len(items) != 3 {
+		t.Fatalf("expected 3 worktrees, got %d", len(items))
+	}
+	if !items[0].IsPrimary {
+		t.Fatalf("expected first worktree to be primary")
+	}
+	if items[0].Branch != "main" {
+		t.Fatalf("expected main branch, got %q", items[0].Branch)
+	}
+	if items[1].Branch != "feature/auth" {
+		t.Fatalf("expected feature/auth branch, got %q", items[1].Branch)
+	}
+	if !items[2].IsPrunable {
+		t.Fatalf("expected prunable worktree to be flagged")
+	}
+}
+
+func TestSanitizeBranchToDirectoryName(t *testing.T) {
+	tests := []struct {
+		name   string
+		branch string
+		want   string
+	}{
+		{name: "simple", branch: "feature-auth", want: "feature-auth"},
+		{name: "slashes", branch: "feature/auth", want: "feature-auth"},
+		{name: "spaces", branch: "feature auth", want: "feature-auth"},
+		{name: "symbols", branch: "fix:#123", want: "fix-123"},
+		{name: "empty", branch: "", want: "worktree"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeBranchToDirectoryName(tt.branch); got != tt.want {
+				t.Fatalf("sanitizeBranchToDirectoryName(%q) = %q, want %q", tt.branch, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateWorktreePathUsesCachedList(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		config: &config.Config{
+			WorktreeCacheTTL: 5 * time.Second,
+		},
+		worktreeCache: map[string]cachedWorktreeList{},
+	}
+	s.setCachedWorktrees("ws-1", []WorktreeInfo{
+		{Path: "/workspaces/repo", Branch: "main", IsPrimary: true},
+		{Path: "/workspaces/repo-wt-feature", Branch: "feature/auth"},
+	})
+
+	wt, err := s.validateWorktreePath(
+		context.Background(),
+		"ws-1",
+		"container-1",
+		"root",
+		"/workspaces/repo",
+		"/workspaces/repo-wt-feature",
+	)
+	if err != nil {
+		t.Fatalf("validateWorktreePath() unexpected error: %v", err)
+	}
+	if wt == nil || wt.Path != "/workspaces/repo-wt-feature" {
+		t.Fatalf("validateWorktreePath() returned %+v", wt)
+	}
+}
+
+func TestValidateWorktreePathRejectsInvalidPaths(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		config: &config.Config{
+			WorktreeCacheTTL: 5 * time.Second,
+		},
+		worktreeCache: map[string]cachedWorktreeList{},
+	}
+	s.setCachedWorktrees("ws-1", []WorktreeInfo{
+		{Path: "/workspaces/repo", Branch: "main", IsPrimary: true},
+	})
+
+	tests := []string{
+		"",
+		"../etc/passwd",
+		"/tmp/not-allowed",
+		"/workspaces/repo/../../etc",
+		"/workspaces/does-not-exist",
+	}
+	for _, requested := range tests {
+		_, err := s.validateWorktreePath(
+			context.Background(),
+			"ws-1",
+			"container-1",
+			"root",
+			"/workspaces/repo",
+			requested,
+		)
+		if err == nil {
+			t.Fatalf("expected error for requested path %q", requested)
+		}
+	}
+}
+
+func TestResolveWorktreeWorkDir(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		config: &config.Config{
+			GitExecTimeout:   5 * time.Second,
+			WorktreeCacheTTL: 5 * time.Second,
+		},
+		worktreeCache: map[string]cachedWorktreeList{},
+	}
+	s.setCachedWorktrees("ws-1", []WorktreeInfo{
+		{Path: "/workspaces/repo", Branch: "main", IsPrimary: true},
+		{Path: "/workspaces/repo-wt-feature", Branch: "feature/auth"},
+	})
+
+	noWorktreeReq := httptest.NewRequest("GET", "/workspaces/ws-1/git/status", nil)
+	workDir, err := s.resolveWorktreeWorkDir(
+		noWorktreeReq,
+		"ws-1",
+		"container-1",
+		"root",
+		"/workspaces/repo",
+	)
+	if err != nil {
+		t.Fatalf("resolveWorktreeWorkDir() unexpected error without query param: %v", err)
+	}
+	if workDir != "/workspaces/repo" {
+		t.Fatalf("resolveWorktreeWorkDir() = %q, want /workspaces/repo", workDir)
+	}
+
+	withWorktreeReq := httptest.NewRequest(
+		"GET",
+		"/workspaces/ws-1/git/status?worktree=/workspaces/repo-wt-feature",
+		nil,
+	)
+	workDir, err = s.resolveWorktreeWorkDir(
+		withWorktreeReq,
+		"ws-1",
+		"container-1",
+		"root",
+		"/workspaces/repo",
+	)
+	if err != nil {
+		t.Fatalf("resolveWorktreeWorkDir() unexpected error with query param: %v", err)
+	}
+	if workDir != "/workspaces/repo-wt-feature" {
+		t.Fatalf("resolveWorktreeWorkDir() = %q, want /workspaces/repo-wt-feature", workDir)
+	}
+}

--- a/specs/015-worktree-context/contracts/api.md
+++ b/specs/015-worktree-context/contracts/api.md
@@ -1,0 +1,370 @@
+# API Contracts: Worktree Context Switching
+
+**Phase 1 output** | **Date**: 2026-02-17
+
+## VM Agent Endpoints (New)
+
+### List Worktrees
+
+```
+GET /workspaces/{workspaceId}/worktrees?token={jwt}
+```
+
+**Authentication**: Workspace JWT (query param) or session cookie
+
+**Response 200**:
+```json
+{
+  "worktrees": [
+    {
+      "path": "/workspaces/my-repo",
+      "branch": "main",
+      "headCommit": "a1b2c3d",
+      "isPrimary": true,
+      "isDirty": false,
+      "dirtyFileCount": 0
+    },
+    {
+      "path": "/workspaces/my-repo-wt-feature-auth",
+      "branch": "feature/auth",
+      "headCommit": "e4f5g6h",
+      "isPrimary": false,
+      "isDirty": true,
+      "dirtyFileCount": 3
+    }
+  ]
+}
+```
+
+**Error 404**: Workspace not found or not running
+**Error 401**: Invalid or expired token
+
+**Implementation**: Runs `git worktree list --porcelain` inside the container, then `git status --porcelain -s` for each worktree to get dirty state. Results cached per `WORKTREE_CACHE_TTL`.
+
+---
+
+### Create Worktree
+
+```
+POST /workspaces/{workspaceId}/worktrees?token={jwt}
+Content-Type: application/json
+```
+
+**Request body**:
+```json
+{
+  "branch": "feature/auth",
+  "createBranch": false,
+  "baseBranch": "main"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `branch` | string | Yes | Branch name to check out in the worktree |
+| `createBranch` | boolean | No | If `true`, create a new branch (default: `false`) |
+| `baseBranch` | string | No | Base ref for new branch creation (default: primary worktree's HEAD) |
+
+**Response 201**:
+```json
+{
+  "path": "/workspaces/my-repo-wt-feature-auth",
+  "branch": "feature/auth",
+  "headCommit": "a1b2c3d",
+  "isPrimary": false,
+  "isDirty": false,
+  "dirtyFileCount": 0
+}
+```
+
+**Error 400**: Invalid branch name
+**Error 409**: Branch already checked out in another worktree
+**Error 422**: Max worktrees exceeded
+**Error 404**: Workspace not found, branch not found (when `createBranch: false`)
+
+**Implementation**:
+1. Validate branch name with `git check-ref-format`
+2. Check worktree count against `MAX_WORKTREES_PER_WORKSPACE`
+3. Check branch not already checked out via `git worktree list`
+4. If `createBranch: true`: `git worktree add -b <branch> <path> <baseBranch>`
+5. If `createBranch: false`: `git worktree add <path> <branch>`
+6. Invalidate worktree cache
+
+---
+
+### Remove Worktree
+
+```
+DELETE /workspaces/{workspaceId}/worktrees?token={jwt}&path={worktreePath}&force={boolean}
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | string | Yes | URL-encoded absolute container path of the worktree |
+| `force` | boolean | No | Force removal even if dirty (default: `false`) |
+
+**Response 200**:
+```json
+{
+  "removed": "/workspaces/my-repo-wt-feature-auth"
+}
+```
+
+**Error 400**: Cannot remove the primary worktree
+**Error 409**: Worktree has uncommitted changes (when `force: false`). Response includes:
+```json
+{
+  "error": "WORKTREE_DIRTY",
+  "message": "Worktree has uncommitted changes",
+  "dirtyFileCount": 3
+}
+```
+**Error 404**: Worktree not found
+
+**Implementation**:
+1. Validate path is a legitimate worktree (not primary)
+2. If not `force`: check dirty state via `git status --porcelain`
+3. Stop any agent sessions bound to this worktree (via in-memory session host map)
+4. Run `git worktree remove [--force] <path>`
+5. Invalidate worktree cache
+
+---
+
+## VM Agent Endpoints (Modified)
+
+### Git Status (add worktree param)
+
+```
+GET /workspaces/{workspaceId}/git/status?token={jwt}&worktree={path}
+```
+
+| New Param | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `worktree` | string | No | URL-encoded worktree path. Default: primary worktree |
+
+**Behavior change**: When `worktree` is provided, the `docker exec -w` flag uses the worktree path instead of `ContainerWorkDir`. The worktree path is validated against `git worktree list` output.
+
+---
+
+### Git Diff (add worktree param)
+
+```
+GET /workspaces/{workspaceId}/git/diff?token={jwt}&path={file}&staged={bool}&worktree={path}
+```
+
+| New Param | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `worktree` | string | No | URL-encoded worktree path. Default: primary worktree |
+
+---
+
+### Git File (add worktree param)
+
+```
+GET /workspaces/{workspaceId}/git/file?token={jwt}&path={file}&ref={ref}&worktree={path}
+```
+
+| New Param | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `worktree` | string | No | URL-encoded worktree path. Default: primary worktree |
+
+---
+
+### File List (add worktree param)
+
+```
+GET /workspaces/{workspaceId}/files/list?token={jwt}&path={dir}&worktree={path}
+```
+
+| New Param | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `worktree` | string | No | URL-encoded worktree path. Default: primary worktree |
+
+---
+
+### File Find (add worktree param)
+
+```
+GET /workspaces/{workspaceId}/files/find?token={jwt}&worktree={path}
+```
+
+| New Param | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `worktree` | string | No | URL-encoded worktree path. Default: primary worktree |
+
+---
+
+## VM Agent WebSocket Protocols (Modified)
+
+### Multi-Terminal WebSocket
+
+```
+GET /terminal/ws/multi?token={jwt}
+```
+
+**Modified message: `create_session`**
+
+```json
+{
+  "type": "create_session",
+  "data": {
+    "sessionId": "uuid",
+    "rows": 24,
+    "cols": 80,
+    "name": "Terminal 1",
+    "workDir": "/workspaces/my-repo-wt-feature-auth"
+  }
+}
+```
+
+| New Field | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `workDir` | string | No | Working directory for the new PTY session. Default: workspace's `ContainerWorkDir` |
+
+**Validation**: If `workDir` is provided, it must be a valid worktree path (validated against `git worktree list`).
+
+**Response `session_created`** (unchanged — already includes `workingDirectory`):
+```json
+{
+  "type": "session_created",
+  "sessionId": "uuid",
+  "data": {
+    "sessionId": "uuid",
+    "workingDirectory": "/workspaces/my-repo-wt-feature-auth"
+  }
+}
+```
+
+---
+
+### Agent WebSocket
+
+```
+GET /agent/ws?token={jwt}&sessionId={id}&worktree={path}
+```
+
+| New Param | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `worktree` | string | No | URL-encoded worktree path for the agent session. Default: workspace's `ContainerWorkDir` |
+
+**Behavior**: When `worktree` is provided, the `SessionHost` is created with `ContainerWorkDir` set to the worktree path. The agent's `NewSession(Cwd: ...)` uses this path. The worktree parameter is only used when creating a NEW session host — reconnecting to an existing session host ignores the parameter (the session retains its original CWD).
+
+---
+
+## Control Plane API Endpoints (Modified)
+
+### Create Agent Session
+
+```
+POST /api/workspaces/{id}/agent-sessions
+Content-Type: application/json
+```
+
+**Modified request body**:
+```json
+{
+  "label": "Feature auth work",
+  "worktreePath": "/workspaces/my-repo-wt-feature-auth"
+}
+```
+
+| New Field | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `worktreePath` | string | No | Container-side worktree path. Stored in D1. Default: `null` (primary worktree) |
+
+**Modified response** (added field):
+```json
+{
+  "id": "uuid",
+  "workspaceId": "uuid",
+  "status": "running",
+  "label": "Feature auth work",
+  "worktreePath": "/workspaces/my-repo-wt-feature-auth",
+  "createdAt": "2026-02-17T...",
+  "updatedAt": "2026-02-17T..."
+}
+```
+
+---
+
+### List Agent Sessions
+
+```
+GET /api/workspaces/{id}/agent-sessions
+```
+
+**Modified response** (added field to each session):
+```json
+[
+  {
+    "id": "uuid",
+    "workspaceId": "uuid",
+    "status": "running",
+    "label": "Main branch review",
+    "worktreePath": null,
+    "createdAt": "...",
+    "updatedAt": "..."
+  },
+  {
+    "id": "uuid",
+    "workspaceId": "uuid",
+    "status": "running",
+    "label": "Feature auth work",
+    "worktreePath": "/workspaces/my-repo-wt-feature-auth",
+    "createdAt": "...",
+    "updatedAt": "..."
+  }
+]
+```
+
+---
+
+## Shared Types (packages/shared)
+
+### New Types
+
+```typescript
+export interface WorktreeInfo {
+  path: string;
+  branch: string;
+  headCommit: string;
+  isPrimary: boolean;
+  isDirty: boolean;
+  dirtyFileCount: number;
+}
+
+export interface CreateWorktreeRequest {
+  branch: string;
+  createBranch?: boolean;
+  baseBranch?: string;
+}
+
+export interface RemoveWorktreeResponse {
+  removed: string;
+}
+
+export interface WorktreeListResponse {
+  worktrees: WorktreeInfo[];
+}
+```
+
+### Modified Types
+
+```typescript
+export interface AgentSession {
+  id: string;
+  workspaceId: string;
+  status: AgentSessionStatus;
+  createdAt: string;
+  updatedAt: string;
+  stoppedAt?: string | null;
+  errorMessage?: string | null;
+  label?: string | null;
+  worktreePath?: string | null;  // NEW
+}
+
+export interface CreateAgentSessionRequest {
+  label?: string;
+  worktreePath?: string;  // NEW
+}
+```

--- a/specs/015-worktree-context/data-model.md
+++ b/specs/015-worktree-context/data-model.md
@@ -1,0 +1,149 @@
+# Data Model: Worktree Context Switching
+
+**Phase 1 output** | **Date**: 2026-02-17
+
+## Entities
+
+### WorktreeInfo (VM Agent — in-memory + API response)
+
+Represents a single git worktree within a workspace.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | string | Absolute container-side path (e.g., `/workspaces/my-repo-wt-feature-auth`) |
+| `branch` | string | Branch name, or commit hash if detached HEAD |
+| `headCommit` | string | Short HEAD commit hash (7 chars) |
+| `isPrimary` | boolean | `true` for the original clone directory |
+| `isDirty` | boolean | `true` if there are uncommitted changes |
+| `dirtyFileCount` | number | Count of modified/staged/untracked files (0 if not dirty) |
+
+**Notes**:
+- Not persisted in a database — derived from `git worktree list --porcelain` + `git status --porcelain` at request time
+- Cached briefly on the VM Agent (configurable via `WORKTREE_CACHE_TTL`, default 5s) to avoid repeated `docker exec` calls
+- The primary worktree is identified by matching against `WorkspaceRuntime.ContainerWorkDir`
+
+### WorktreeBinding (on AgentSession — D1 persistent)
+
+Associates an agent session with its creation-time worktree.
+
+| Field | Type | Nullable | Description |
+|-------|------|----------|-------------|
+| `worktree_path` | TEXT | Yes | Container-side worktree path. `NULL` = primary worktree (default) |
+
+**Added to**: `agent_sessions` table via migration `0010_agent_sessions_worktree_path.sql`
+
+**Semantics**:
+- Set once at agent session creation time, never updated
+- `NULL` is treated as "primary worktree" (backward compatible with existing sessions)
+- When the bound worktree is removed, the agent session is stopped (FR-021)
+
+### WorktreeBinding (on Terminal Session — VM Agent SQLite)
+
+Associates a terminal PTY session with its creation-time worktree.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `work_dir` | TEXT | The `WorkDir` already stored on `pty.Session` — no schema change needed |
+
+**Notes**:
+- The PTY session already stores its working directory (used for `docker exec -w`)
+- With per-session CWD support, each terminal session naturally records its worktree path
+- The `workingDirectory` field is already exposed in `session_created` / `session_list` WebSocket messages
+- The tab strip uses this to show worktree badges
+
+### ActiveWorktree (UI state — URL parameter)
+
+The currently selected worktree in the browser, stored as a URL search parameter.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `worktree` | URL search param | URL-encoded container path, e.g., `?worktree=%2Fworkspaces%2Fmy-repo-wt-feature-auth` |
+
+**Semantics**:
+- Absent or empty = primary worktree
+- Determines context for file browser, git viewer, and new terminal/agent session creation
+- Does NOT affect existing terminal or agent sessions (they retain their creation-time binding)
+- Validated against worktree list on each use
+
+## Entity Relationships
+
+```
+Workspace (1:many) ← WorktreeInfo (derived from git, not stored)
+    │
+    ├── (1:many) ← AgentSession
+    │                 └── worktree_path (FK-like reference to WorktreeInfo.path)
+    │
+    └── (1:many) ← TerminalSession (via PTY Manager)
+                      └── work_dir (same semantics)
+```
+
+## State Transitions
+
+### Worktree Lifecycle
+
+```
+(none) ──create──▶ active ──remove──▶ (none)
+                     │
+                     ├── prunable (directory manually deleted)
+                     │       │
+                     │       └──prune──▶ (none)
+                     │
+                     └── dirty (uncommitted changes)
+                             │
+                             └──force-remove──▶ (none)
+```
+
+**State details**:
+- **active**: Worktree exists, listed by `git worktree list`, directory accessible
+- **prunable**: Worktree metadata exists in `.git/worktrees/` but directory is missing. Detected by `git worktree list` showing `prunable` flag
+- **dirty**: Worktree has uncommitted changes. Detected by `git status --porcelain` in the worktree directory
+
+### Active Worktree Selection (UI state machine)
+
+```
+primary ──select(wt)──▶ worktree-X
+   ▲                        │
+   │                        │ select(primary) or worktree removed
+   └────────────────────────┘
+```
+
+**Transitions**:
+- `select(wt)`: User picks a worktree from the selector → URL param updated → file browser and git viewer re-scope
+- `select(primary)`: User picks the primary worktree → URL param cleared
+- `worktree removed`: If the active worktree is removed, automatically fall back to primary
+
+## Validation Rules
+
+### Worktree Creation
+
+| Rule | Validation | Error |
+|------|-----------|-------|
+| Branch not already checked out | `git worktree list` shows no worktree with this branch | "Branch '{branch}' is already checked out in worktree at {path}" |
+| Max worktrees not exceeded | Count of existing worktrees < `MAX_WORKTREES_PER_WORKSPACE` | "Maximum of {max} worktrees per workspace reached" |
+| Branch exists (for existing branch) | `git rev-parse --verify {branch}` succeeds | "Branch '{branch}' does not exist" |
+| Valid branch name (for new branch) | `git check-ref-format --branch {name}` succeeds | "Invalid branch name: {name}" |
+| Primary worktree exists | Workspace is running and primary worktree is accessible | "Workspace is not running" |
+
+### Worktree Removal
+
+| Rule | Validation | Error |
+|------|-----------|-------|
+| Not the primary worktree | `isPrimary` is `false` | "Cannot remove the primary worktree" |
+| User confirmed if dirty | Client sends `force: true` when worktree has uncommitted changes | "Worktree has {count} uncommitted changes. Use force to remove" |
+
+### Worktree Path Validation (Security)
+
+| Rule | Validation | Error |
+|------|-----------|-------|
+| Path in worktree list | Exact match against `git worktree list` output | "Not a valid worktree path" |
+| Path under /workspaces/ | `strings.HasPrefix(path, "/workspaces/")` | "Invalid worktree path" |
+| No path traversal | `!strings.Contains(path, "..")` | "Invalid worktree path" |
+| No null bytes | `!strings.ContainsRune(path, 0)` | "Invalid worktree path" |
+
+## Configuration
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `MAX_WORKTREES_PER_WORKSPACE` | `5` | Maximum worktrees per workspace (including primary) |
+| `WORKTREE_CACHE_TTL` | `5s` | Cache duration for `git worktree list` results |
+| `GIT_WORKTREE_TIMEOUT` | `30s` | Timeout for git worktree create/remove operations |

--- a/specs/015-worktree-context/plan.md
+++ b/specs/015-worktree-context/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan: Worktree Context Switching
+
+**Branch**: `015-worktree-context` | **Date**: 2026-02-17 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/015-worktree-context/spec.md`
+
+## Summary
+
+Deep git worktree integration enabling parallel branch work within a single workspace. Users can create, switch, and remove worktrees via a selector in the workspace header. All subsystems — file browser, git viewer, terminals, and agent chat sessions — become worktree-scoped, allowing instant context switching between branches without container rebuilds. Terminals and agent sessions are bound to their creation-time worktree and retain that binding for their lifetime.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (API + Web), Go 1.22+ (VM Agent)
+**Primary Dependencies**: Hono (API), React 18 + Vite 5 (Web), creack/pty + gorilla/websocket (VM Agent), ACP SDK (agent sessions)
+**Storage**: Cloudflare D1 (agent session worktree metadata), SQLite on VM (terminal session metadata), Docker named volumes (worktree directories)
+**Testing**: Vitest + Miniflare (API/Web), Go testing (VM Agent)
+**Target Platform**: Cloudflare Workers (API), Cloudflare Pages (Web), Linux VMs (VM Agent)
+**Project Type**: web (monorepo: apps/api, apps/web, packages/vm-agent, packages/shared, packages/terminal)
+**Performance Goals**: Worktree switch <1s (no reload), worktree creation <10s, parallel agent sessions across 2+ worktrees
+**Constraints**: Named Docker volume mount at `/workspaces` (enables sibling worktree access), configurable max worktrees per workspace, worktree paths validated against `git worktree list` output
+**Scale/Scope**: Per-workspace feature; typical usage 2-5 worktrees per workspace
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Open Source | PASS | Feature is core platform functionality, no premium gating |
+| II. Infrastructure Stability | PASS | TDD required for worktree CRUD, path validation, and session binding. Integration tests for docker exec worktree commands |
+| III. Documentation Excellence | PASS | API contracts documented, data model specified, quickstart provided |
+| IV. Approachable Code | PASS | Worktree selector is intuitive UX, errors are actionable (branch already checked out, dirty worktree warnings) |
+| V. Transparent Roadmap | PASS | Feature spec exists at specs/015-worktree-context/ |
+| VI. Automated Quality Gates | PASS | Tests enforced via CI, no new manual gates needed |
+| VII. Inclusive Contribution | N/A | No changes to contribution flow |
+| VIII. AI-Friendly Repository | PASS | CLAUDE.md will be updated with worktree feature in Recent Changes |
+| IX. Clean Code Architecture | PASS | New Go package `internal/server/worktrees.go`, frontend `WorktreeSelector` component, shared types extended. No circular deps |
+| X. Simplicity & Clarity | PASS | Worktree path is threaded through existing `ContainerWorkDir` pattern. No new abstractions beyond what git worktree provides. Max worktree limit prevents complexity explosion |
+| XI. No Hardcoded Values | PASS | `MAX_WORKTREES_PER_WORKSPACE` configurable via env var with default. All worktree paths derived dynamically. No hardcoded branch names or paths |
+
+**Gate Result**: PASS — no violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/015-worktree-context/
+├── spec.md              # Feature specification (complete)
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── api.md           # VM Agent + Control Plane API contracts
+└── tasks.md             # Phase 2 output (NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+packages/vm-agent/
+├── internal/
+│   ├── config/config.go          # Add MAX_WORKTREES_PER_WORKSPACE env var
+│   ├── server/
+│   │   ├── worktrees.go          # NEW: worktree CRUD endpoints + validation
+│   │   ├── git.go                # Add worktree query param support
+│   │   ├── files.go              # Add worktree query param support
+│   │   ├── server.go             # Register worktree routes
+│   │   ├── websocket.go          # Accept worktree param for new PTY sessions
+│   │   ├── agent_ws.go           # Accept worktree param for agent sessions
+│   │   └── workspace_routing.go  # Worktree path validation helper
+│   ├── pty/
+│   │   └── manager.go            # CreateSessionWithWorkDir method
+│   └── acp/
+│       └── session_host.go       # Accept per-session ContainerWorkDir
+└── tests/                        # Unit + integration tests
+
+apps/api/
+├── src/
+│   ├── db/schema.ts              # Add worktreePath to agentSessions
+│   └── routes/workspaces.ts      # Pass worktreePath in create/list agent sessions
+└── tests/                        # Integration tests
+
+apps/web/
+├── src/
+│   ├── components/
+│   │   ├── WorktreeSelector.tsx   # NEW: dropdown with create/remove
+│   │   ├── FileBrowserPanel.tsx   # Accept worktree prop
+│   │   ├── GitChangesPanel.tsx    # Accept worktree prop
+│   │   ├── GitDiffView.tsx        # Accept worktree prop
+│   │   ├── WorkspaceTabStrip.tsx  # Worktree badge on tabs
+│   │   └── ChatSession.tsx        # Pass worktree to agent WS URL
+│   ├── pages/
+│   │   └── Workspace.tsx          # Worktree state, selector, URL param
+│   └── lib/
+│       └── api.ts                 # Add worktree param to VM Agent calls
+└── tests/
+
+packages/shared/
+└── src/types.ts                   # WorktreeInfo type, extended AgentSession
+
+packages/terminal/
+└── src/MultiTerminal.tsx          # Accept worktree for new sessions
+```
+
+**Structure Decision**: Changes span VM Agent (Go), Control Plane API (TypeScript), Web UI (React), shared types, and terminal package. No new packages needed — feature integrates into existing architecture via new endpoints and prop threading.

--- a/specs/015-worktree-context/quickstart.md
+++ b/specs/015-worktree-context/quickstart.md
@@ -1,0 +1,154 @@
+# Quickstart: Worktree Context Switching
+
+**Phase 1 output** | **Date**: 2026-02-17
+
+## Overview
+
+This feature adds git worktree support to SAM workspaces. Users can work on multiple branches simultaneously without switching — each worktree gets its own file tree, git state, terminals, and agent sessions.
+
+## Implementation Phases
+
+### Phase 1: VM Agent Backend (Go)
+
+**Goal**: Worktree CRUD endpoints + worktree-aware git/files/terminal/agent
+
+1. **Add worktree endpoints** (`internal/server/worktrees.go`):
+   - `GET /workspaces/:id/worktrees` — list via `git worktree list --porcelain`
+   - `POST /workspaces/:id/worktrees` — create via `git worktree add`
+   - `DELETE /workspaces/:id/worktrees` — remove via `git worktree remove`
+
+2. **Add worktree path validation** (`internal/server/worktrees.go`):
+   - `validateWorktreePath()` — cross-reference against `git worktree list`
+   - Cache results per `WORKTREE_CACHE_TTL` (default 5s)
+
+3. **Add worktree param to git/files endpoints** (`git.go`, `files.go`):
+   - Extract optional `worktree` query param
+   - Validate via `validateWorktreePath()`
+   - Use as `workDir` override for `docker exec -w`
+
+4. **Add per-session CWD to PTY** (`pty/manager.go`, `websocket.go`):
+   - Add `WorkDir` param to `CreateSessionWithID()`
+   - Parse `workDir` from `create_session` WebSocket message
+   - Validate worktree path before creating session
+
+5. **Add worktree-scoped agent sessions** (`agent_ws.go`):
+   - Parse `worktree` query param from agent WS URL
+   - Pass as `ContainerWorkDir` to `SessionHost` config
+
+6. **Add config** (`config/config.go`):
+   - `MAX_WORKTREES_PER_WORKSPACE` (default: 5)
+   - `WORKTREE_CACHE_TTL` (default: 5s)
+   - `GIT_WORKTREE_TIMEOUT` (default: 30s)
+
+### Phase 2: Control Plane API (TypeScript)
+
+**Goal**: Persist worktree metadata on agent sessions
+
+1. **D1 migration** (`migrations/0010_agent_sessions_worktree_path.sql`):
+   - `ALTER TABLE agent_sessions ADD COLUMN worktree_path TEXT`
+
+2. **Schema update** (`db/schema.ts`):
+   - Add `worktreePath: text('worktree_path')` to `agentSessions`
+
+3. **Route updates** (`routes/workspaces.ts`):
+   - Accept `worktreePath` in `POST /api/workspaces/:id/agent-sessions`
+   - Include `worktreePath` in session list/detail responses
+
+4. **Shared types** (`packages/shared/src/types.ts`):
+   - Add `WorktreeInfo`, `CreateWorktreeRequest` types
+   - Add `worktreePath` to `AgentSession`, `CreateAgentSessionRequest`
+
+### Phase 3: Frontend — Worktree Selector & Context Switching
+
+**Goal**: Worktree dropdown + scoped file browser and git viewer
+
+1. **WorktreeSelector component** (`components/WorktreeSelector.tsx`):
+   - Dropdown listing all worktrees with branch names
+   - Primary worktree visually distinguished
+   - "New worktree" action with branch picker
+   - "Remove" context action (with dirty warning)
+   - Mobile-responsive (56px touch targets)
+
+2. **Workspace page integration** (`pages/Workspace.tsx`):
+   - Add `worktrees` and `activeWorktree` state
+   - Add `?worktree=` URL search param
+   - Fetch worktree list on mount and after create/remove
+   - Pass `activeWorktree` to file browser, git viewer
+
+3. **API client updates** (`lib/api.ts`):
+   - Add `getWorktrees()`, `createWorktree()`, `removeWorktree()` functions
+   - Add optional `worktree` param to `getGitStatus()`, `getGitDiff()`, etc.
+
+4. **File browser & git viewer** (`FileBrowserPanel.tsx`, `GitChangesPanel.tsx`):
+   - Accept `worktree` prop
+   - Pass to API calls as query param
+
+### Phase 4: Terminal & Agent Session Integration
+
+**Goal**: Worktree-scoped terminals and agent chat sessions with tab badges
+
+1. **Terminal integration** (`packages/terminal/`):
+   - Add `workDir` to `create_session` protocol message
+   - `MultiTerminal` accepts `defaultWorkDir` prop
+   - Expose session `workingDirectory` for tab badge
+
+2. **Tab strip updates** (`WorkspaceTabStrip.tsx`):
+   - Add worktree badge to terminal and chat tabs
+   - Badge shows short branch name (derived from worktree path)
+
+3. **Agent session integration** (`ChatSession.tsx`, `Workspace.tsx`):
+   - Pass `worktreePath` when creating agent sessions (control plane API)
+   - Pass `worktree` query param on agent WebSocket URL
+   - Show worktree badge on chat tabs
+
+4. **Worktree removal cleanup** (VM Agent):
+   - When worktree is removed, stop agent sessions bound to it
+   - Notify connected viewers via ACP protocol
+
+### Phase 5: Polish & Edge Cases
+
+1. **Stale worktree detection**: Detect prunable worktrees, offer cleanup
+2. **Detached HEAD display**: Show commit hash instead of branch name
+3. **Keyboard shortcut**: Add worktree switcher to command palette
+4. **URL deep linking**: Verify worktree param survives all navigation flows
+
+## Key Files to Modify
+
+| File | Changes |
+|------|---------|
+| `packages/vm-agent/internal/server/worktrees.go` | NEW — worktree CRUD + validation |
+| `packages/vm-agent/internal/server/git.go` | Add worktree query param |
+| `packages/vm-agent/internal/server/files.go` | Add worktree query param |
+| `packages/vm-agent/internal/server/websocket.go` | Per-session workDir in create_session |
+| `packages/vm-agent/internal/server/agent_ws.go` | Worktree param on agent WS |
+| `packages/vm-agent/internal/server/server.go` | Register worktree routes |
+| `packages/vm-agent/internal/pty/manager.go` | Per-session workDir in CreateSessionWithID |
+| `packages/vm-agent/internal/config/config.go` | New env vars |
+| `apps/api/src/db/migrations/0010_*.sql` | NEW — add worktree_path column |
+| `apps/api/src/db/schema.ts` | Add worktreePath field |
+| `apps/api/src/routes/workspaces.ts` | Accept/return worktreePath |
+| `packages/shared/src/types.ts` | WorktreeInfo type, AgentSession extension |
+| `packages/terminal/src/protocol.ts` | Add workDir to create_session |
+| `packages/terminal/src/MultiTerminal.tsx` | Accept defaultWorkDir prop |
+| `apps/web/src/components/WorktreeSelector.tsx` | NEW — worktree dropdown |
+| `apps/web/src/components/FileBrowserPanel.tsx` | Accept worktree prop |
+| `apps/web/src/components/GitChangesPanel.tsx` | Accept worktree prop |
+| `apps/web/src/components/WorkspaceTabStrip.tsx` | Worktree badge |
+| `apps/web/src/components/ChatSession.tsx` | Worktree-scoped agent sessions |
+| `apps/web/src/pages/Workspace.tsx` | Worktree state, selector, URL param |
+| `apps/web/src/lib/api.ts` | Worktree API functions |
+
+## Testing Strategy
+
+| Layer | Test Type | Focus |
+|-------|-----------|-------|
+| VM Agent: worktree CRUD | Unit | Parse `git worktree list` output, path validation, error cases |
+| VM Agent: worktree CRUD | Integration | `docker exec git worktree add/remove` in real container |
+| VM Agent: git/files with worktree | Unit | Query param parsing, workDir override |
+| VM Agent: PTY per-session CWD | Unit | `CreateSessionWithID` with custom workDir |
+| VM Agent: agent WS worktree | Unit | Worktree param extraction and validation |
+| Control plane: agent session | Integration | Create/list sessions with worktreePath |
+| Control plane: D1 migration | Integration | Migration applies, column exists, nullable |
+| Frontend: WorktreeSelector | Unit | Render, create/remove actions, dirty warnings |
+| Frontend: API client | Unit | Worktree param added to fetch calls |
+| Frontend: Workspace page | Integration | Worktree state, URL param, context switching |

--- a/specs/015-worktree-context/research.md
+++ b/specs/015-worktree-context/research.md
@@ -1,0 +1,142 @@
+# Research: Worktree Context Switching
+
+**Phase 0 output** | **Date**: 2026-02-17
+
+## Research Questions & Findings
+
+### R1: Git Worktree Operations Inside Docker Named Volume
+
+**Decision**: Run `git worktree add/remove/list` inside the devcontainer via `docker exec`. Worktrees are created as sibling directories under `/workspaces/` within the same named volume.
+
+**Rationale**: The named volume `sam-ws-<workspaceId>` is mounted at `/workspaces` inside the container. The main repo lives at `/workspaces/<repoDirName>/`. Creating a worktree at `/workspaces/<repoDirName>-<branch>/` places it in the same volume, so all git metadata cross-references (`.git` file pointing to main repo's `.git/worktrees/`) resolve correctly. No container rebuild or mount changes needed.
+
+**Alternatives considered**:
+- Creating worktrees on the host filesystem: Rejected — host-side directories are not visible inside the container (only the named volume is mounted)
+- Creating worktrees inside the repo directory (e.g., `/workspaces/my-repo/.worktrees/`): Rejected — pollutes the working tree, may confuse tools and `.gitignore` rules
+- Adding dynamic bind mounts per worktree: Rejected — requires container restart, overly complex
+
+**Key finding**: `docker exec -w /workspaces/my-repo containerID git worktree add /workspaces/my-repo-feature feature` works correctly because both the `-w` flag sets the CWD for git to find `.git/`, and the absolute target path resolves within the same volume.
+
+---
+
+### R2: Per-Session Working Directory for PTY Sessions
+
+**Decision**: Add optional `workDir` field to the multi-terminal `create_session` WebSocket message. The PTY `Session` already supports per-session `WorkDir` in `SessionConfig`; only the `Manager.CreateSessionWithID()` method and the WebSocket protocol need changes to thread it through.
+
+**Rationale**: Currently, `pty.Manager` holds a single global `workDir` applied to all sessions. However, `pty.Session` already accepts `WorkDir` in `SessionConfig` and passes it as `docker exec -w <workDir>`. The change is to allow `CreateSessionWithID()` to accept an optional override, falling back to the manager's default.
+
+**Changes required**:
+1. **Go**: Add `WorkDir string` field to `wsCreateSessionData` struct; pass to `CreateSessionWithID()`; add `workDir` parameter to `CreateSessionWithID()` signature
+2. **TypeScript protocol**: Add optional `workDir` field to `create_session` message encoder
+3. **MultiTerminal component**: Accept `workDir` prop or per-session CWD parameter
+
+**Alternatives considered**:
+- Separate PTY Manager per worktree: Rejected — adds unnecessary complexity. A single manager with per-session CWD override is simpler
+- Changing CWD after session creation: Rejected — `docker exec -w` is set at process start; can't change after
+
+---
+
+### R3: Per-Session Working Directory for Agent (ACP) Sessions
+
+**Decision**: Pass the worktree path as `ContainerWorkDir` when creating a new `SessionHost` via `getOrCreateSessionHost()`. The ACP SDK's `NewSession(Cwd: ...)` already supports specifying the agent's working directory per session.
+
+**Rationale**: Each `SessionHost` owns a single agent process. The `GatewayConfig.ContainerWorkDir` is used as the `Cwd` for `NewSession()` and `LoadSession()`. Since each agent session already gets its own `SessionHost` instance, we just need to set `ContainerWorkDir` to the worktree path instead of the default workspace path.
+
+**Changes required**:
+1. Add `worktree` query parameter to the agent WebSocket URL (`/agent/ws?token=...&sessionId=...&worktree=/workspaces/my-repo-feature`)
+2. In `handleAgentWS`, extract the worktree parameter and validate it
+3. Pass the worktree path as `ContainerWorkDir` in the `GatewayConfig` when calling `getOrCreateSessionHost()`
+
+**Alternatives considered**:
+- ACP protocol message to change CWD mid-session: Not supported by ACP SDK, and per the spec, session worktree binding is immutable after creation
+
+---
+
+### R4: Worktree Path Validation (Security)
+
+**Decision**: Validate worktree paths server-side by:
+1. Running `git worktree list --porcelain` inside the container to get the canonical list of worktree paths
+2. Checking that any client-supplied `worktree` parameter matches one of these paths exactly
+3. As a defense-in-depth measure, also verify the path starts with `/workspaces/` and contains no `..` segments
+
+**Rationale**: The `worktree` parameter is client-controlled and passed to `docker exec -w`. Without validation, an attacker could set it to an arbitrary path (e.g., `/etc/`) and execute commands there. By cross-referencing with `git worktree list` output, we ensure only legitimate worktree directories are accepted.
+
+**Implementation approach**:
+- Create a `validateWorktreePath(ctx, containerID, user, primaryWorkDir, requestedPath)` helper in `worktrees.go`
+- Cache `git worktree list` results briefly (e.g., 5 seconds) since worktree creation/deletion is infrequent
+- Return a clear error message ("not a valid worktree") on validation failure
+
+**Alternatives considered**:
+- Path prefix check only (`strings.HasPrefix(path, "/workspaces/")`): Rejected — insufficient; allows any path under `/workspaces/` even if not a worktree
+- Allowlist in config: Rejected — too static; worktrees are created dynamically
+
+---
+
+### R5: D1 Migration for `worktree_path` Column
+
+**Decision**: Add `worktree_path TEXT` column to `agent_sessions` table via a D1 migration file. The column is nullable — existing sessions and sessions in the primary worktree will have `NULL`, meaning "default workspace directory."
+
+**Rationale**: The project uses numbered SQL migration files in `apps/api/src/db/migrations/` applied by Wrangler during deployment. Adding a nullable column via `ALTER TABLE` is safe, non-blocking, and backward-compatible. Drizzle ORM schema (`schema.ts`) must be updated in the same commit.
+
+**Migration file**: `apps/api/src/db/migrations/0010_agent_sessions_worktree_path.sql`
+```sql
+ALTER TABLE agent_sessions ADD COLUMN worktree_path TEXT;
+```
+
+**Schema update**: Add `worktreePath: text('worktree_path')` to `agentSessions` table in `schema.ts`.
+
+**Alternatives considered**:
+- Storing worktree info as JSON metadata field: Rejected — `worktree_path` is a single string, a dedicated column is simpler and queryable
+- Not persisting in D1 (only in VM Agent memory): Rejected — the control plane API serves `AgentSession` responses and needs to include the worktree path for UI rendering after page reload
+
+---
+
+### R6: Worktree Naming Convention
+
+**Decision**: Worktree directories are named `<repoDirName>-wt-<sanitizedBranchName>` under `/workspaces/`. For example, repo `my-repo` with branch `feature/auth` creates a worktree at `/workspaces/my-repo-wt-feature-auth`.
+
+**Rationale**: Using a `-wt-` infix avoids collisions with other workspace directories on multi-workspace nodes. Branch names are sanitized (slashes to dashes, special chars removed) to produce valid directory names.
+
+**Alternatives considered**:
+- Using numeric IDs (`my-repo-wt-1`, `my-repo-wt-2`): Rejected — not meaningful to users
+- Using branch name only (`feature-auth`): Rejected — could collide with other workspace repo directories
+- Letting the user choose the directory name: Rejected per spec scope — unnecessary complexity
+
+---
+
+### R7: Maximum Worktrees Per Workspace
+
+**Decision**: Configurable via `MAX_WORKTREES_PER_WORKSPACE` environment variable with a default of 5. Enforced server-side on the VM Agent before creating a new worktree.
+
+**Rationale**: Each worktree consumes disk space (a full checkout of the branch). With typical repos at 100MB-1GB, 5 worktrees is reasonable for the default CX3x1 VM size. Users with larger VMs can increase the limit.
+
+**Constitution compliance**: Principle XI (No Hardcoded Values) — the limit is configurable via env var with a sensible default.
+
+---
+
+### R8: Active Worktree URL Persistence
+
+**Decision**: Store the active worktree as a URL search parameter `?worktree=<path>` (URL-encoded). The path is the container-side absolute path (e.g., `/workspaces/my-repo-wt-feature-auth`). If the parameter is absent or empty, the primary worktree is used.
+
+**Rationale**: URL-based persistence provides free deep-linking, browser back/forward support, and survives page refresh. This follows the existing pattern where `git`, `files`, `view`, and `sessionId` parameters are used.
+
+**Alternatives considered**:
+- `localStorage` persistence: Rejected — not shareable, doesn't survive incognito
+- Using branch name instead of path: Rejected — branch name alone is ambiguous if the worktree directory was customized
+
+---
+
+### R9: Worktree-Scoped Git/Files Endpoints
+
+**Decision**: Add an optional `worktree` query parameter to existing git and file endpoints. When present and validated, it overrides the default `ContainerWorkDir` used as the `-w` flag for `docker exec`.
+
+**Endpoints affected**:
+- `GET /workspaces/:id/git/status?worktree=...`
+- `GET /workspaces/:id/git/diff?worktree=...`
+- `GET /workspaces/:id/git/file?worktree=...`
+- `GET /workspaces/:id/files/list?worktree=...`
+- `GET /workspaces/:id/files/find?worktree=...`
+
+**Rationale**: This is the minimal change — adding an optional parameter to existing endpoints rather than creating parallel endpoint sets. The `worktree` parameter defaults to the primary worktree when absent, preserving backward compatibility.
+
+**Security**: Every endpoint must validate the `worktree` parameter against `git worktree list` output before using it as a `docker exec -w` path. Reuse the `validateWorktreePath()` helper from R4.

--- a/specs/015-worktree-context/tasks.md
+++ b/specs/015-worktree-context/tasks.md
@@ -1,0 +1,318 @@
+# Tasks: Worktree Context Switching
+
+**Input**: Design documents from `/specs/015-worktree-context/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/api.md, quickstart.md
+
+**Tests**: Tests are included per project constitution (Principle II: Infrastructure Stability) — TDD required for critical paths.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **VM Agent (Go)**: `packages/vm-agent/internal/`
+- **Control Plane API**: `apps/api/src/`
+- **Web UI**: `apps/web/src/`
+- **Shared Types**: `packages/shared/src/`
+- **Terminal Package**: `packages/terminal/src/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Shared types, configuration, and database migration that all user stories depend on
+
+- [x] T001 Add `WorktreeInfo`, `CreateWorktreeRequest`, `WorktreeListResponse`, `RemoveWorktreeResponse` types to `packages/shared/src/types.ts`
+- [x] T002 Add `worktreePath` field to `AgentSession` and `CreateAgentSessionRequest` interfaces in `packages/shared/src/types.ts`
+- [x] T003 [P] Add `MAX_WORKTREES_PER_WORKSPACE`, `WORKTREE_CACHE_TTL`, and `GIT_WORKTREE_TIMEOUT` env vars to `packages/vm-agent/internal/config/config.go`
+- [x] T004 [P] Create D1 migration `apps/api/src/db/migrations/0010_agent_sessions_worktree_path.sql` adding `worktree_path TEXT` column to `agent_sessions`
+- [x] T005 [P] Add `worktreePath: text('worktree_path')` to `agentSessions` table in `apps/api/src/db/schema.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: VM Agent worktree CRUD endpoints and path validation that ALL user stories depend on
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T006 Implement `parseWorktreeList()` function to parse `git worktree list --porcelain` output into `[]WorktreeInfo` structs in `packages/vm-agent/internal/server/worktrees.go`
+- [x] T007 Implement `validateWorktreePath()` helper that cross-references a client-supplied path against `git worktree list` output with caching per `WORKTREE_CACHE_TTL` in `packages/vm-agent/internal/server/worktrees.go`
+- [x] T008 Implement `sanitizeBranchToDirectoryName()` helper that converts branch names (e.g., `feature/auth`) to valid directory names (e.g., `feature-auth`) in `packages/vm-agent/internal/server/worktrees.go`
+- [x] T009 Implement `resolveWorktreeWorkDir()` helper that extracts optional `worktree` query param, validates it via `validateWorktreePath()`, and returns the effective workDir (falling back to `ContainerWorkDir`) in `packages/vm-agent/internal/server/worktrees.go`
+- [x] T010 Write unit tests for `parseWorktreeList()`, `validateWorktreePath()`, `sanitizeBranchToDirectoryName()`, and `resolveWorktreeWorkDir()` in `packages/vm-agent/internal/server/worktrees_test.go`
+- [x] T011 Implement `handleListWorktrees` handler for `GET /workspaces/{workspaceId}/worktrees` that runs `git worktree list --porcelain` and `git status --porcelain` per worktree in `packages/vm-agent/internal/server/worktrees.go`
+- [x] T012 Implement `handleCreateWorktree` handler for `POST /workspaces/{workspaceId}/worktrees` with branch validation, max worktree check, duplicate branch check, and `git worktree add` in `packages/vm-agent/internal/server/worktrees.go`
+- [x] T013 Implement `handleRemoveWorktree` handler for `DELETE /workspaces/{workspaceId}/worktrees` with primary protection, dirty check, force option, agent session cleanup, and `git worktree remove` in `packages/vm-agent/internal/server/worktrees.go`
+- [x] T014 Register worktree routes (`GET/POST/DELETE /workspaces/{workspaceId}/worktrees`) in `packages/vm-agent/internal/server/server.go` `setupRoutes()`
+- [ ] T015 Write unit tests for `handleListWorktrees`, `handleCreateWorktree`, `handleRemoveWorktree` handlers covering success paths, validation errors (409 branch conflict, 422 max exceeded, 400 invalid branch, 400 primary removal), and force removal in `packages/vm-agent/internal/server/worktrees_test.go`
+
+**Checkpoint**: Worktree CRUD endpoints functional. All downstream stories can now begin.
+
+---
+
+## Phase 3: User Story 1 — View and Switch Between Worktrees (Priority: P1) MVP
+
+**Goal**: Worktree selector in workspace header with instant context switching. File browser and git viewer re-scope to the active worktree.
+
+**Independent Test**: Open worktree selector, see primary worktree listed. Create worktrees via US2 (or manually via terminal). Switch between worktrees and verify file browser and git viewer show different content.
+
+### Implementation for User Story 1
+
+- [x] T016 [P] [US1] Add `getWorktrees(workspaceUrl, workspaceId, token)` function to `apps/web/src/lib/api.ts` calling `GET /workspaces/{id}/worktrees?token=...`
+- [x] T017 [P] [US1] Add optional `worktree` parameter to `getGitStatus()`, `getGitDiff()`, `getGitFile()`, `getFileList()`, `getFileIndex()` functions in `apps/web/src/lib/api.ts`
+- [x] T018 [US1] Add `worktree` query param support to `handleGitStatus`, `handleGitDiff`, `handleGitFile` handlers using `resolveWorktreeWorkDir()` in `packages/vm-agent/internal/server/git.go`
+- [x] T019 [US1] Add `worktree` query param support to `handleFileList`, `handleFileFind` handlers using `resolveWorktreeWorkDir()` in `packages/vm-agent/internal/server/files.go`
+- [x] T020 [US1] Write unit tests for worktree param parsing and workDir override in git and file handlers in `packages/vm-agent/internal/server/git_test.go` and `packages/vm-agent/internal/server/files_test.go`
+- [x] T021 [US1] Create `WorktreeSelector` component in `apps/web/src/components/WorktreeSelector.tsx` — dropdown listing worktrees by branch name, primary distinguished with badge, mobile-responsive with 56px touch targets
+- [x] T022 [US1] Add `worktrees`, `activeWorktree` state and `?worktree=` URL search param to `apps/web/src/pages/Workspace.tsx` — fetch worktree list on mount, restore active worktree from URL on reload
+- [x] T023 [US1] Integrate `WorktreeSelector` into workspace header in `apps/web/src/pages/Workspace.tsx` — show when workspace is running, wire `onSelect` to update `activeWorktree` state and URL param
+- [x] T024 [US1] Pass `activeWorktree` as `worktree` prop to `FileBrowserPanel` in `apps/web/src/pages/Workspace.tsx` and thread it through to `getFileList()` / `getFileIndex()` calls in `apps/web/src/components/FileBrowserPanel.tsx`
+- [x] T025 [US1] Pass `activeWorktree` as `worktree` prop to `GitChangesPanel` and `GitDiffView` in `apps/web/src/pages/Workspace.tsx` and thread it through to `getGitStatus()` / `getGitDiff()` / `getGitFile()` calls in `apps/web/src/components/GitChangesPanel.tsx` and `apps/web/src/components/GitDiffView.tsx`
+- [x] T026 [US1] Close or refresh git panel / file browser when active worktree changes to prevent stale data display in `apps/web/src/pages/Workspace.tsx`
+- [x] T027 [US1] Write unit tests for `WorktreeSelector` component (render with worktrees, select callback, primary badge) in `apps/web/src/components/__tests__/WorktreeSelector.test.tsx`
+- [x] T028 [US1] Write unit tests for worktree URL param persistence and restoration in `apps/web/src/pages/__tests__/Workspace.test.tsx`
+
+**Checkpoint**: Users can see worktrees in a selector, switch between them, and the file browser + git viewer re-scope instantly. URL param survives reload.
+
+---
+
+## Phase 4: User Story 2 — Create and Remove Worktrees (Priority: P1) MVP
+
+**Goal**: Users can create new worktrees from the selector (existing or new branch) and remove them with dirty-state warnings.
+
+**Independent Test**: Click "New worktree" in selector, pick a branch, verify it appears. Try creating a duplicate (should error). Remove a worktree, verify it disappears. Remove a dirty worktree with force confirmation.
+
+### Implementation for User Story 2
+
+- [x] T029 [P] [US2] Add `createWorktree(workspaceUrl, workspaceId, token, request)` and `removeWorktree(workspaceUrl, workspaceId, token, path, force)` functions to `apps/web/src/lib/api.ts`
+- [x] T030 [US2] Add "New worktree" action to `WorktreeSelector` in `apps/web/src/components/WorktreeSelector.tsx` — inline form or modal with branch name input, create-branch toggle, loading state, error display (409 duplicate, 422 max exceeded)
+- [x] T031 [US2] Add "Remove" context action to each non-primary worktree entry in `WorktreeSelector` in `apps/web/src/components/WorktreeSelector.tsx` — confirmation dialog showing dirty file count when `isDirty`, force option, auto-switch to primary if active worktree removed
+- [x] T032 [US2] Wire create/remove actions in `apps/web/src/pages/Workspace.tsx` — call API, refresh worktree list on success, update `activeWorktree` if removed worktree was active
+- [x] T033 [US2] Disable or hide remove option for the primary worktree in `WorktreeSelector` in `apps/web/src/components/WorktreeSelector.tsx`
+- [x] T034 [US2] Write unit tests for create worktree form (branch input, validation, error states) and remove worktree dialog (dirty warning, force confirmation, primary protection) in `apps/web/src/components/__tests__/WorktreeSelector.test.tsx`
+
+**Checkpoint**: Full worktree lifecycle — create, switch, remove — works end-to-end from the UI. Users can manage parallel branch checkouts.
+
+---
+
+## Phase 5: User Story 5 — Worktree-Aware File Browser and Git Viewer (Priority: P2)
+
+**Goal**: File browser and git viewer fully scoped to the active worktree. This is largely delivered by US1; this phase handles edge cases and polish.
+
+**Independent Test**: Switch worktrees while file browser is open — verify file listing changes. Switch while viewing a git diff — verify panel refreshes or closes. Verify no stale data from previous worktree leaks through.
+
+**Note**: US5 is sequenced before US3/US4 because it completes the read-only experience started by US1 with minimal additional work.
+
+### Implementation for User Story 5
+
+- [x] T035 [US5] Reset file browser `currentPath` to root (`.`) when active worktree changes in `apps/web/src/components/FileBrowserPanel.tsx`
+- [x] T036 [US5] Clear `filesParam` and `gitParam` URL search params when active worktree changes if they reference stale context in `apps/web/src/pages/Workspace.tsx`
+- [x] T037 [US5] Invalidate and re-fetch command palette file index (`paletteFileIndex`) when active worktree changes in `apps/web/src/pages/Workspace.tsx`
+- [x] T038 [US5] Write tests verifying file browser resets and git panel refreshes on worktree switch in `apps/web/src/pages/__tests__/Workspace.test.tsx`
+
+**Checkpoint**: File browser and git viewer are fully worktree-scoped with no stale data leakage on switch.
+
+---
+
+## Phase 6: User Story 3 — Worktree-Scoped Terminals (Priority: P2)
+
+**Goal**: New terminals open in the active worktree's directory. Tab strip shows worktree badge per terminal.
+
+**Independent Test**: Select a non-primary worktree, create a new terminal, run `pwd` — verify CWD matches the worktree. Switch worktree, verify existing terminal keeps its CWD. Check tab badges.
+
+### Implementation for User Story 3
+
+- [x] T039 [P] [US3] Add optional `workDir` field to `create_session` message in `packages/terminal/src/protocol.ts` — update `encodeTerminalWsCreateSession()` to accept and include `workDir`
+- [x] T040 [P] [US3] Add `WorkDir string` field to `wsCreateSessionData` struct in `packages/vm-agent/internal/server/websocket.go`
+- [x] T041 [US3] Add `workDir` parameter to `pty.Manager.CreateSessionWithID()` in `packages/vm-agent/internal/pty/manager.go` — use provided workDir if non-empty, fall back to manager default
+- [x] T042 [US3] Thread `workDir` from `wsCreateSessionData` through `CreateSessionWithID()` call in `handleMultiTerminalWS` `create_session` handler, with worktree path validation via `resolveWorktreeWorkDir()`, in `packages/vm-agent/internal/server/websocket.go`
+- [x] T043 [US3] Write unit tests for `CreateSessionWithID()` with custom workDir override and default fallback in `packages/vm-agent/internal/pty/manager_test.go`
+- [x] T044 [US3] Add `defaultWorkDir` prop to `MultiTerminal` component in `packages/terminal/src/MultiTerminal.tsx` — pass to `encodeTerminalWsCreateSession()` when creating new sessions
+- [x] T045 [US3] Pass `activeWorktree` path as `defaultWorkDir` to `MultiTerminal` in `apps/web/src/pages/Workspace.tsx`
+- [x] T046 [US3] Add worktree badge to terminal tabs in `WorkspaceTabStrip` in `apps/web/src/components/WorkspaceTabStrip.tsx` — derive short branch name from `workingDirectory` on `MultiTerminalSessionSnapshot`, show as small label on tab
+- [x] T047 [US3] Write unit tests for terminal tab worktree badge rendering in `apps/web/src/components/__tests__/WorkspaceTabStrip.test.tsx`
+
+**Checkpoint**: Terminals open in the correct worktree directory. Tab badges clearly indicate which worktree each terminal belongs to.
+
+---
+
+## Phase 7: User Story 4 — Worktree-Scoped Agent Chat Sessions (Priority: P2)
+
+**Goal**: New agent sessions bound to the active worktree. Tab badges show worktree. Sessions persist worktree binding across reload. Removing a worktree stops its bound sessions.
+
+**Independent Test**: Select a worktree, create a chat session, ask the agent to run `pwd` — verify CWD matches. Reload page — verify session retains worktree badge. Remove the worktree — verify session stops.
+
+### Implementation for User Story 4
+
+- [x] T048 [P] [US4] Accept `worktreePath` in `POST /api/workspaces/:id/agent-sessions` request body, store in `agent_sessions.worktree_path` column, in `apps/api/src/routes/workspaces.ts`
+- [x] T049 [P] [US4] Include `worktreePath` in agent session list and detail responses (`toAgentSessionResponse()` helper) in `apps/api/src/routes/workspaces.ts`
+- [x] T050 [US4] Write integration tests for creating and listing agent sessions with `worktreePath` in `apps/api/tests/integration/`
+- [x] T051 [US4] Extract `worktree` query param from agent WebSocket URL in `handleAgentWS`, validate via `resolveWorktreeWorkDir()`, and pass as `ContainerWorkDir` in `GatewayConfig` to `getOrCreateSessionHost()` in `packages/vm-agent/internal/server/agent_ws.go`
+- [x] T052 [US4] Write unit tests for agent WS worktree param extraction and validation in `packages/vm-agent/internal/server/agent_ws_test.go`
+- [x] T053 [US4] Pass `activeWorktree` as `worktreePath` when calling `createAgentSession()` in `apps/web/src/pages/Workspace.tsx`
+- [x] T054 [US4] Append `&worktree=<path>` to agent WebSocket URL in `ChatSession` when session has a `worktreePath` in `apps/web/src/components/ChatSession.tsx`
+- [x] T055 [US4] Add worktree badge to chat session tabs in `WorkspaceTabStrip` — derive branch name from `agentSession.worktreePath` in `apps/web/src/components/WorkspaceTabStrip.tsx`
+- [x] T056 [US4] When a worktree is removed via `handleRemoveWorktree`, stop agent sessions bound to that worktree by iterating in-memory session hosts and calling `Stop()` in `packages/vm-agent/internal/server/worktrees.go`
+- [x] T057 [US4] Write unit tests for chat tab worktree badge rendering and agent session worktree binding persistence in `apps/web/src/components/__tests__/WorkspaceTabStrip.test.tsx` and `apps/web/src/pages/__tests__/Workspace.test.tsx`
+
+**Checkpoint**: Agent sessions are worktree-scoped with persistent binding. Tab badges show worktree. Removing a worktree cleans up bound sessions.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, edge cases, and final quality checks
+
+- [x] T058 [P] Add `MAX_WORKTREES_PER_WORKSPACE`, `WORKTREE_CACHE_TTL`, `GIT_WORKTREE_TIMEOUT` to environment variables documentation in `CLAUDE.md` and `AGENTS.md`
+- [x] T059 [P] Add worktree endpoints (`GET/POST/DELETE /workspaces/:id/worktrees`) and modified endpoint params to API Endpoints section in `CLAUDE.md` and `AGENTS.md`
+- [x] T060 [P] Add `worktree-context` to Recent Changes section in `CLAUDE.md` and `AGENTS.md`
+- [x] T061 Handle detached HEAD worktrees in `WorktreeSelector` — show commit hash instead of branch name when `branch` is empty or a raw hash in `apps/web/src/components/WorktreeSelector.tsx`
+- [x] T062 Handle stale/prunable worktrees in `handleListWorktrees` — detect prunable flag from `git worktree list --porcelain` output and surface in `WorktreeInfo` response in `packages/vm-agent/internal/server/worktrees.go`
+- [x] T063 Add worktree switcher to command palette — register a "Switch Worktree" action in the shortcut registry that opens the worktree selector in `apps/web/src/pages/Workspace.tsx`
+- [x] T064 Run full test suites (`pnpm test`, Go tests) and verify all pass
+- [x] T065 Run typecheck (`pnpm typecheck`) and lint (`pnpm lint`) across all packages and fix any issues
+- [x] T066 Build all packages (`pnpm build`) and verify no build errors
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 (shared types and config)
+- **US1 (Phase 3)**: Depends on Phase 2 (worktree CRUD + validation endpoints)
+- **US2 (Phase 4)**: Depends on Phase 2 (worktree CRUD endpoints) + US1 (WorktreeSelector component exists)
+- **US5 (Phase 5)**: Depends on US1 (worktree prop threading in place)
+- **US3 (Phase 6)**: Depends on Phase 2 (worktree path validation) — can run in parallel with US1/US2
+- **US4 (Phase 7)**: Depends on Phase 1 (D1 migration + schema) + Phase 2 (worktree path validation) — can run in parallel with US3
+- **Polish (Phase 8)**: Depends on all user story phases complete
+
+### User Story Dependencies
+
+```
+Phase 1: Setup ──────────────────────────┐
+                                          ▼
+Phase 2: Foundational ───┬──────────────────────────────────────┐
+                          │                                      │
+                          ▼                                      ▼
+Phase 3: US1 (View/Switch) ──┬──▶ Phase 4: US2 (Create/Remove)  │
+                              │                                   │
+                              ▼                                   │
+                    Phase 5: US5 (File/Git Polish)                │
+                                                                  │
+                    Phase 6: US3 (Terminals) ◀────────────────────┤
+                                                                  │
+                    Phase 7: US4 (Agent Sessions) ◀───────────────┘
+                              │
+                              ▼
+                    Phase 8: Polish
+```
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation (TDD for VM Agent critical paths)
+- Shared types/config before endpoint handlers
+- Backend handlers before frontend components
+- Core implementation before integration wiring
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+**Phase 1** (all tasks can run in parallel):
+
+- T001 + T002 (shared types — same file, sequential)
+- T003, T004, T005 (different files, parallel)
+
+**Phase 2** (sequential — each builds on the previous):
+
+- T006 → T007 → T008 → T009 → T010 (helpers)
+- T011 → T012 → T013 → T014 → T015 (handlers)
+
+**Phase 3 (US1)** — after Phase 2:
+
+- T016, T017 (API client — parallel, different functions)
+- T018, T019 (VM Agent handlers — parallel, different files)
+- T021 (WorktreeSelector — parallel with T018/T019)
+
+**Phase 6 (US3) + Phase 7 (US4)** — can run in parallel after Phase 2:
+
+- All of US3 (terminal) is independent from US4 (agent sessions)
+
+---
+
+## Parallel Example: Phase 1 Setup
+
+```
+# All three can run in parallel (different files):
+Task T003: "Add worktree env vars to packages/vm-agent/internal/config/config.go"
+Task T004: "Create D1 migration apps/api/src/db/migrations/0010_agent_sessions_worktree_path.sql"
+Task T005: "Add worktreePath to agentSessions in apps/api/src/db/schema.ts"
+```
+
+## Parallel Example: User Story 1
+
+```
+# After Phase 2, these can run in parallel:
+Task T016: "Add getWorktrees() to apps/web/src/lib/api.ts"
+Task T017: "Add worktree param to existing API functions in apps/web/src/lib/api.ts"
+Task T018: "Add worktree param to git handlers in packages/vm-agent/internal/server/git.go"
+Task T019: "Add worktree param to file handlers in packages/vm-agent/internal/server/files.go"
+Task T021: "Create WorktreeSelector component in apps/web/src/components/WorktreeSelector.tsx"
+```
+
+## Parallel Example: US3 + US4
+
+```
+# After Phase 2, these two stories can proceed in parallel:
+US3 (Terminals): T039-T047
+US4 (Agent Sessions): T048-T057
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 + 2 Only)
+
+1. Complete Phase 1: Setup (shared types, config, migration)
+2. Complete Phase 2: Foundational (worktree CRUD endpoints + validation)
+3. Complete Phase 3: US1 — View and switch worktrees
+4. Complete Phase 4: US2 — Create and remove worktrees
+5. **STOP and VALIDATE**: Test worktree selector, switching, file browser scoping, git viewer scoping
+6. Deploy — users can now manage worktrees and browse files/git per branch
+
+### Incremental Delivery
+
+1. Setup + Foundational → Backend ready
+2. US1 + US2 → Worktree selector + CRUD (MVP!)
+3. US5 → File browser/git viewer polish
+4. US3 → Worktree-scoped terminals with badges
+5. US4 → Worktree-scoped agent sessions with badges
+6. Each story adds value without breaking previous stories
+
+### Parallel Team Strategy
+
+With multiple developers after Phase 2:
+
+- **Developer A**: US1 (view/switch) → US2 (create/remove) → US5 (polish)
+- **Developer B**: US3 (terminals) → US4 (agent sessions)
+- Stories integrate independently; no merge conflicts expected (different files)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks
+- [Story] label maps task to specific user story for traceability
+- Each user story is independently completable and testable
+- TDD required for VM Agent critical paths (worktree CRUD, path validation)
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- US5 is sequenced before US3/US4 because it completes the read-only experience with minimal work


### PR DESCRIPTION
## Summary

- Implemented spec `015-worktree-context` end-to-end across VM agent, API, shared types, terminal package, and web workspace UI.
- Added VM-agent worktree CRUD endpoints (`GET/POST/DELETE /workspaces/:id/worktrees`) plus optional `worktree` scoping for git/file endpoints.
- Added worktree-scoped terminal and agent session creation (`workDir` / `worktree`), plus persistent `worktreePath` on API agent sessions via D1 migration `0010_agent_sessions_worktree_path.sql`.
- Added `WorktreeSelector` UI with create/remove/switch, URL param persistence, and worktree badges on tabs.
- Synced docs (`CLAUDE.md`, `AGENTS.md`) with new endpoints/env vars/behavior and updated spec task tracking.

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Additional validation run (if applicable)
- [x] Mobile and desktop verification notes added for UI changes

Additional validation:
- `cd packages/vm-agent && go test ./...`
- `gofmt -w` on all touched Go files

UI notes:
- Worktree selector and tab badge flows validated via unit tests on workspace/worktree/tab-strip paths.
- Full workspace and component test coverage updated for worktree URL persistence and stale-query clearing behavior.

## UI Compliance Checklist (Required for UI changes)

- [x] Mobile-first layout verified
- [x] Accessibility checks completed
- [x] Shared UI components used or exception documented

## Exceptions (If any)

- Scope: VM-agent handler integration tests for all worktree CRUD success/error paths (`T015`)
- Rationale: Existing VM-agent handler tests do not currently provide a docker-exec test harness; core behavior is covered by helper/unit tests and full package test pass.
- Expiration: Follow-up in next iteration of VM-agent server test harness improvements.

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [x] external-api-change
- [x] cross-component-change
- [x] business-logic-change
- [x] public-surface-change
- [x] docs-sync-change
- [x] security-sensitive-change
- [x] ui-change
- [x] infra-change

### External References

- N/A: This work implemented repository-local spec artifacts under `specs/015-worktree-context/*` and existing project architecture/docs.

### Codebase Impact Analysis

- `packages/vm-agent/internal/server/*` (worktree endpoints, git/files/workspace websocket/agent websocket integration)
- `packages/vm-agent/internal/config/config.go` (new env vars)
- `packages/vm-agent/internal/pty/*` and `packages/vm-agent/internal/acp/*` (session workdir binding)
- `apps/api/src/db/*` + `apps/api/src/routes/workspaces.ts` (worktreePath persistence)
- `packages/shared/src/types.ts` (public contracts)
- `packages/terminal/*` (protocol + default workdir)
- `apps/web/src/pages/Workspace.tsx`, `apps/web/src/components/*`, `apps/web/src/lib/*` (selector + worktree threading)

### Documentation & Specs

- `CLAUDE.md`
- `AGENTS.md` (kept identical to `CLAUDE.md`)
- `specs/015-worktree-context/tasks.md`
- `specs/015-worktree-context/plan.md`
- `specs/015-worktree-context/research.md`
- `specs/015-worktree-context/data-model.md`
- `specs/015-worktree-context/contracts/api.md`
- `specs/015-worktree-context/quickstart.md`

### Constitution & Risk Check

- Checked principles for test-first quality, explicit ownership, clear architecture boundaries, and Principle XI no hardcoded runtime values.
- Added configurable worktree limits/timeouts/cache TTL (`MAX_WORKTREES_PER_WORKSPACE`, `GIT_WORKTREE_TIMEOUT`, `WORKTREE_CACHE_TTL`) instead of hardcoding.
- Worktree path validation constrained to `/workspaces/` and validated against `git worktree list` before use.

<!-- AGENT_PREFLIGHT_END -->
