### PR TITLE
fix: allow secret file mounts at any absolute path in devcontainer

### DIFF
--- a/apps/api/src/routes/projects/_helpers.ts
+++ b/apps/api/src/routes/projects/_helpers.ts
@@ -27,13 +27,6 @@ export function byteLength(value: string): number {
 }
 
 /**
- * Allowed absolute path prefixes for runtime files.
- * Only paths under user home directories are permitted inside the devcontainer.
- * System paths (/etc, /usr, /var, etc.) are blocked to prevent privilege escalation.
- */
-export const ALLOWED_ABSOLUTE_PREFIXES = ['/home/node/', '/home/user/'];
-
-/**
  * Blocked ~ (home-relative) paths that could enable persistence or privilege escalation.
  */
 export const BLOCKED_HOME_PATHS = [
@@ -64,16 +57,8 @@ export function normalizeProjectFilePath(path: string): string {
     }
   }
 
-  // Block absolute paths outside allowed prefixes (prevents /etc/cron.d, /etc/profile.d, etc.)
-  if (normalized.startsWith('/')) {
-    const allowed = ALLOWED_ABSOLUTE_PREFIXES.some((prefix) => normalized.startsWith(prefix));
-    if (!allowed) {
-      throw errors.badRequest(
-        'Absolute paths are only allowed under /home/node/ or /home/user/. ' +
-          'Use a relative path or ~/... for home directory files.'
-      );
-    }
-  }
+  // Allow absolute paths — files are injected into the devcontainer which is
+  // already a sandbox. The .. traversal check above is sufficient protection.
 
   // Block dangerous home-relative paths (prevents SSH key injection, etc.)
   if (normalized.startsWith('~')) {

--- a/packages/vm-agent/internal/bootstrap/bootstrap.go
+++ b/packages/vm-agent/internal/bootstrap/bootstrap.go
@@ -1918,20 +1918,9 @@ func normalizeProjectRuntimeFilePath(rawPath string) (string, error) {
 
 	normalized := filepath.ToSlash(filepath.Clean(trimmed))
 
-	// Absolute paths: only allow under safe home directories.
-	// System paths (/etc, /usr, /var, etc.) are blocked to prevent privilege escalation.
+	// Allow absolute paths — files are injected into the devcontainer which is
+	// already a sandbox. The .. traversal check above is sufficient protection.
 	if strings.HasPrefix(normalized, "/") {
-		allowedPrefixes := []string{"/home/node/", "/home/user/"}
-		allowed := false
-		for _, prefix := range allowedPrefixes {
-			if strings.HasPrefix(normalized, prefix) {
-				allowed = true
-				break
-			}
-		}
-		if !allowed {
-			return "", fmt.Errorf("absolute paths are only allowed under /home/node/ or /home/user/")
-		}
 		return normalized, nil
 	}
 

--- a/packages/vm-agent/internal/bootstrap/bootstrap_test.go
+++ b/packages/vm-agent/internal/bootstrap/bootstrap_test.go
@@ -603,7 +603,7 @@ func TestNormalizeProjectRuntimeFilePath(t *testing.T) {
 		{name: "relative path", input: ".env.local", want: ".env.local"},
 		{name: "nested path", input: "config/app/env.txt", want: "config/app/env.txt"},
 		{name: "absolute path", input: "/home/node/.npmrc", want: "/home/node/.npmrc"},
-		{name: "absolute etc path", input: "/etc/apt/sources.list.d/custom.list", wantErr: true},
+		{name: "absolute etc path", input: "/etc/apt/sources.list.d/custom.list", want: "/etc/apt/sources.list.d/custom.list"},
 		{name: "home tilde path", input: "~/.ssh/config", want: "~/.ssh/config"},
 		{name: "home tilde nested", input: "~/.config/gh/hosts.yml", want: "~/.config/gh/hosts.yml"},
 		{name: "reject absolute with dotdot", input: "/home/node/../../etc/shadow", wantErr: true},


### PR DESCRIPTION
The Shannon security assessment (454fb5f) restricted absolute paths to
only /home/node/ and /home/user/, but this was overly conservative.
Files are injected into the devcontainer which is already a sandbox —
there is no host filesystem escape. The .. traversal protection and
~/.ssh/authorized_keys blocklist remain in place.

This unblocks mounting secrets at paths like /etc/apt/sources.list.d/,
/root/.docker/config.json, etc.

https://claude.ai/code/session_01J3FWZ834h2cAvtKr4EoqGQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded absolute path validation to accept file paths from additional system locations, improving flexibility in project file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->