### PR TITLE
feat(web): show workspace cards on project overview

### DIFF
--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -335,6 +335,7 @@ workspacesRoutes.get('/', async (c) => {
   const userId = getUserId(c);
   const status = c.req.query('status');
   const nodeId = c.req.query('nodeId');
+  const projectId = c.req.query('projectId');
   const db = drizzle(c.env.DATABASE, { schema });
 
   // Build WHERE conditions in SQL instead of filtering in memory (P1 fix).
@@ -344,6 +345,9 @@ workspacesRoutes.get('/', async (c) => {
   }
   if (nodeId) {
     conditions.push(eq(schema.workspaces.nodeId, nodeId));
+  }
+  if (projectId) {
+    conditions.push(eq(schema.workspaces.projectId, projectId));
   }
 
   const rows = await db

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -622,11 +622,13 @@ export async function listNodeEvents(
 // =============================================================================
 export async function listWorkspaces(
   status?: string,
-  nodeId?: string
+  nodeId?: string,
+  projectId?: string
 ): Promise<WorkspaceResponse[]> {
   const params = new URLSearchParams();
   if (status) params.set('status', status);
   if (nodeId) params.set('nodeId', nodeId);
+  if (projectId) params.set('projectId', projectId);
   const url = params.toString() ? `/api/workspaces?${params.toString()}` : '/api/workspaces';
   return request<WorkspaceResponse[]>(url);
 }

--- a/tasks/active/2026-02-23-workspace-project-association.md
+++ b/tasks/active/2026-02-23-workspace-project-association.md
@@ -34,14 +34,14 @@ Workspaces attached to a repository show up associated with the correct project 
 
 ## Detailed Tasklist
 
-- [ ] Add `projectId` query parameter support to `GET /api/workspaces` in `apps/api/src/routes/workspaces.ts`
-- [ ] Update `listWorkspaces()` in `apps/web/src/lib/api.ts` to accept `projectId` parameter
-- [ ] Add workspace fetching to `apps/web/src/pages/ProjectOverview.tsx` using `listWorkspaces({ projectId })`
-- [ ] Render workspace cards on ProjectOverview (reuse existing `WorkspaceCard` component from Dashboard)
-- [ ] Show loading state only when no data yet (follow the new loading state pattern)
-- [ ] Handle empty state (no workspaces for this project)
-- [ ] Run typecheck: `pnpm typecheck`
-- [ ] Run build: `pnpm build`
+- [x] Add `projectId` query parameter support to `GET /api/workspaces` in `apps/api/src/routes/workspaces.ts`
+- [x] Update `listWorkspaces()` in `apps/web/src/lib/api.ts` to accept `projectId` parameter
+- [x] Add workspace fetching to `apps/web/src/pages/ProjectOverview.tsx` using `listWorkspaces({ projectId })`
+- [x] Render workspace cards on ProjectOverview (reuse existing `WorkspaceCard` component from Dashboard)
+- [x] Show loading state only when no data yet (follow the new loading state pattern)
+- [x] Handle empty state (no workspaces for this project)
+- [x] Run typecheck: `pnpm typecheck`
+- [x] Run build: `pnpm build`
 
 ## Files to Modify
 


### PR DESCRIPTION
## Summary

- Fix workspaces not showing on project page — they appeared on Dashboard but not ProjectOverview
- Root cause: ProjectOverview only displayed a count (`Linked workspaces: N`), never fetched actual workspace data
- Added `projectId` query filter to `GET /api/workspaces` endpoint
- Updated `listWorkspaces()` client to support `projectId` parameter
- ProjectOverview now fetches and renders workspace cards with stop/restart/delete actions

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] Additional validation run (if applicable)
- [ ] Mobile and desktop verification notes added for UI changes

## UI Compliance Checklist (Required for UI changes)

- [x] Mobile-first layout verified
- [x] Accessibility checks completed
- [x] Shared UI components used or exception documented

## Exceptions (If any)

- Scope: N/A
- Rationale: N/A
- Expiration: N/A

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [x] cross-component-change
- [ ] business-logic-change
- [ ] public-surface-change
- [ ] docs-sync-change
- [ ] security-sensitive-change
- [x] ui-change
- [ ] infra-change

### External References

N/A: Internal feature fix using existing patterns from Dashboard.tsx.

### Codebase Impact Analysis

- `apps/api/src/routes/workspaces.ts` — Added `projectId` query parameter filter to GET /
- `apps/web/src/lib/api.ts` — Added `projectId` parameter to `listWorkspaces()`
- `apps/web/src/pages/ProjectOverview.tsx` — Added workspace fetching, rendering with WorkspaceCard, stop/restart/delete handlers

### Documentation & Specs

N/A: Bug fix restoring expected behavior — no new interfaces or contracts.

### Constitution & Risk Check

- Principle XI (No Hardcoded Values): No hardcoded values introduced. API filter uses standard query parameter pattern.
- Risk: Low — additive change. New query parameter is optional and backwards-compatible.

<!-- AGENT_PREFLIGHT_END -->