### PR TITLE
feat(web): add 'View in file browser' button to git diff viewer

### DIFF
--- a/apps/web/src/components/GitDiffView.tsx
+++ b/apps/web/src/components/GitDiffView.tsx
@@ -1,5 +1,5 @@
 import { type CSSProperties, type FC, useCallback, useEffect, useState } from 'react';
-import { X } from 'lucide-react';
+import { X, FileText } from 'lucide-react';
 import { Spinner } from '@simple-agent-manager/ui';
 import { getGitDiff, getGitFile } from '../lib/api';
 
@@ -13,6 +13,7 @@ interface GitDiffViewProps {
   isMobile: boolean;
   onBack: () => void;
   onClose: () => void;
+  onViewInFileBrowser?: (filePath: string) => void;
 }
 
 type ViewMode = 'diff' | 'full';
@@ -27,6 +28,7 @@ export const GitDiffView: FC<GitDiffViewProps> = ({
   isMobile,
   onBack,
   onClose,
+  onViewInFileBrowser,
 }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -174,6 +176,17 @@ export const GitDiffView: FC<GitDiffViewProps> = ({
             onClick={() => setViewMode('full')}
           />
         </div>
+
+        {onViewInFileBrowser && (
+          <button
+            onClick={() => onViewInFileBrowser(filePath)}
+            aria-label="View in file browser"
+            title="View in file browser"
+            style={iconBtnStyle(isMobile)}
+          >
+            <FileText size={isMobile ? 18 : 16} />
+          </button>
+        )}
 
         <button onClick={onClose} aria-label="Close" style={iconBtnStyle(isMobile)}>
           <X size={isMobile ? 18 : 16} />

--- a/apps/web/src/pages/Workspace.tsx
+++ b/apps/web/src/pages/Workspace.tsx
@@ -663,6 +663,19 @@ export function Workspace() {
     navigate(`/workspaces/${id}?${params.toString()}`);
   }, [id, navigate, searchParams]);
 
+  const handleGitDiffToFileBrowser = useCallback(
+    (filePath: string) => {
+      const params = new URLSearchParams(searchParams);
+      params.delete('git');
+      params.delete('file');
+      params.delete('staged');
+      params.set('files', 'view');
+      params.set('path', filePath);
+      navigate(`/workspaces/${id}?${params.toString()}`);
+    },
+    [id, navigate, searchParams]
+  );
+
   // ── File browser navigation ──
   const handleOpenFileBrowser = useCallback(() => {
     const params = new URLSearchParams(searchParams);
@@ -2048,6 +2061,7 @@ export function Workspace() {
           isMobile={isMobile}
           onBack={handleBackFromGitDiff}
           onClose={handleCloseGitPanel}
+          onViewInFileBrowser={handleGitDiffToFileBrowser}
         />
       )}
 


### PR DESCRIPTION
## Summary

- Add a "View in file browser" button (FileText icon) to the git diff viewer header
- Clicking navigates to the same file in the file viewer panel via URL query params (`?files=view&path=...`)
- Button appears between the Diff/Full toggle and the close button
- Follows existing navigation patterns (URL-driven, `useCallback` handlers)

## Validation

- [x] `pnpm typecheck`
- [ ] Additional validation run (if applicable)
- [x] Mobile and desktop verification notes added for UI changes

## UI Compliance Checklist (Required for UI changes)

- [x] Mobile-first layout verified (uses existing `isMobile` prop for icon sizing)
- [x] Accessibility checks completed (aria-label, title attribute)
- [x] Shared UI components used (lucide-react `FileText` icon, existing `iconBtnStyle`)

## Exceptions (If any)

- Scope: N/A
- Rationale: N/A
- Expiration: N/A

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [ ] cross-component-change
- [ ] business-logic-change
- [ ] public-surface-change
- [ ] docs-sync-change
- [ ] security-sensitive-change
- [x] ui-change
- [ ] infra-change

### External References

N/A: Internal UI navigation addition.

### Codebase Impact Analysis

- `apps/web/src/components/GitDiffView.tsx` — added optional `onViewInFileBrowser` prop and FileText icon button
- `apps/web/src/pages/Workspace.tsx` — added `handleGitDiffToFileBrowser` handler, passed to GitDiffView

### Documentation & Specs

N/A: Internal UI feature, no user-facing documentation changes needed.

### Constitution & Risk Check

- Principle XI: No hardcoded values. Uses existing design tokens and URL patterns.
- Risk: Minimal — optional prop, no behavioral change when not provided.

<!-- AGENT_PREFLIGHT_END -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)