### PR TITLE
feat: dynamic OpenCode config with AI proxy fallback

### DIFF
--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -412,4 +412,7 @@ export interface Env {
   TRIGGER_EXECUTION_LOG_RETENTION_DAYS?: string;    // Days to retain completed/failed/skipped execution logs (default: 90)
   TRIGGER_EXECUTION_CLEANUP_ENABLED?: string;       // Kill switch: "false" to disable cleanup sweep (default: enabled)
   TRIGGER_STALE_RECOVERY_BATCH_SIZE?: string;       // Max stale executions to recover per sweep (default: 100)
+  // AI inference proxy configuration
+  AI_PROXY_ENABLED?: string;                         // "true" to enable Workers AI proxy for agents (default: disabled)
+  AI_PROXY_DEFAULT_MODEL?: string;                   // Default model for AI proxy (default: @cf/qwen/qwen3-30b-a3b-fp8)
 }

--- a/apps/api/src/routes/workspaces/runtime.ts
+++ b/apps/api/src/routes/workspaces/runtime.ts
@@ -1,4 +1,4 @@
-import { type BootstrapTokenData, getAgentDefinition, isValidAgentType } from '@simple-agent-manager/shared';
+import { type BootstrapTokenData, getAgentDefinition, type InferenceConfig, isValidAgentType } from '@simple-agent-manager/shared';
 import { and, eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/d1';
 import { Hono } from 'hono';
@@ -69,6 +69,24 @@ runtimeRoutes.post('/:id/agent-key', jsonValidator(AgentTypeBodySchema), async (
     }
   }
 
+  // AI proxy fallback: when no user/fallback credential exists but the platform AI proxy is enabled,
+  // return an inferenceConfig that tells the VM agent to use the proxy with the workspace callback token.
+  let inferenceConfig: InferenceConfig | undefined;
+  if (!credentialData && body.agentType === 'opencode' && c.env.AI_PROXY_ENABLED === 'true') {
+    const defaultModel = c.env.AI_PROXY_DEFAULT_MODEL || '@cf/qwen/qwen3-30b-a3b-fp8';
+    inferenceConfig = {
+      provider: 'openai-compatible',
+      baseURL: `https://api.${c.env.BASE_DOMAIN}/ai/v1`,
+      model: defaultModel,
+      apiKeySource: 'callback-token',
+    };
+    credentialData = {
+      credential: 'proxy',
+      credentialKind: 'api-key',
+      credentialSource: 'platform',
+    };
+  }
+
   if (!credentialData) {
     throw errors.notFound('Agent credential');
   }
@@ -92,6 +110,7 @@ runtimeRoutes.post('/:id/agent-key', jsonValidator(AgentTypeBodySchema), async (
   return c.json({
     apiKey: credentialData.credential,
     credentialKind: credentialData.credentialKind,
+    ...(inferenceConfig && { inferenceConfig }),
   });
 });
 

--- a/apps/api/tests/unit/routes/opencode-credential-fallback.test.ts
+++ b/apps/api/tests/unit/routes/opencode-credential-fallback.test.ts
@@ -180,6 +180,161 @@ describe('POST /workspaces/:id/agent-key — OpenCode Scaleway fallback', () => 
     expect(resp.status).toBe(404);
   });
 
