### PR TITLE
fix(acp-client): fix scroll-to-bottom FAB visibility

### DIFF
--- a/packages/acp-client/src/components/AgentPanel.tsx
+++ b/packages/acp-client/src/components/AgentPanel.tsx
@@ -292,12 +292,12 @@ export const AgentPanel = React.forwardRef<AgentPanelHandle, AgentPanelProps>(fu
             <ConversationItemView key={item.id} item={item} />
           ))}
         </div>
-        {/* Scroll-to-bottom FAB */}
+        {/* Scroll-to-bottom FAB — z-10 required because overflow-y-auto creates a stacking context */}
         {!isAtBottom && messages.items.length > 0 && (
           <button
             type="button"
             onClick={scrollToBottom}
-            className="absolute bottom-3 right-3 w-8 h-8 flex items-center justify-center rounded-full bg-white border border-gray-300 shadow-md text-gray-500 hover:bg-gray-50 hover:text-gray-700 transition-colors"
+            className="absolute bottom-3 right-5 z-10 w-8 h-8 flex items-center justify-center rounded-full bg-white border border-gray-300 shadow-md text-gray-500 hover:bg-gray-50 hover:text-gray-700 transition-colors"
             aria-label="Scroll to bottom"
             title="Scroll to bottom"
           >


### PR DESCRIPTION
## Summary

- Added `z-10` to the scroll-to-bottom FAB so it renders above the scroll container (which creates a stacking context via `overflow-y: auto`)
- Bumped right offset from `right-3` (12px) to `right-5` (20px) to clear the scrollbar

## Validation

- [x] `pnpm typecheck` (via build)
- [x] `pnpm test` — 246 tests pass
- [x] `pnpm lint` (implicit — no new code, only class changes)

## Exceptions (If any)

- Scope: N/A
- Rationale: N/A
- Expiration: N/A

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [x] ui-change

### External References

N/A: CSS z-index fix, no external APIs.

### Codebase Impact Analysis

- `packages/acp-client/src/components/AgentPanel.tsx` — Added `z-10` and changed `right-3` to `right-5` on FAB button classname

### Documentation & Specs

N/A: Bug fix to CSS classes only.

### Constitution & Risk Check

N/A: No business logic changes.

<!-- AGENT_PREFLIGHT_END -->

Generated with [Claude Code](https://claude.com/claude-code)