### PR TITLE
fix(web): fix terminal worktree bug and redesign worktree selector

### DIFF
--- a/apps/web/tests/unit/components/worktree-selector.test.tsx
+++ b/apps/web/tests/unit/components/worktree-selector.test.tsx
@@ -49,15 +49,40 @@ describe('WorktreeSelector', () => {
     expect(props.onSelect).toHaveBeenCalledWith('/workspaces/repo-wt-feature-auth');
   });
 
+  it('creation form is hidden by default and toggleable', () => {
+    render(<WorktreeSelector {...props} />);
+
+    // Open the popover
+    fireEvent.click(screen.getByRole('button', { name: /Switch worktree \(main\)/i }));
+
+    // Creation form should be hidden
+    expect(screen.queryByPlaceholderText('branch name')).not.toBeInTheDocument();
+
+    // Click the plus button to show creation form
+    fireEvent.click(screen.getByRole('button', { name: 'New worktree' }));
+
+    // Creation form should now be visible
+    expect(screen.getByPlaceholderText('branch name')).toBeInTheDocument();
+
+    // Click plus again to hide
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel new worktree' }));
+    expect(screen.queryByPlaceholderText('branch name')).not.toBeInTheDocument();
+  });
+
   it('calls onCreate with branch and createBranch option', async () => {
     render(<WorktreeSelector {...props} />);
 
+    // Open popover
     fireEvent.click(screen.getByRole('button', { name: /Switch worktree \(main\)/i }));
+
+    // Expand creation form
+    fireEvent.click(screen.getByRole('button', { name: 'New worktree' }));
+
     fireEvent.change(screen.getByPlaceholderText('branch name'), {
       target: { value: 'feature/new-panel' },
     });
     fireEvent.click(screen.getByLabelText('Create new branch'));
-    fireEvent.click(screen.getByRole('button', { name: 'New Worktree' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create Worktree' }));
 
     await waitFor(() => {
       expect(props.onCreate).toHaveBeenCalledWith({
@@ -67,15 +92,41 @@ describe('WorktreeSelector', () => {
     });
   });
 
-  it('calls onRemove with force=true for dirty non-primary worktree', async () => {
+  it('collapses creation form after successful creation', async () => {
     render(<WorktreeSelector {...props} />);
 
     fireEvent.click(screen.getByRole('button', { name: /Switch worktree \(main\)/i }));
-    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+    fireEvent.click(screen.getByRole('button', { name: 'New worktree' }));
+
+    fireEvent.change(screen.getByPlaceholderText('branch name'), {
+      target: { value: 'feature/test' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create Worktree' }));
+
+    await waitFor(() => {
+      expect(props.onCreate).toHaveBeenCalled();
+    });
+
+    // Form should be collapsed after successful creation
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('branch name')).not.toBeInTheDocument();
+    });
+  });
+
+  it('calls onRemove with single confirmation for dirty worktree', async () => {
+    render(<WorktreeSelector {...props} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Switch worktree \(main\)/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Remove feature\/auth/i }));
 
     await waitFor(() => {
       expect(props.onRemove).toHaveBeenCalledWith('/workspaces/repo-wt-feature-auth', true);
     });
+    // Single confirmation, not double
+    expect(window.confirm).toHaveBeenCalledTimes(1);
+    expect(window.confirm).toHaveBeenCalledWith(
+      expect.stringContaining('3 dirty files')
+    );
   });
 
   it('shows commit hash for detached-head worktree labels', () => {
@@ -109,5 +160,14 @@ describe('WorktreeSelector', () => {
 
     expect(screen.getByRole('button', { name: 'Close worktree menu' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /^feature\/auth/i })).toBeInTheDocument();
+  });
+
+  it('shows dirty file count badge for dirty worktrees', () => {
+    render(<WorktreeSelector {...props} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Switch worktree \(main\)/i }));
+
+    // The dirty worktree should show its file count
+    expect(screen.getByText('3')).toBeInTheDocument();
   });
 });

--- a/packages/terminal/src/MultiTerminal.tsx
+++ b/packages/terminal/src/MultiTerminal.tsx
@@ -103,6 +103,7 @@ export const MultiTerminal = React.forwardRef<MultiTerminalHandle, MultiTerminal
       onActivity,
       sessions,
       getPersistedSessions,
+      defaultWorkDir,
     });
     latestRef.current = {
       createSession,
@@ -113,6 +114,7 @@ export const MultiTerminal = React.forwardRef<MultiTerminalHandle, MultiTerminal
       onActivity,
       sessions,
       getPersistedSessions,
+      defaultWorkDir,
     };
 
     const resolveLocalSessionId = useCallback((sessionId?: string): string | null => {
@@ -198,7 +200,15 @@ export const MultiTerminal = React.forwardRef<MultiTerminalHandle, MultiTerminal
       createTerminalInstance(sessionId);
       const ws = wsRef.current;
       if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(encodeTerminalWsCreateSession(sessionId, 24, 80, undefined, defaultWorkDir));
+        ws.send(
+          encodeTerminalWsCreateSession(
+            sessionId,
+            24,
+            80,
+            undefined,
+            latestRef.current.defaultWorkDir
+          )
+        );
       }
       return sessionId;
     }, [createTerminalInstance]);
@@ -324,7 +334,13 @@ export const MultiTerminal = React.forwardRef<MultiTerminalHandle, MultiTerminal
                 const sessionId = latestRef.current.createSession();
                 createTerminalInstance(sessionId);
                 ws.send(
-                  encodeTerminalWsCreateSession(sessionId, 24, 80, undefined, defaultWorkDir)
+                  encodeTerminalWsCreateSession(
+                    sessionId,
+                    24,
+                    80,
+                    undefined,
+                    latestRef.current.defaultWorkDir
+                  )
                 );
               } else {
                 for (const localSession of pendingLocalSessions) {
@@ -351,7 +367,7 @@ export const MultiTerminal = React.forwardRef<MultiTerminalHandle, MultiTerminal
                         24,
                         80,
                         localSession.name,
-                        defaultWorkDir
+                        latestRef.current.defaultWorkDir
                       )
                     );
                   }


