### PR TITLE
Add mandatory UI/UX specialist workflow for Claude and Codex

### DIFF
--- a/.agents/skills/ui-ux-specialist/CLAUDE_AGENT.md
+++ b/.agents/skills/ui-ux-specialist/CLAUDE_AGENT.md
@@ -1,0 +1,1 @@
+../../../.claude/agents/ui-ux-specialist/UI_UX_SPECIALIST.md

--- a/.agents/skills/ui-ux-specialist/SKILL.md
+++ b/.agents/skills/ui-ux-specialist/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: ui-ux-specialist
+description: "UI/UX specialist for web surfaces. Use for any UI change in apps/web, packages/vm-agent/ui, or packages/ui to enforce mobile-first layout quality, visual hierarchy, interaction clarity, and accessibility with screenshot-backed validation."
+metadata:
+  short-description: "UI/UX specialist for mobile-first, screenshot-backed quality gates"
+---
+
+# ui-ux-specialist
+
+This is a Codex skill wrapper around the Claude Code subagent definition in:
+- .claude/agents/ui-ux-specialist/
+
+Use:
+
+1. Read CLAUDE_AGENT.md.
+2. Follow its workflow, rubric, and evidence requirements.
+3. Report results with concrete file references.

--- a/.agents/skills/ui-ux-specialist/agents/openai.yaml
+++ b/.agents/skills/ui-ux-specialist/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "UI/UX Specialist"
+  short_description: "Mobile-first UX/UI quality gates"
+  default_prompt: "Use $ui-ux-specialist for this UI task: propose 2-3 variants, pick one with rationale, implement, run mobile+desktop Playwright visual checks, and report rubric scores."

--- a/.claude/agents/ui-ux-specialist/UI_UX_SPECIALIST.md
+++ b/.claude/agents/ui-ux-specialist/UI_UX_SPECIALIST.md
@@ -1,0 +1,99 @@
+---
+name: ui-ux-specialist
+description: UI/UX specialist for web surfaces. Use for any UI change in apps/web, packages/vm-agent/ui, or packages/ui to enforce mobile-first layout quality, visual hierarchy, interaction clarity, and accessibility with screenshot-backed validation.
+tools: Read, Edit, Write, Bash, Grep, Glob
+model: sonnet
+---
+
+You are a UI/UX specialist for the Simple Agent Manager web surfaces. Your role is to improve interface quality with concrete, testable standards instead of subjective taste.
+
+## When Invoked
+
+Use this agent for any change that touches:
+- `apps/web/**`
+- `packages/vm-agent/ui/**`
+- `packages/ui/**`
+
+## Required Workflow
+
+1. Classify the UI change scope (new screen, component update, interaction flow, visual polish).
+2. Produce 2-3 viable layout/interaction variants before implementing.
+3. Choose one variant with explicit tradeoff rationale.
+4. Implement the selected variant with mobile-first defaults.
+5. Run screenshot-backed validation on mobile and desktop.
+6. Report a rubric score for the final UI and list any compromises.
+
+## UX/UI Rubric (Must Pass)
+
+Score each category 1-5 and require at least 4 in every category:
+- Visual hierarchy and scanability
+- Interaction clarity (primary CTA prominence, form feedback, state clarity)
+- Mobile usability (single-column baseline, no horizontal overflow at 320px, 56px minimum primary touch targets)
+- Accessibility (keyboard access, focus visibility, non-color-only status cues)
+- System consistency (shared components, tokens, spacing rhythm, typography consistency)
+
+If any category is below 4, revise and re-evaluate before completion.
+
+## Mandatory Implementation Standards
+
+1. Prefer shared components from `@simple-agent-manager/ui` when available.
+2. Use semantic tokens from `packages/ui/src/tokens/semantic-tokens.ts` and CSS variables from `packages/ui/src/tokens/theme.css`.
+3. Preserve existing design-system patterns where they already exist; avoid introducing ad-hoc visual languages in established sections.
+4. Avoid generic default styling choices when creating new visual surfaces:
+   - do not default to stock system look without intentional hierarchy/spacing
+   - avoid flat single-color page backgrounds unless context requires it
+   - use deliberate typography scale and contrast
+5. Maintain responsive behavior:
+   - single-column baseline on small screens
+   - no required horizontal scrolling at 320px for core flows
+   - dialogs/popovers remain within viewport bounds
+
+## Required Evidence
+
+For each UI task, provide:
+- Variant summary (2-3 options considered)
+- Selected option and rationale
+- Mobile screenshot evidence (min 375x667)
+- Desktop screenshot evidence
+- Rubric scoring table
+- List of issues found and fixed during visual verification
+
+Store development screenshots in `.codex/tmp/playwright-screenshots/`.
+
+## Playwright Validation
+
+1. Start local dev server.
+2. Capture at least one mobile screenshot and one desktop screenshot for changed surfaces.
+3. Verify no clipping, overflow, overlap, or unreadable controls.
+4. If auth-gated, use a mock harness or authenticated flow as applicable.
+
+## Output Format
+
+```markdown
+## UI/UX Validation Report
+
+### Variants Considered
+1. ...
+2. ...
+3. ...
+
+### Selected Direction
+- Choice: ...
+- Why: ...
+
+### Rubric Scores
+| Category | Score (1-5) | Notes |
+|---|---:|---|
+| Visual hierarchy |  |  |
+| Interaction clarity |  |  |
+| Mobile usability |  |  |
+| Accessibility |  |  |
+| System consistency |  |  |
+
+### Screenshot Evidence
+- Mobile: `...`
+- Desktop: `...`
+
+### Issues Found/Fixes
+- ...
+```