+  it('returns inferenceConfig when AI_PROXY_ENABLED and no user credential', async () => {
+    let queryCount = 0;
+    mockDB.limit.mockImplementation(() => {
+      queryCount++;
+      if (queryCount === 1) {
+        return [{ userId: 'user-1' }];
+      }
+      // All credential lookups return empty
+      return [];
+    });
+
+    const proxyEnv = {
+      ...mockEnv,
+      AI_PROXY_ENABLED: 'true',
+      AI_PROXY_DEFAULT_MODEL: '@cf/test-model',
+      BASE_DOMAIN: 'example.com',
+    } as unknown as Env;
+
+    const resp = await app.request(
+      '/api/workspaces/ws-123/agent-key',
+      {
+        method: 'POST',
+        body: JSON.stringify({ agentType: 'opencode' }),
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-callback-token',
+        },
+      },
+      proxyEnv,
+    );
+    expect(resp.status).toBe(200);
+
+    const json = await resp.json();
+    expect(json.apiKey).toBe('proxy');
+    expect(json.credentialKind).toBe('api-key');
+    expect(json.inferenceConfig).toBeDefined();
+    expect(json.inferenceConfig.provider).toBe('openai-compatible');
+    expect(json.inferenceConfig.baseURL).toBe('https://api.example.com/ai/v1');
+    expect(json.inferenceConfig.model).toBe('@cf/test-model');
+    expect(json.inferenceConfig.apiKeySource).toBe('callback-token');
+  });
+
+  it('uses default model when AI_PROXY_DEFAULT_MODEL is not set', async () => {
+    let queryCount = 0;
+    mockDB.limit.mockImplementation(() => {
+      queryCount++;
+      if (queryCount === 1) {
+        return [{ userId: 'user-1' }];
+      }
+      return [];
+    });
+
+    const proxyEnv = {
+      ...mockEnv,
+      AI_PROXY_ENABLED: 'true',
+      BASE_DOMAIN: 'example.com',
+    } as unknown as Env;
+
+    const resp = await app.request(
+      '/api/workspaces/ws-123/agent-key',
+      {
+        method: 'POST',
+        body: JSON.stringify({ agentType: 'opencode' }),
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-callback-token',
+        },
+      },
+      proxyEnv,
+    );
+    expect(resp.status).toBe(200);
+
+    const json = await resp.json();
+    expect(json.inferenceConfig.model).toBe('@cf/qwen/qwen3-30b-a3b-fp8');
+  });
+
+  it('does NOT return inferenceConfig when user has own credential', async () => {
+    let queryCount = 0;
+    mockDB.limit.mockImplementation(() => {
+      queryCount++;
+      if (queryCount === 1) {
+        return [{ userId: 'user-1' }];
+      }
+      if (queryCount === 2) {
+        // User has a dedicated agent key
+        return [{
+          encryptedToken: 'encrypted-user',
+          iv: 'iv-user',
+          credentialKind: 'api-key',
+          isActive: true,
+        }];
+      }
+      return [];
+    });
+
+    mockDecrypt.mockResolvedValueOnce('user-api-key');
+
+    const proxyEnv = {
+      ...mockEnv,
+      AI_PROXY_ENABLED: 'true',
+      AI_PROXY_DEFAULT_MODEL: '@cf/test-model',
+      BASE_DOMAIN: 'example.com',
+    } as unknown as Env;
+
+    const resp = await app.request(
+      '/api/workspaces/ws-123/agent-key',
+      {
+        method: 'POST',
+        body: JSON.stringify({ agentType: 'opencode' }),
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-callback-token',
+        },
+      },
+      proxyEnv,
+    );
+    expect(resp.status).toBe(200);
+
+    const json = await resp.json();
+    expect(json.apiKey).toBe('user-api-key');
+    expect(json.inferenceConfig).toBeUndefined();
+  });
+
+  it('does NOT return inferenceConfig for non-opencode agents even with AI proxy enabled', async () => {
+    let queryCount = 0;
+    mockDB.limit.mockImplementation(() => {
+      queryCount++;
+      if (queryCount === 1) {
+        return [{ userId: 'user-1' }];
+      }
+      return [];
+    });
+
+    const proxyEnv = {
+      ...mockEnv,
+      AI_PROXY_ENABLED: 'true',
+      BASE_DOMAIN: 'example.com',
+    } as unknown as Env;
+
+    const resp = await app.request(
+      '/api/workspaces/ws-123/agent-key',
+      {
+        method: 'POST',
+        body: JSON.stringify({ agentType: 'claude-code' }),
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-callback-token',
+        },
+      },
+      proxyEnv,
+    );
+    // Should return 404, not use proxy for non-opencode agents
+    expect(resp.status).toBe(404);
+  });
+
   it('handles malformed Scaleway credential JSON gracefully', async () => {
     let queryCount = 0;
     mockDB.limit.mockImplementation(() => {

--- a/packages/shared/src/agents.ts
+++ b/packages/shared/src/agents.ts
@@ -176,8 +176,22 @@ export interface SaveAgentCredentialRequest {
   autoActivate?: boolean; // Default true
 }
 
+/** Inference configuration for platform-managed AI proxy */
+export interface InferenceConfig {
+  /** Provider type (e.g., 'openai-compatible') */
+  provider: string;
+  /** Base URL for the inference API (e.g., 'https://api.{domain}/ai/v1') */
+  baseURL: string;
+  /** Default model identifier (e.g., '@cf/qwen/qwen3-30b-a3b-fp8') */
+  model: string;
+  /** How the API key is sourced — 'callback-token' means reuse workspace callback token */
+  apiKeySource?: string;
+}
+
 /** Response from /api/workspaces/:id/agent-key endpoint */
 export interface AgentKeyResponse {
   apiKey: string; // Decrypted credential (API key or OAuth token)
   credentialKind: CredentialKind; // Type for proper env var injection
+  /** When present, tells the VM agent to build provider config for a platform-managed proxy */
+  inferenceConfig?: InferenceConfig;
 }

--- a/packages/vm-agent/internal/acp/gateway.go
+++ b/packages/vm-agent/internal/acp/gateway.go
@@ -409,10 +409,19 @@ func (g *Gateway) handleMessage(ctx context.Context, data []byte) {
 
 // --- Shared types and utilities used by both Gateway and SessionHost ---
 
+// inferenceConfig holds platform-managed AI proxy configuration returned from the control plane.
+type inferenceConfig struct {
+	Provider     string `json:"provider"`
+	BaseURL      string `json:"baseURL"`
+	Model        string `json:"model"`
+	ApiKeySource string `json:"apiKeySource,omitempty"`
+}
+
 // agentCredential holds the credential and its type returned from the control plane.
 type agentCredential struct {
-	credential     string
-	credentialKind string // "api-key" or "oauth-token"
+	credential      string
+	credentialKind  string // "api-key" or "oauth-token"
+	inferenceConfig *inferenceConfig
 }
 
 func byteReader(data []byte) io.ReadCloser {

--- a/packages/vm-agent/internal/acp/opencode_config_test.go
+++ b/packages/vm-agent/internal/acp/opencode_config_test.go
@@ -1,0 +1,234 @@
+package acp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBuildOpenCodeConfig_PlatformProxy(t *testing.T) {
+	cred := &agentCredential{
+		credential:     "proxy",
+		credentialKind: "api-key",
+		inferenceConfig: &inferenceConfig{
+			Provider:     "openai-compatible",
+			BaseURL:      "https://api.example.com/ai/v1",
+			Model:        "@cf/qwen/qwen3-30b-a3b-fp8",
+			ApiKeySource: "callback-token",
+		},
+	}
+	settings := &agentSettingsPayload{Model: ""}
+	callbackToken := "cb-token-123"
+
+	result := buildOpenCodeConfig(cred, settings, callbackToken)
+
+	// Marshal and re-parse to verify structure
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify model uses sam-ai/ prefix
+	model, ok := parsed["model"].(string)
+	if !ok || model != "sam-ai/@cf/qwen/qwen3-30b-a3b-fp8" {
+		t.Errorf("expected model 'sam-ai/@cf/qwen/qwen3-30b-a3b-fp8', got %q", model)
+	}
+
+	// Verify provider structure
+	providers, ok := parsed["provider"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected 'provider' to be an object")
+	}
+	samAI, ok := providers["sam-ai"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected 'sam-ai' provider entry")
+	}
+
+	if npm, _ := samAI["npm"].(string); npm != "@ai-sdk/openai-compatible" {
+		t.Errorf("expected npm '@ai-sdk/openai-compatible', got %q", npm)
+	}
+
+	options, ok := samAI["options"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected 'options' in sam-ai provider")
+	}
+
+	if baseURL, _ := options["baseURL"].(string); baseURL != "https://api.example.com/ai/v1" {
+		t.Errorf("expected baseURL 'https://api.example.com/ai/v1', got %q", baseURL)
+	}
+
+	// Key check: callback token should be used as apiKey
+	if apiKey, _ := options["apiKey"].(string); apiKey != "cb-token-123" {
+		t.Errorf("expected apiKey to be callback token 'cb-token-123', got %q", apiKey)
+	}
+}
+
+func TestBuildOpenCodeConfig_PlatformProxy_UserModelOverride(t *testing.T) {
+	cred := &agentCredential{
+		credential:     "proxy",
+		credentialKind: "api-key",
+		inferenceConfig: &inferenceConfig{
+			Provider:     "openai-compatible",
+			BaseURL:      "https://api.example.com/ai/v1",
+			Model:        "@cf/qwen/qwen3-30b-a3b-fp8",
+			ApiKeySource: "callback-token",
+		},
+	}
+	settings := &agentSettingsPayload{Model: "custom-model-override"}
+	callbackToken := "cb-token-456"
+
+	result := buildOpenCodeConfig(cred, settings, callbackToken)
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	// User model override should take precedence
+	model, _ := parsed["model"].(string)
+	if model != "sam-ai/custom-model-override" {
+		t.Errorf("expected model 'sam-ai/custom-model-override', got %q", model)
+	}
+}
+
+func TestBuildOpenCodeConfig_LegacyScaleway(t *testing.T) {
+	cred := &agentCredential{
+		credential:      "scw-secret-key",
+		credentialKind:  "api-key",
+		inferenceConfig: nil, // No inference config = legacy path
+	}
+	settings := &agentSettingsPayload{Model: ""}
+	callbackToken := "cb-token-unused"
+
+	result := buildOpenCodeConfig(cred, settings, callbackToken)
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should use scaleway defaults
+	model, _ := parsed["model"].(string)
+	if model != "scaleway/qwen3-coder-30b-a3b-instruct" {
+		t.Errorf("expected model 'scaleway/qwen3-coder-30b-a3b-instruct', got %q", model)
+	}
+
+	providers, ok := parsed["provider"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected 'provider' to be an object")
+	}
+	scaleway, ok := providers["scaleway"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected 'scaleway' provider entry")
+	}
+
+	options, ok := scaleway["options"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected 'options' in scaleway provider")
+	}
+
+	if baseURL, _ := options["baseURL"].(string); baseURL != "https://api.scaleway.ai/v1" {
+		t.Errorf("expected Scaleway baseURL, got %q", baseURL)
+	}
+	if apiKey, _ := options["apiKey"].(string); apiKey != "{env:SCW_SECRET_KEY}" {
+		t.Errorf("expected env reference for apiKey, got %q", apiKey)
+	}
+}
+
+func TestBuildOpenCodeConfig_LegacyScaleway_UserModelOverride(t *testing.T) {
+	cred := &agentCredential{
+		credential:      "scw-secret-key",
+		credentialKind:  "api-key",
+		inferenceConfig: nil,
+	}
+	settings := &agentSettingsPayload{Model: "my-custom/model"}
+	callbackToken := "unused"
+
+	result := buildOpenCodeConfig(cred, settings, callbackToken)
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	model, _ := parsed["model"].(string)
+	if model != "my-custom/model" {
+		t.Errorf("expected model 'my-custom/model', got %q", model)
+	}
+}
+
+func TestBuildOpenCodeConfig_NilSettings(t *testing.T) {
+	// Platform proxy with nil settings — should use default model
+	cred := &agentCredential{
+		credential:     "proxy",
+		credentialKind: "api-key",
+		inferenceConfig: &inferenceConfig{
+			Provider:     "openai-compatible",
+			BaseURL:      "https://api.example.com/ai/v1",
+			Model:        "@cf/qwen/qwen3-30b-a3b-fp8",
+			ApiKeySource: "callback-token",
+		},
+	}
+
+	result := buildOpenCodeConfig(cred, nil, "cb-token")
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	model, _ := parsed["model"].(string)
+	if model != "sam-ai/@cf/qwen/qwen3-30b-a3b-fp8" {
+		t.Errorf("expected default model with sam-ai/ prefix, got %q", model)
+	}
+}
+
+func TestBuildOpenCodeConfig_NilSettings_Legacy(t *testing.T) {
+	// Legacy Scaleway with nil settings — should use Scaleway defaults
+	cred := &agentCredential{
+		credential:      "scw-key",
+		credentialKind:  "api-key",
+		inferenceConfig: nil,
+	}
+
+	result := buildOpenCodeConfig(cred, nil, "unused")
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	model, _ := parsed["model"].(string)
+	if model != "scaleway/qwen3-coder-30b-a3b-instruct" {
+		t.Errorf("expected Scaleway default model, got %q", model)
+	}
+}

--- a/packages/vm-agent/internal/acp/session_host.go
+++ b/packages/vm-agent/internal/acp/session_host.go
@@ -948,33 +948,17 @@ func (h *SessionHost) startAgent(ctx context.Context, agentType string, cred *ag
 		}
 	}
 
-	// For OpenCode: build OPENCODE_CONFIG_CONTENT JSON for Scaleway inference.
-	// Uses the env var (highest priority config source) to inject provider and model
-	// settings without overwriting any repo-level .opencode.json.
+	// For OpenCode: build OPENCODE_CONFIG_CONTENT JSON dynamically based on credential source.
+	// When an inferenceConfig is returned (platform AI proxy), use it with the callback token.
+	// Otherwise fall back to the legacy Scaleway config.
 	if agentType == "opencode" {
-		model := "scaleway/qwen3-coder-30b-a3b-instruct" // default
-		if settings != nil && settings.Model != "" {
-			model = settings.Model
-		}
-
-		opencodeConfig := map[string]interface{}{
-			"provider": map[string]interface{}{
-				"scaleway": map[string]interface{}{
-					"options": map[string]interface{}{
-						"baseURL": "https://api.scaleway.ai/v1",
-						"apiKey":  "{env:SCW_SECRET_KEY}",
-					},
-				},
-			},
-			"model": model,
-		}
-
-		configJSON, err := json.Marshal(opencodeConfig)
+		configJSON, err := json.Marshal(buildOpenCodeConfig(cred, settings, h.config.CallbackToken))
 		if err != nil {
 			slog.Error("opencode: failed to marshal config", "error", err)
 		} else {
 			envVars = append(envVars, "OPENCODE_CONFIG_CONTENT="+string(configJSON))
-			slog.Info("OpenCode config injected", "model", model)
+			slog.Info("OpenCode config injected",
+				"hasInferenceConfig", cred.inferenceConfig != nil)
 		}
 	}
 
@@ -2061,8 +2045,9 @@ func (h *SessionHost) fetchAgentKey(ctx context.Context, agentType string) (*age
 	}
 
 	var result struct {
-		APIKey         string `json:"apiKey"`
-		CredentialKind string `json:"credentialKind"`
+		APIKey          string           `json:"apiKey"`
+		CredentialKind  string           `json:"credentialKind"`
+		InferenceConfig *inferenceConfig `json:"inferenceConfig,omitempty"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
@@ -2077,8 +2062,9 @@ func (h *SessionHost) fetchAgentKey(ctx context.Context, agentType string) (*age
 	}
 
 	return &agentCredential{
-		credential:     result.APIKey,
-		credentialKind: result.CredentialKind,
+		credential:      result.APIKey,
+		credentialKind:  result.CredentialKind,
+		inferenceConfig: result.InferenceConfig,
 	}, nil
 }
 
@@ -2120,6 +2106,69 @@ func (h *SessionHost) fetchAgentSettings(ctx context.Context, agentType string) 
 
 	slog.Info("Fetched agent settings from control plane", "model", result.Model, "permissionMode", result.PermissionMode)
 	return &result
+}
+
+// buildOpenCodeConfig builds the OPENCODE_CONFIG_CONTENT JSON object dynamically
+// based on the credential source. When the control plane returns an inferenceConfig
+// (platform AI proxy), it builds an openai-compatible provider config using the
+// proxy URL and callback token. Otherwise falls back to the legacy Scaleway config.
+func buildOpenCodeConfig(cred *agentCredential, settings *agentSettingsPayload, callbackToken string) map[string]interface{} {
+	if cred.inferenceConfig != nil {
+		return buildOpenAICompatibleConfig(cred.inferenceConfig, settings, callbackToken)
+	}
+
+	// Legacy: Scaleway default
+	return buildScalewayOpenCodeConfig(settings)
+}
+
+// buildOpenAICompatibleConfig builds an OpenCode provider config for an OpenAI-compatible
+// API endpoint (e.g., the SAM AI proxy). Uses the callback token as the API key when
+// apiKeySource is "callback-token".
+func buildOpenAICompatibleConfig(cfg *inferenceConfig, settings *agentSettingsPayload, callbackToken string) map[string]interface{} {
+	apiKey := callbackToken
+	if cfg.ApiKeySource != "callback-token" {
+		// If not using callback token, leave apiKey as the literal credential
+		// (future: could support other sources)
+		apiKey = cfg.ApiKeySource
+	}
+
+	model := cfg.Model
+	if settings != nil && settings.Model != "" {
+		model = settings.Model
+	}
+
+	return map[string]interface{}{
+		"provider": map[string]interface{}{
+			"sam-ai": map[string]interface{}{
+				"npm": "@ai-sdk/openai-compatible",
+				"options": map[string]interface{}{
+					"baseURL": cfg.BaseURL,
+					"apiKey":  apiKey,
+				},
+			},
+		},
+		"model": "sam-ai/" + model,
+	}
+}
+
+// buildScalewayOpenCodeConfig builds the legacy Scaleway provider config for OpenCode.
+func buildScalewayOpenCodeConfig(settings *agentSettingsPayload) map[string]interface{} {
+	model := "scaleway/qwen3-coder-30b-a3b-instruct"
+	if settings != nil && settings.Model != "" {
+		model = settings.Model
+	}
+
+	return map[string]interface{}{
+		"provider": map[string]interface{}{
+			"scaleway": map[string]interface{}{
+				"options": map[string]interface{}{
+					"baseURL": "https://api.scaleway.ai/v1",
+					"apiKey":  "{env:SCW_SECRET_KEY}",
+				},
+			},
+		},
+		"model": model,
+	}
 }
 
 // --- sessionHostClient: ACP SDK client interface ---


### PR DESCRIPTION
## Summary
- Extend the workspace agent-key response with optional `inferenceConfig` data for platform-managed OpenCode inference.
- Add the shared `InferenceConfig` type so the worker and VM agent agree on the proxy configuration contract.
- Replace the hardcoded OpenCode provider configuration path in the VM agent with dynamic config generation.
- Reuse the workspace callback token as the API key when the inference config declares `apiKeySource: callback-token`.
- Preserve the existing user-credential path while adding the platform AI proxy fallback when `AI_PROXY_ENABLED=true` and no user credential is available.
- Add Go and TypeScript tests around config generation, callback-token reuse, and `/agent-key` proxy fallback behavior.

## Context
This branch came from SAM task `01KP3BKDVGKEDGA6PNWRM8X8DW` ("Implement dynamic OpenCode config with AI proxy fallback"). It was pushed on `sam/vm-agent-dynamic-opencode-01kp3b` but never had a PR opened.

## Validation
- Added 6 Go unit tests and 4 TypeScript unit tests.
- API tests passed (`3473` passing at task completion).
- Typecheck and lint were reported clean in the task output.

## Notes
This branch is the VM-agent/API follow-up that makes the existing AI proxy path usable by OpenCode when users have no API key configured. It is narrowly scoped to the config contract and fallback path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI Proxy support with enable/disable configuration
  * Introduced AI Proxy default model selection
  * Added OpenAI-compatible inference configuration as a fallback for agents without user-provided credentials

* **Tests**
  * Added comprehensive unit tests for AI Proxy fallback behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->