### PR DESCRIPTION
## Summary

- **Fix terminal stale closure bug**: `defaultWorkDir` was captured in a closure but not tracked through `latestRef`, so switching worktrees had zero effect on newly created terminal tabs. Now reads from `latestRef.current.defaultWorkDir` in all 3 usage sites.
- **Change worktree icon**: `GitBranch` → `GitFork` so the worktree selector is visually distinct from the git changes button on mobile (both were identical `GitBranch` icons).
- **Redesign WorktreeSelector as compact popover**: Creation form hidden behind `+` toggle (was always visible and dominating the panel), single confirmation on remove (was double `window.confirm`), auto-height sizing (50vh mobile / 320px desktop, down from 70vh / 420px), all hardcoded colors replaced with design tokens, click-outside-to-close on desktop.

## Test plan

- [x] Terminal package tests pass (93 tests including new `uses updated defaultWorkDir after prop change` test)
- [x] Web tests pass (347 tests including updated WorktreeSelector tests)
- [x] Typecheck passes
- [x] Lint passes (no new warnings)
- [ ] Verify on live app: switch worktrees, create terminal tab, confirm it opens in correct worktree
- [ ] Verify worktree selector icon is distinct from git changes icon on mobile
- [ ] Verify compact popover sizing and collapsible creation form

### Agent Preflight

**Change classes**: `ui-change`, `cross-component-change`

**Context gathered**:
- Reviewed `MultiTerminal.tsx` latestRef pattern and identified stale closure bug
- Reviewed `WorktreeSelector.tsx` current UI and identified oversizing, icon collision, double-confirm issues
- Reviewed existing design tokens and Button component for consistent styling

**Impact analysis**: Terminal bug fix changes callback behavior but not the external API. WorktreeSelector redesign changes DOM structure (tests updated). No API or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)