### PR TITLE
fix: use npx wrangler for www deploy

### DIFF
--- a/.github/workflows/deploy-www.yml
+++ b/.github/workflows/deploy-www.yml
@@ -43,8 +43,7 @@ jobs:
         run: pnpm --filter @simple-agent-manager/www build
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CF_API_TOKEN }}
-          accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          command: pages deploy apps/www/dist --project-name=sam-www --commit-dirty=true
+        run: npx wrangler pages deploy apps/www/dist --project-name=sam-www --commit-dirty=true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

- Replace `cloudflare/wrangler-action@v3` with `npx wrangler` in the marketing site deploy workflow
- The action tried `pnpm add wrangler` at the workspace root, which pnpm rejects in a monorepo without `-w` flag
- `npx wrangler` finds the binary already installed via api/web package devDependencies

## Validation

- [x] `pnpm lint` — no changes to lintable code
- [x] `pnpm typecheck` — no changes to TypeScript
- [x] `pnpm test` — no changes to testable code
- [x] Additional validation run: CI workflow change only, validated by merge+deploy

## Exceptions (If any)

- Scope: Workflow file only
- Rationale: No tests needed for CI workflow YAML changes
- Expiration: N/A

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [ ] cross-component-change
- [ ] business-logic-change
- [ ] public-surface-change
- [ ] docs-sync-change
- [ ] security-sensitive-change
- [ ] ui-change
- [x] infra-change

### External References

N/A: Fix is based on CI failure logs from run #22244466579 showing `ERR_PNPM_ADDING_TO_ROOT` when `cloudflare/wrangler-action@v3` tries `pnpm add wrangler` without `-w` flag.

### Codebase Impact Analysis

- `.github/workflows/deploy-www.yml` — only file changed
- No impact on application code, only CI/CD pipeline for marketing site

### Documentation & Specs

N/A: No behavior or interface changes, only CI workflow fix.

### Constitution & Risk Check

- Principle XI (No Hardcoded Values): N/A — no hardcoded values introduced
- Risk: Low — replaces third-party action with direct `npx` call, consistent with existing `deploy.yml` patterns

<!-- AGENT_PREFLIGHT_END -->

Generated with [Claude Code](https://claude.com/claude-code)