### PR TITLE
fix(ci): skip app CI and deploy workflows for www-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'apps/www/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'apps/www/**'
 
 jobs:
   changes:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Deploy
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'apps/www/**'
   workflow_dispatch:
     inputs:
       skip_agent:

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -3,6 +3,8 @@ name: E2E Smoke
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'apps/www/**'
 
 jobs:
   vm-agent-smoke:


### PR DESCRIPTION
## Summary

- Add `paths-ignore: ['apps/www/**']` to `deploy.yml`, `ci.yml`, and `e2e-smoke.yml`
- Prevents the full app deployment pipeline (Pulumi + Wrangler + VM Agent) from running when only marketing site files change
- `deploy-www.yml` already had correct path filtering and is unaffected

## Context

When `apps/www/**` changes are pushed to main, three workflows fire unnecessarily:

| Workflow | What it does | Time wasted |
|----------|-------------|-------------|
| `deploy.yml` | Full Pulumi infra + API Worker + Web UI + DB migrations + VM Agent build/upload | ~5-10 min |
| `ci.yml` | Lint, typecheck, test, build for the entire app | ~2 min |
| `e2e-smoke.yml` | VM Agent smoke tests (two matrix variants) | ~2.5 min |

`apps/www/` is a fully standalone Astro static site with zero shared package dependencies. It has its own dedicated `deploy-www.yml` workflow which already has correct `paths` filtering.

## Validation

- [x] `deploy-www.yml` is unaffected (it uses `paths`, not `paths-ignore`)
- [x] `workflow_dispatch` triggers on `deploy.yml` are unaffected (paths-ignore only applies to push events)
- [x] All three workflows still trigger normally for any non-www change

## Exceptions (If any)

- Scope: N/A
- Rationale: N/A
- Expiration: N/A

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [ ] cross-component-change
- [ ] business-logic-change
- [ ] public-surface-change
- [ ] docs-sync-change
- [ ] security-sensitive-change
- [ ] ui-change
- [x] infra-change

### External References

GitHub Actions `paths-ignore` documentation: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

Key behavior: `paths-ignore` only filters the specific event type it's nested under. `workflow_dispatch` is unaffected. When both `paths` and `paths-ignore` would apply, only one can be used per event.

### Codebase Impact Analysis

- `.github/workflows/deploy.yml` — push trigger now excludes `apps/www/**`
- `.github/workflows/ci.yml` — push and pull_request triggers now exclude `apps/www/**`
- `.github/workflows/e2e-smoke.yml` — pull_request trigger now excludes `apps/www/**`

No application code affected. `deploy-www.yml` (the www deployment workflow) is unchanged and already correctly path-filtered.

### Documentation & Specs

No docs reference the specific CI trigger configuration. The CLAUDE.md CI section describes workflow purpose but not path filters.

### Constitution & Risk Check

- **Principle XI (No Hardcoded Values)**: N/A — workflow path filters are inherently repo-structure-specific.
- **Risk**: Low. Worst case if `apps/www/` gains shared dependencies in the future, these paths-ignore entries would need to be revisited. Currently `apps/www/` is a standalone Astro site with its own `package.json` and no imports from `packages/*`.

<!-- AGENT_PREFLIGHT_END -->


🤖 Generated with [Claude Code](https://claude.com/claude-code)