### PR TITLE
fix(vm-agent): ensure GH_TOKEN available in PTY and ACP sessions

### DIFF
--- a/packages/vm-agent/internal/acp/gateway.go
+++ b/packages/vm-agent/internal/acp/gateway.go
@@ -70,6 +70,10 @@ type GatewayConfig struct {
 	ContainerWorkDir string
 	// OnActivity is called when there's ACP activity (for idle detection).
 	OnActivity func()
+	// GitTokenFetcher returns a fresh GitHub installation token for the
+	// workspace. It is called at ACP session start to inject GH_TOKEN into
+	// the agent process. If nil or returns error, GH_TOKEN is omitted.
+	GitTokenFetcher func(ctx context.Context) (string, error)
 	// BootLog is the reporter for sending structured logs to the control plane.
 	// Agent errors (stderr, crashes) are reported here for observability.
 	BootLog BootLogReporter

--- a/packages/vm-agent/internal/acp/process.go
+++ b/packages/vm-agent/internal/acp/process.go
@@ -63,6 +63,17 @@ func parseEnvExportLines(content string) []string {
 	return result
 }
 
+// hasEnvVar checks whether a KEY=value list contains a non-empty value for key.
+func hasEnvVar(envVars []string, key string) bool {
+	prefix := key + "="
+	for _, entry := range envVars {
+		if strings.HasPrefix(entry, prefix) && len(entry) > len(prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // AgentProcess manages an ACP-compliant agent subprocess running inside the
 // devcontainer via docker exec. It pipes stdin/stdout for NDJSON communication.
 type AgentProcess struct {

--- a/packages/vm-agent/internal/server/server.go
+++ b/packages/vm-agent/internal/server/server.go
@@ -174,6 +174,7 @@ func New(cfg *config.Config) (*Server, error) {
 		ContainerUser:           containerUser,
 		ContainerWorkDir:        containerWorkDir,
 		OnActivity:              idleDetector.RecordActivity,
+		GitTokenFetcher:         nil, // set below after server construction
 		FileExecTimeout:         cfg.GitExecTimeout,
 		FileMaxSize:             cfg.GitFileMaxSize,
 		ErrorReporter:           errorReporter,
@@ -219,6 +220,9 @@ func New(cfg *config.Config) (*Server, error) {
 		logReader:           logreader.NewReaderWithTimeout(cfg.LogReaderTimeout),
 		bootLogBroadcasters: NewBootLogBroadcasterManager(),
 	}
+
+	// Wire the git token fetcher now that the server exists.
+	s.acpConfig.GitTokenFetcher = s.fetchGitToken
 
 	if cfg.WorkspaceID != "" {
 		s.workspaces[cfg.WorkspaceID] = &WorkspaceRuntime{

--- a/tasks/active/2026-02-23-gh-token-empty-in-workspaces.md
+++ b/tasks/active/2026-02-23-gh-token-empty-in-workspaces.md
@@ -44,18 +44,18 @@ The suspected issue is that `ensureSAMEnvironment` in `bootstrap.go` is called w
 
 ## Detailed Tasklist
 
-- [ ] Read `packages/vm-agent/internal/server/workspace_provisioning.go` to understand the full provisioning flow
-- [ ] Read `packages/vm-agent/internal/server/git_credential.go` to understand token fetch
-- [ ] Read `apps/api/src/routes/workspaces.ts` around the `/git-token` endpoint (lines 1799-1823)
-- [ ] Check if `fetchGitTokenForWorkspace` has proper retry logic or if it fails silently
-- [ ] Check workspace records in the database — do workspaces have valid `installationId`?
-- [ ] Add retry logic to `fetchGitTokenForWorkspace` if it doesn't exist
-- [ ] Improve error logging when git token fetch fails
-- [ ] Consider adding a "refresh env" mechanism that re-fetches the token and updates env files
-- [ ] Alternatively: make `/etc/profile.d/sam-env.sh` dynamically source GH_TOKEN via the credential helper on shell startup
-- [ ] Test that GH_TOKEN is available in PTY sessions after fix
-- [ ] Test that GH_TOKEN is available in ACP agent sessions after fix
-- [ ] Run Go tests: `cd packages/vm-agent && go test ./...`
+- [x] Read `packages/vm-agent/internal/server/workspace_provisioning.go` to understand the full provisioning flow
+- [x] Read `packages/vm-agent/internal/server/git_credential.go` to understand token fetch
+- [x] Read `apps/api/src/routes/workspaces.ts` around the `/git-token` endpoint
+- [x] Check if `fetchGitTokenForWorkspace` has proper retry logic — it fails silently with warning
+- [x] Analyze root cause: token unavailable at provisioning time → empty GH_TOKEN in env files
+- [x] For PTY sessions: add dynamic GH_TOKEN fallback in `/etc/profile.d/sam-env.sh` via credential helper
+- [x] For ACP sessions: add `GitTokenFetcher` to GatewayConfig, inject fresh GH_TOKEN in session_host.go
+- [x] Separate shell script (with dynamic commands) from static env file (/etc/sam/env)
+- [x] Update tests for new behavior (dynamic fallback block always present)
+- [ ] Test that GH_TOKEN is available in PTY sessions after fix (requires deployed workspace)
+- [ ] Test that GH_TOKEN is available in ACP agent sessions after fix (requires deployed workspace)
+- [x] Run Go tests: `cd packages/vm-agent && go test ./...`
 
 ## Files to Modify
 


### PR DESCRIPTION
## Summary

- Fix GH_TOKEN being empty in SAM workspaces despite GitHub token being available via credential helper
- Root cause: token fetch can fail at provisioning time (timing race, missing installationId), and there was no fallback mechanism
- Two-pronged fix covering both session types:
  - **PTY sessions**: Dynamic fallback in `/etc/profile.d/sam-env.sh` fetches fresh token from git credential helper on shell startup
  - **ACP sessions**: New `GitTokenFetcher` on `GatewayConfig` lets `session_host.go` fetch a fresh token before starting agent processes
- Separated `/etc/profile.d/sam-env.sh` (shell script with dynamic commands) from `/etc/sam/env` (static KEY=VALUE for parsers)

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `go vet ./...`
- [x] `go test ./internal/bootstrap/ ./internal/acp/ ./internal/server/`
- [ ] Live deployment test (GH_TOKEN available in PTY + ACP)

## Exceptions (If any)

- Scope: Live deployment testing deferred — requires a running workspace with GitHub App installation
- Rationale: All unit tests pass; the fix is additive with graceful fallbacks
- Expiration: Verify on next staging deployment

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [x] cross-component-change
- [x] business-logic-change
- [ ] public-surface-change
- [ ] docs-sync-change
- [ ] security-sensitive-change
- [ ] ui-change
- [ ] infra-change

### External References

N/A: Internal fix using existing git credential helper infrastructure. No new external APIs consumed.

### Codebase Impact Analysis

- `packages/vm-agent/internal/acp/gateway.go` — Added `GitTokenFetcher` field to `GatewayConfig`
- `packages/vm-agent/internal/acp/process.go` — Added `hasEnvVar()` helper
- `packages/vm-agent/internal/acp/session_host.go` — Inject fresh GH_TOKEN via GitTokenFetcher if missing from env files
- `packages/vm-agent/internal/bootstrap/bootstrap.go` — Dynamic GH_TOKEN fallback in shell script, separated shell script from static env file, added `buildSAMStaticEnv()`
- `packages/vm-agent/internal/bootstrap/bootstrap_test.go` — Updated tests for new dynamic fallback behavior
- `packages/vm-agent/internal/server/server.go` — Wire `GitTokenFetcher` to `Server.fetchGitToken`

### Documentation & Specs

N/A: Internal bug fix. No user-facing API or documentation changes.

### Constitution & Risk Check

- Principle XI (No Hardcoded Values): No hardcoded values. Dynamic fetch uses existing configurable `ControlPlaneURL`.
- Risk: Low — all changes are additive fallbacks. If dynamic fetch fails, behavior is identical to before (empty GH_TOKEN). No breaking changes.

<!-- AGENT_PREFLIGHT_END -->