### PR TITLE
Wire REQUIRE_APPROVAL through deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -230,6 +230,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+          # Optional feature flags (GitHub Environment variables)
+          REQUIRE_APPROVAL: ${{ vars.REQUIRE_APPROVAL }}
 
       - name: Read Security Keys from Pulumi State
         id: pulumi_keys

--- a/docs/guides/self-hosting.md
+++ b/docs/guides/self-hosting.md
@@ -45,6 +45,12 @@ All configuration lives in a **GitHub Environment** named `production`. This mak
 | `RESOURCE_PREFIX` | Prefix for Cloudflare resources (optional) | `sam` |
 | `PULUMI_STATE_BUCKET` | R2 bucket for Pulumi state (optional) | `sam-pulumi-state` |
 
+**Optional feature flags** (GitHub Environment variables):
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `REQUIRE_APPROVAL` | Require admin approval for new users. First user becomes superadmin. | _(unset — all users active)_ |
+
 **Optional runtime-config limit variables** (GitHub Environment variables):
 
 | Variable | Description | Default |

--- a/scripts/deploy/sync-wrangler-config.ts
+++ b/scripts/deploy/sync-wrangler-config.ts
@@ -76,6 +76,8 @@ function updateEnvironmentBindings(
       BASE_DOMAIN: outputs.stackSummary.baseDomain,
       VERSION: DEPLOYMENT_CONFIG.version,
       PAGES_PROJECT_NAME: outputs.pagesName,
+      // Optional feature flags from environment
+      ...(process.env.REQUIRE_APPROVAL ? { REQUIRE_APPROVAL: process.env.REQUIRE_APPROVAL } : {}),
     },
     d1_databases: [
       {


### PR DESCRIPTION
## Summary

- Passes `REQUIRE_APPROVAL` GitHub Environment variable through `sync-wrangler-config.ts` so it becomes a Cloudflare Worker var at deploy time
- No secrets needed — just set the variable in GitHub Settings → Environments → production
- Documents the flag in self-hosting guide under "Optional feature flags"

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`

## Exceptions (If any)

- Scope: N/A
- Rationale: N/A
- Expiration: N/A

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [ ] cross-component-change
- [ ] business-logic-change
- [ ] public-surface-change
- [x] docs-sync-change
- [ ] security-sensitive-change
- [ ] ui-change
- [x] infra-change

### External References

N/A: No external APIs involved. Uses existing Cloudflare Workers vars mechanism and GitHub Actions vars pattern already established in the deploy workflow.

### Codebase Impact Analysis

- `scripts/deploy/sync-wrangler-config.ts` — Conditionally adds `REQUIRE_APPROVAL` to Worker vars when env var is set
- `.github/workflows/deploy.yml` — Passes `vars.REQUIRE_APPROVAL` to the sync-wrangler-config step
- `docs/guides/self-hosting.md` — Documents the new optional feature flag

### Documentation & Specs

- `docs/guides/self-hosting.md` updated with "Optional feature flags" table documenting `REQUIRE_APPROVAL`

### Constitution & Risk Check

- Principle XI (No Hardcoded Values): `REQUIRE_APPROVAL` is sourced from GitHub Environment variables, not hardcoded. When unset, the flag is omitted from Worker vars entirely.
- No security risk: the value is non-sensitive (`true` or unset), exposed as a Worker var not a secret.

<!-- AGENT_PREFLIGHT_END -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)