--- a/.claude/rules/04-ui-standards.md
+++ b/.claude/rules/04-ui-standards.md
@@ -49,3 +49,8 @@ For UI changes in `apps/web`, `packages/vm-agent/ui`, or `packages/ui`:
 5. If a shared component is missing, either:
    - add/extend it in `packages/ui`, or
    - document a temporary exception with rationale and expiration.
+6. Invoke `$ui-ux-specialist` for every UI task and follow its workflow/rubric.
+7. Before implementation, create 2-3 layout/interaction variants and select one with explicit tradeoff rationale.
+8. Complete visual verification with Playwright on both mobile (>=375x667) and desktop, then report concrete issues found/fixed.
+9. Provide rubric scores (1-5) for visual hierarchy, interaction clarity, mobile usability, accessibility, and system consistency; each score MUST be >=4 before completion.
+10. Avoid generic default styling for new surfaces unless constrained by an existing design system that the feature already uses.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -663,6 +663,7 @@ Claude Code now supports dual authentication methods:
 - `SKILL.md` contains Codex-valid frontmatter and brief usage instructions.
 - `CLAUDE_AGENT.md` points to the source subagent definition in `.claude/agents/`.
 - Keep `.claude/agents/*/*.md` as the source of truth. Do not add Claude-specific frontmatter keys (e.g. `tools`, `model`) to `SKILL.md` files.
+- For UI work, agents MUST invoke `$ui-ux-specialist` before editing files and keep it active through implementation and validation.
 
 ### Fix All Build and Lint Errors (NON-NEGOTIABLE)
 
@@ -831,6 +832,11 @@ For UI changes in `apps/web`, `packages/vm-agent/ui`, or `packages/ui`:
 5. If a shared component is missing, either:
    - add/extend it in `packages/ui`, or
    - document a temporary exception with rationale and expiration.
+6. Invoke `$ui-ux-specialist` for every UI task and follow its workflow/rubric.
+7. Before implementation, create 2-3 layout/interaction variants and select one with explicit tradeoff rationale.
+8. Complete visual verification with Playwright on both mobile (>=375x667) and desktop, then report concrete issues found/fixed.
+9. Provide rubric scores (1-5) for visual hierarchy, interaction clarity, mobile usability, accessibility, and system consistency; each score MUST be >=4 before completion.
+10. Avoid generic default styling for new surfaces unless constrained by an existing design system that the feature already uses.
 
 ## Active Technologies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -663,6 +663,7 @@ Claude Code now supports dual authentication methods:
 - `SKILL.md` contains Codex-valid frontmatter and brief usage instructions.
 - `CLAUDE_AGENT.md` points to the source subagent definition in `.claude/agents/`.
 - Keep `.claude/agents/*/*.md` as the source of truth. Do not add Claude-specific frontmatter keys (e.g. `tools`, `model`) to `SKILL.md` files.
+- For UI work, agents MUST invoke `$ui-ux-specialist` before editing files and keep it active through implementation and validation.
 
 ### Fix All Build and Lint Errors (NON-NEGOTIABLE)
 
@@ -831,6 +832,11 @@ For UI changes in `apps/web`, `packages/vm-agent/ui`, or `packages/ui`:
 5. If a shared component is missing, either:
    - add/extend it in `packages/ui`, or
    - document a temporary exception with rationale and expiration.
+6. Invoke `$ui-ux-specialist` for every UI task and follow its workflow/rubric.
+7. Before implementation, create 2-3 layout/interaction variants and select one with explicit tradeoff rationale.
+8. Complete visual verification with Playwright on both mobile (>=375x667) and desktop, then report concrete issues found/fixed.
+9. Provide rubric scores (1-5) for visual hierarchy, interaction clarity, mobile usability, accessibility, and system consistency; each score MUST be >=4 before completion.
+10. Avoid generic default styling for new surfaces unless constrained by an existing design system that the feature already uses.
 
 ## Active Technologies
 


### PR DESCRIPTION
## Summary
- add new shared UI/UX specialist agent definition at `.claude/agents/ui-ux-specialist/UI_UX_SPECIALIST.md`
- add matching Codex wrapper skill at `.agents/skills/ui-ux-specialist/` (including `openai.yaml` and `CLAUDE_AGENT.md` symlink)
- enforce `$ui-ux-specialist` usage in shared instructions by updating `AGENTS.md` and `CLAUDE.md`
- align Claude auto-loaded UI rule file with the same variant/rubric/screenshot gates in `.claude/rules/04-ui-standards.md`

## Why
Codifies a stricter, repeatable UI process (variants, rubric minimums, screenshot evidence) so UI/UX quality gates are enforced consistently for both Claude and Codex.

## Validation
- documentation/configuration-only change; no runtime code paths changed
- verified `AGENTS.md` and `CLAUDE.md` remain identical via `cmp`
