### PR TITLE
feat(www): add Cloudflare Pages infra provisioning and teardown workflows

### DIFF
--- a/.github/workflows/deploy-www.yml
+++ b/.github/workflows/deploy-www.yml
@@ -14,6 +14,8 @@ concurrency:
 
 env:
   NODE_VERSION: '22'
+  # Pages project name — must match provision-www.yml
+  PAGES_PROJECT: sam-www
 
 jobs:
   deploy:
@@ -41,9 +43,31 @@ jobs:
 
       - name: Build marketing site
         run: pnpm --filter @simple-agent-manager/www build
+        env:
+          SITE_URL: https://www.${{ vars.BASE_DOMAIN }}
 
       - name: Deploy to Cloudflare Pages
-        run: npx wrangler pages deploy apps/www/dist --project-name=sam-www --commit-dirty=true
+        run: npx wrangler pages deploy apps/www/dist --project-name=${{ env.PAGES_PROJECT }} --commit-dirty=true
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+
+      - name: Write Job Summary
+        if: always()
+        run: |
+          WWW_DOMAIN="www.${{ vars.BASE_DOMAIN }}"
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "## Marketing Site Deployed" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "**URL:** https://${WWW_DOMAIN}" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Pages URL:** https://${{ env.PAGES_PROJECT }}.pages.dev" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Commit:** \`${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## Marketing Site Deployment Failed" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Check the logs above for error details." >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "### Troubleshooting" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Ensure infrastructure is provisioned (run the **Provision Marketing Site Infrastructure** workflow)" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Verify \`CF_API_TOKEN\` and \`CF_ACCOUNT_ID\` secrets are set" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/provision-www.yml
+++ b/.github/workflows/provision-www.yml
@@ -1,0 +1,290 @@
+name: Provision Marketing Site Infrastructure
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: www-infra
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: '22'
+  # Pages project name — must match deploy-www.yml
+  PAGES_PROJECT: sam-www
+
+jobs:
+  provision:
+    name: Provision Cloudflare Pages + DNS
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Resolve Domain
+        id: domain
+        run: |
+          DOMAIN="${{ vars.BASE_DOMAIN }}"
+          if [ -z "$DOMAIN" ]; then
+            echo "::error::BASE_DOMAIN is not set in environment variables."
+            exit 1
+          fi
+          echo "base=$DOMAIN" >> "$GITHUB_OUTPUT"
+          echo "www=www.$DOMAIN" >> "$GITHUB_OUTPUT"
+          echo "Base domain: $DOMAIN"
+          echo "WWW domain: www.$DOMAIN"
+
+      # ========================================
+      # Phase 1: Cloudflare Pages Project
+      # ========================================
+      - name: Create Pages Project
+        run: |
+          echo "Creating Cloudflare Pages project: $PAGES_PROJECT"
+          # wrangler pages project create is idempotent-ish — errors if project exists, which is fine
+          npx wrangler pages project create "$PAGES_PROJECT" --production-branch main 2>&1 || echo "Pages project already exists (OK)"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+
+      # ========================================
+      # Phase 2: DNS Records
+      # ========================================
+      - name: Create DNS Records
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
+        run: |
+          BASE_DOMAIN="${{ steps.domain.outputs.base }}"
+          API="https://api.cloudflare.com/client/v4"
+          AUTH="Authorization: Bearer $CF_API_TOKEN"
+
+          # --- www CNAME → sam-www.pages.dev (proxied) ---
+          echo "=== Creating CNAME record for www.$BASE_DOMAIN ==="
+          EXISTING=$(curl -sf "$API/zones/$CF_ZONE_ID/dns_records?type=CNAME&name=www.$BASE_DOMAIN" \
+            -H "$AUTH" | jq '.result | length')
+
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "CNAME record for www.$BASE_DOMAIN already exists, updating..."
+            RECORD_ID=$(curl -sf "$API/zones/$CF_ZONE_ID/dns_records?type=CNAME&name=www.$BASE_DOMAIN" \
+              -H "$AUTH" | jq -r '.result[0].id')
+            curl -sf "$API/zones/$CF_ZONE_ID/dns_records/$RECORD_ID" \
+              -X PUT \
+              -H "$AUTH" \
+              -H "Content-Type: application/json" \
+              -d "{
+                \"type\": \"CNAME\",
+                \"name\": \"www\",
+                \"content\": \"${PAGES_PROJECT}.pages.dev\",
+                \"ttl\": 1,
+                \"proxied\": true,
+                \"comment\": \"Marketing site (Cloudflare Pages) - managed by provision-www workflow\"
+              }" | jq '.success'
+          else
+            echo "Creating CNAME: www.$BASE_DOMAIN -> ${PAGES_PROJECT}.pages.dev"
+            curl -sf "$API/zones/$CF_ZONE_ID/dns_records" \
+              -H "$AUTH" \
+              -H "Content-Type: application/json" \
+              -d "{
+                \"type\": \"CNAME\",
+                \"name\": \"www\",
+                \"content\": \"${PAGES_PROJECT}.pages.dev\",
+                \"ttl\": 1,
+                \"proxied\": true,
+                \"comment\": \"Marketing site (Cloudflare Pages) - managed by provision-www workflow\"
+              }" | jq '.success'
+          fi
+
+          # --- Apex A record → 192.0.2.1 (proxied, for redirect interception) ---
+          echo ""
+          echo "=== Creating A record for $BASE_DOMAIN (apex redirect target) ==="
+          EXISTING=$(curl -sf "$API/zones/$CF_ZONE_ID/dns_records?type=A&name=$BASE_DOMAIN" \
+            -H "$AUTH" | jq '.result | length')
+
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "A record for $BASE_DOMAIN already exists, updating..."
+            RECORD_ID=$(curl -sf "$API/zones/$CF_ZONE_ID/dns_records?type=A&name=$BASE_DOMAIN" \
+              -H "$AUTH" | jq -r '.result[0].id')
+            curl -sf "$API/zones/$CF_ZONE_ID/dns_records/$RECORD_ID" \
+              -X PUT \
+              -H "$AUTH" \
+              -H "Content-Type: application/json" \
+              -d "{
+                \"type\": \"A\",
+                \"name\": \"@\",
+                \"content\": \"192.0.2.1\",
+                \"ttl\": 1,
+                \"proxied\": true,
+                \"comment\": \"Apex redirect to www - managed by provision-www workflow\"
+              }" | jq '.success'
+          else
+            echo "Creating A record: $BASE_DOMAIN -> 192.0.2.1 (proxied, for redirect)"
+            curl -sf "$API/zones/$CF_ZONE_ID/dns_records" \
+              -H "$AUTH" \
+              -H "Content-Type: application/json" \
+              -d "{
+                \"type\": \"A\",
+                \"name\": \"@\",
+                \"content\": \"192.0.2.1\",
+                \"ttl\": 1,
+                \"proxied\": true,
+                \"comment\": \"Apex redirect to www - managed by provision-www workflow\"
+              }" | jq '.success'
+          fi
+
+      # ========================================
+      # Phase 3: Custom Domain on Pages Project
+      # ========================================
+      - name: Add Custom Domain to Pages Project
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          WWW_DOMAIN="${{ steps.domain.outputs.www }}"
+          API="https://api.cloudflare.com/client/v4"
+          AUTH="Authorization: Bearer $CF_API_TOKEN"
+
+          echo "Adding custom domain $WWW_DOMAIN to Pages project $PAGES_PROJECT..."
+
+          RESPONSE=$(curl -s -w "\n%{http_code}" "$API/accounts/$CF_ACCOUNT_ID/pages/projects/$PAGES_PROJECT/domains" \
+            -H "$AUTH" \
+            -H "Content-Type: application/json" \
+            -d "{\"name\": \"$WWW_DOMAIN\"}")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          if echo "$BODY" | jq -e '.success == true' > /dev/null 2>&1; then
+            echo "Custom domain $WWW_DOMAIN added successfully."
+          elif echo "$BODY" | jq -e '.errors[0].code == 8000040' > /dev/null 2>&1; then
+            echo "Custom domain $WWW_DOMAIN already exists on project (OK)."
+          else
+            echo "::warning::Custom domain response (HTTP $HTTP_CODE): $BODY"
+            echo "This may resolve after DNS propagation. Check Cloudflare dashboard if needed."
+          fi
+
+      # ========================================
+      # Phase 4: Apex → www Redirect (Page Rule)
+      # ========================================
+      - name: Create Apex Redirect Rule
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
+        run: |
+          BASE_DOMAIN="${{ steps.domain.outputs.base }}"
+          WWW_DOMAIN="${{ steps.domain.outputs.www }}"
+          API="https://api.cloudflare.com/client/v4"
+          AUTH="Authorization: Bearer $CF_API_TOKEN"
+
+          echo "Creating Page Rule: $BASE_DOMAIN/* -> https://$WWW_DOMAIN/\$1 (301)"
+
+          # Check for existing page rule matching this pattern
+          EXISTING_RULES=$(curl -sf "$API/zones/$CF_ZONE_ID/pagerules?status=active" \
+            -H "$AUTH")
+          EXISTING_ID=$(echo "$EXISTING_RULES" | jq -r --arg pattern "${BASE_DOMAIN}/*" \
+            '.result[] | select(.targets[0].constraint.value == $pattern) | .id' 2>/dev/null)
+
+          if [ -n "$EXISTING_ID" ] && [ "$EXISTING_ID" != "null" ]; then
+            echo "Page Rule already exists (ID: $EXISTING_ID), updating..."
+            curl -sf "$API/zones/$CF_ZONE_ID/pagerules/$EXISTING_ID" \
+              -X PUT \
+              -H "$AUTH" \
+              -H "Content-Type: application/json" \
+              -d "{
+                \"targets\": [{
+                  \"target\": \"url\",
+                  \"constraint\": {
+                    \"operator\": \"matches\",
+                    \"value\": \"${BASE_DOMAIN}/*\"
+                  }
+                }],
+                \"actions\": [{
+                  \"id\": \"forwarding_url\",
+                  \"value\": {
+                    \"url\": \"https://${WWW_DOMAIN}/\$1\",
+                    \"status_code\": 301
+                  }
+                }],
+                \"status\": \"active\"
+              }" | jq '.success'
+          else
+            echo "Creating new Page Rule..."
+            curl -sf "$API/zones/$CF_ZONE_ID/pagerules" \
+              -H "$AUTH" \
+              -H "Content-Type: application/json" \
+              -d "{
+                \"targets\": [{
+                  \"target\": \"url\",
+                  \"constraint\": {
+                    \"operator\": \"matches\",
+                    \"value\": \"${BASE_DOMAIN}/*\"
+                  }
+                }],
+                \"actions\": [{
+                  \"id\": \"forwarding_url\",
+                  \"value\": {
+                    \"url\": \"https://${WWW_DOMAIN}/\$1\",
+                    \"status_code\": 301
+                  }
+                }],
+                \"status\": \"active\"
+              }" | jq '.success'
+          fi
+
+      # ========================================
+      # Summary
+      # ========================================
+      - name: Write Job Summary
+        if: always()
+        run: |
+          BASE_DOMAIN="${{ steps.domain.outputs.base }}"
+          WWW_DOMAIN="${{ steps.domain.outputs.www }}"
+
+          if [ "${{ job.status }}" = "success" ]; then
+            cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Marketing Site Infrastructure Provisioned
+
+          ### DNS Records (Cloudflare)
+          | Type | Name | Content | Proxied |
+          |------|------|---------|---------|
+          | CNAME | \`www.${BASE_DOMAIN}\` | \`${PAGES_PROJECT}.pages.dev\` | Yes |
+          | A | \`${BASE_DOMAIN}\` | \`192.0.2.1\` | Yes (redirect target) |
+
+          ### Cloudflare Pages
+          - **Project:** \`${PAGES_PROJECT}\`
+          - **Custom domain:** \`${WWW_DOMAIN}\`
+          - **Pages URL:** \`${PAGES_PROJECT}.pages.dev\`
+
+          ### Redirect
+          - \`${BASE_DOMAIN}/*\` → \`https://${WWW_DOMAIN}/\$1\` (301)
+
+          ### Next Steps
+          1. Run the **Deploy Marketing Site** workflow to publish the site
+          2. Verify \`https://${WWW_DOMAIN}\` loads after deployment
+          3. Verify \`https://${BASE_DOMAIN}\` redirects to \`https://${WWW_DOMAIN}\`
+          EOF
+          else
+            cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Provisioning Failed
+
+          Check the logs above for error details.
+
+          ### Troubleshooting
+          - Verify \`CF_API_TOKEN\` has DNS and Pages edit permissions
+          - Verify \`CF_ZONE_ID\` is correct for \`${BASE_DOMAIN}\`
+          - Verify \`BASE_DOMAIN\` is set in environment variables
+          EOF
+          fi

--- a/.github/workflows/teardown-www.yml
+++ b/.github/workflows/teardown-www.yml
@@ -1,0 +1,201 @@
+name: Teardown Marketing Site Infrastructure
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type DELETE to confirm teardown'
+        required: true
+        type: string
+
+concurrency:
+  group: www-infra
+  cancel-in-progress: false
+
+env:
+  PAGES_PROJECT: sam-www
+
+jobs:
+  teardown:
+    name: Teardown Cloudflare Pages + DNS
+    runs-on: ubuntu-latest
+    environment: production
+    if: ${{ github.event.inputs.confirm == 'DELETE' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Resolve Domain
+        id: domain
+        run: |
+          DOMAIN="${{ vars.BASE_DOMAIN }}"
+          if [ -z "$DOMAIN" ]; then
+            echo "::error::BASE_DOMAIN is not set in environment variables."
+            exit 1
+          fi
+          echo "base=$DOMAIN" >> "$GITHUB_OUTPUT"
+          echo "www=www.$DOMAIN" >> "$GITHUB_OUTPUT"
+
+      # ========================================
+      # Phase 1: Remove Page Rule (apex redirect)
+      # ========================================
+      - name: Remove Apex Redirect Page Rule
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
+        run: |
+          BASE_DOMAIN="${{ steps.domain.outputs.base }}"
+          API="https://api.cloudflare.com/client/v4"
+          AUTH="Authorization: Bearer $CF_API_TOKEN"
+
+          echo "Looking for Page Rule matching ${BASE_DOMAIN}/*..."
+          RULE_ID=$(curl -sf "$API/zones/$CF_ZONE_ID/pagerules?status=active" \
+            -H "$AUTH" | jq -r --arg pattern "${BASE_DOMAIN}/*" \
+            '.result[] | select(.targets[0].constraint.value == $pattern) | .id' 2>/dev/null)
+
+          if [ -n "$RULE_ID" ] && [ "$RULE_ID" != "null" ]; then
+            echo "Deleting Page Rule: $RULE_ID"
+            curl -sf "$API/zones/$CF_ZONE_ID/pagerules/$RULE_ID" \
+              -X DELETE \
+              -H "$AUTH" | jq '.success'
+          else
+            echo "No matching Page Rule found (OK)."
+          fi
+
+      # ========================================
+      # Phase 2: Remove Custom Domain from Pages
+      # ========================================
+      - name: Remove Custom Domain from Pages Project
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          WWW_DOMAIN="${{ steps.domain.outputs.www }}"
+          API="https://api.cloudflare.com/client/v4"
+          AUTH="Authorization: Bearer $CF_API_TOKEN"
+
+          echo "Removing custom domain $WWW_DOMAIN from $PAGES_PROJECT..."
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            "$API/accounts/$CF_ACCOUNT_ID/pages/projects/$PAGES_PROJECT/domains/$WWW_DOMAIN" \
+            -X DELETE \
+            -H "$AUTH")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          if echo "$BODY" | jq -e '.success == true' > /dev/null 2>&1; then
+            echo "Custom domain removed."
+          else
+            echo "Custom domain removal response (HTTP $HTTP_CODE): $BODY"
+            echo "May already be removed (OK)."
+          fi
+
+      # ========================================
+      # Phase 3: Remove DNS Records
+      # ========================================
+      - name: Remove DNS Records
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
+        run: |
+          BASE_DOMAIN="${{ steps.domain.outputs.base }}"
+          API="https://api.cloudflare.com/client/v4"
+          AUTH="Authorization: Bearer $CF_API_TOKEN"
+
+          # --- Remove www CNAME ---
+          echo "=== Removing CNAME record for www.$BASE_DOMAIN ==="
+          RECORD_ID=$(curl -sf "$API/zones/$CF_ZONE_ID/dns_records?type=CNAME&name=www.$BASE_DOMAIN" \
+            -H "$AUTH" | jq -r '.result[] | select(.comment | test("provision-www")) | .id' 2>/dev/null)
+
+          if [ -n "$RECORD_ID" ] && [ "$RECORD_ID" != "null" ]; then
+            echo "Deleting CNAME record: $RECORD_ID"
+            curl -sf "$API/zones/$CF_ZONE_ID/dns_records/$RECORD_ID" \
+              -X DELETE \
+              -H "$AUTH" | jq '.success'
+          else
+            echo "No www CNAME record found with provision-www tag (OK)."
+          fi
+
+          # --- Remove apex A record ---
+          echo ""
+          echo "=== Removing A record for $BASE_DOMAIN ==="
+          RECORD_ID=$(curl -sf "$API/zones/$CF_ZONE_ID/dns_records?type=A&name=$BASE_DOMAIN" \
+            -H "$AUTH" | jq -r '.result[] | select(.comment | test("provision-www")) | .id' 2>/dev/null)
+
+          if [ -n "$RECORD_ID" ] && [ "$RECORD_ID" != "null" ]; then
+            echo "Deleting A record: $RECORD_ID"
+            curl -sf "$API/zones/$CF_ZONE_ID/dns_records/$RECORD_ID" \
+              -X DELETE \
+              -H "$AUTH" | jq '.success'
+          else
+            echo "No apex A record found with provision-www tag (OK)."
+          fi
+
+      # ========================================
+      # Phase 4: Delete Pages Project
+      # ========================================
+      - name: Delete Pages Project
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          API="https://api.cloudflare.com/client/v4"
+          AUTH="Authorization: Bearer $CF_API_TOKEN"
+
+          echo "Deleting Cloudflare Pages project: $PAGES_PROJECT"
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            "$API/accounts/$CF_ACCOUNT_ID/pages/projects/$PAGES_PROJECT" \
+            -X DELETE \
+            -H "$AUTH")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          if echo "$BODY" | jq -e '.success == true' > /dev/null 2>&1; then
+            echo "Pages project deleted."
+          elif [ "$HTTP_CODE" = "404" ]; then
+            echo "Pages project not found (already deleted, OK)."
+          else
+            echo "::warning::Delete response (HTTP $HTTP_CODE): $BODY"
+          fi
+
+      # ========================================
+      # Summary
+      # ========================================
+      - name: Write Job Summary
+        if: always()
+        run: |
+          BASE_DOMAIN="${{ steps.domain.outputs.base }}"
+          if [ "${{ job.status }}" = "success" ]; then
+            cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Marketing Site Infrastructure Torn Down
+
+          ### Removed
+          - Page Rule: \`${BASE_DOMAIN}/*\` redirect
+          - Custom domain: \`www.${BASE_DOMAIN}\`
+          - DNS CNAME: \`www.${BASE_DOMAIN}\`
+          - DNS A: \`${BASE_DOMAIN}\` (apex redirect)
+          - Pages project: \`${PAGES_PROJECT}\`
+
+          ### To Re-provision
+          Run the **Provision Marketing Site Infrastructure** workflow.
+          EOF
+          else
+            cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Teardown Failed
+
+          Check the logs above for error details. Some resources may have been partially removed.
+          EOF
+          fi
+
+  validate:
+    name: Validate Confirmation
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.confirm != 'DELETE' }}
+    steps:
+      - name: Confirmation Required
+        run: |
+          echo "::error::Teardown requires confirmation. Type 'DELETE' in the confirm field."
+          echo "## Teardown Cancelled" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "You must type \`DELETE\` in the confirmation field to proceed." >> "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
-  site: 'https://simple-agent-manager.org',
+  site: process.env.SITE_URL || 'https://www.simple-agent-manager.org',
   integrations: [sitemap()],
   build: {
     assets: '_assets',

--- a/apps/www/public/robots.txt
+++ b/apps/www/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://simple-agent-manager.org/sitemap-index.xml
+Sitemap: https://www.simple-agent-manager.org/sitemap-index.xml


### PR DESCRIPTION
## Summary

- Add `provision-www.yml` workflow (manual trigger) that provisions all Cloudflare infrastructure for the marketing site with zero ClickOps:
  - Creates `sam-www` Cloudflare Pages project
  - Creates DNS CNAME record: `www.${BASE_DOMAIN}` -> `sam-www.pages.dev` (proxied)
  - Creates DNS A record: `${BASE_DOMAIN}` -> `192.0.2.1` (proxied, for redirect interception)
  - Adds `www.${BASE_DOMAIN}` as custom domain on the Pages project
  - Creates a Page Rule: `${BASE_DOMAIN}/*` -> 301 redirect to `https://www.${BASE_DOMAIN}/$1`
- Add `teardown-www.yml` workflow (manual trigger, requires `DELETE` confirmation) that reverses all provisioning
- Update `deploy-www.yml` to pass `SITE_URL` env var to the build and add a job summary
- Update `astro.config.mjs` to use `SITE_URL` env var (configurable, no hardcoded URL)
- Update `robots.txt` sitemap URL to `www.` subdomain

### Domain mapping after provisioning
| URL | Behavior |
|-----|----------|
| `simple-agent-manager.org` | 301 redirect to `www.simple-agent-manager.org` |
| `www.simple-agent-manager.org` | Marketing site (Cloudflare Pages) |
| `app.simple-agent-manager.org` | Control plane UI (unchanged) |

### Usage
1. Run **Provision Marketing Site Infrastructure** workflow (one-time setup)
2. **Deploy Marketing Site** runs automatically on push to main (or manually)
3. Run **Teardown Marketing Site Infrastructure** to remove everything (type `DELETE` to confirm)

## Test plan

- [x] `pnpm --filter @simple-agent-manager/www build` passes with new config
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm typecheck` passes
- [x] Generated sitemap uses `www.simple-agent-manager.org`
- [ ] Run provision-www workflow after merge
- [ ] Run deploy-www workflow after provisioning
- [ ] Verify `https://www.simple-agent-manager.org` serves the marketing site
- [ ] Verify `https://simple-agent-manager.org` redirects to www

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [ ] cross-component-change
- [ ] business-logic-change
- [ ] public-surface-change
- [ ] docs-sync-change
- [ ] security-sensitive-change
- [ ] ui-change
- [x] infra-change

### External References

Cloudflare API documentation for DNS records, Pages projects, custom domains, and Page Rules. No new external dependencies.

### Codebase Impact Analysis

- `.github/workflows/provision-www.yml` — New: provisions Pages project, DNS, custom domain, redirect
- `.github/workflows/teardown-www.yml` — New: tears down all www infrastructure
- `.github/workflows/deploy-www.yml` — Modified: adds SITE_URL env var, job summary, uses env for project name
- `apps/www/astro.config.mjs` — Modified: site URL from env var instead of hardcoded
- `apps/www/public/robots.txt` — Modified: sitemap URL updated to www subdomain
- No changes to API, shared types, providers, or web app

### Documentation & Specs

No behavior changes to documented interfaces. Infrastructure-only change. CLAUDE.md URL construction rules table already documents the pattern.

### Constitution & Risk Check

- Principle XI (No Hardcoded Values): `SITE_URL` is now configurable via env var. Domain derived from `BASE_DOMAIN`. Pages project name defined as workflow-level env var (single source of truth across provision/deploy/teardown).
- Risk: Low — additive infrastructure workflows, existing deploy behavior preserved, teardown requires explicit confirmation.

<!-- AGENT_PREFLIGHT_END -->

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>