### PR TITLE
Fix chat reconnect routing and idle cleanup persistence

### DIFF
--- a/.claude/rules/06-technical-patterns.md
+++ b/.claude/rules/06-technical-patterns.md
@@ -136,6 +136,37 @@ Before committing UI form changes:
 - [ ] The backend handler reads every field the API request type defines
 - [ ] At least one test verifies the field's value reaches the backend function that acts on it
 
+## Canonical Session Routing (Required)
+
+When a route or UI component bridges persisted chat history to a live agent connection, you MUST resolve the live session using the canonical chat-scoped identifier, not a broader workspace-scoped heuristic.
+
+### Why This Rule Exists
+
+The disappearing-messages regression on 2026-04-22 was caused by `apps/api/src/routes/chat.ts` resolving `agentSessionId` as "latest agent session in the workspace" from D1. That looked plausible, but the canonical mapping already lived in the ProjectData DO as `acp_sessions.chat_session_id`. Once a workspace had multiple agent sessions over time, the UI could attach live ACP state from the wrong conversation and overwrite the expected chat view.
+
+### Required Steps
+
+1. **Find the narrowest canonical identifier** for the handoff. If a mapping table or DO record already ties `chatSessionId` to a live session, use that instead of inferring from `workspaceId`.
+2. **Do not substitute recency for identity.** "Latest session in workspace" is not a safe proxy for "session for this chat."
+3. **Write a route or integration test** that asserts the canonical lookup is used.
+4. **Write a negative assertion** when practical: prove the broader heuristic is not consulted for this path.
+5. **Preserve suspended or transient sessions** by avoiding status filters unless the canonical contract explicitly requires one.
+
+## Idle Cleanup And Message Activity
+
+When a session has an armed idle-cleanup timer, the server must treat newly persisted messages as authoritative activity and extend the timer on the server side.
+
+### Why This Rule Exists
+
+The disappearing-messages regression on 2026-04-22 was triggered by a scheduled idle cleanup stopping a chat session while fresh agent output was still being persisted from the VM agent. The browser had an `idle-reset` endpoint, but the durable-object write path did not extend the cleanup deadline during `persistMessage()` or `persistMessageBatch()`. Once the session was marked `stopped`, `POST /api/workspaces/:id/messages` began returning permanent `400` errors and the VM agent discarded those messages.
+
+### Required Steps
+
+1. **Refresh idle cleanup from authoritative writes.** Any successfully persisted user or agent message must extend an existing idle-cleanup schedule inside the ProjectData DO.
+2. **Do not rely on browser optimism.** Client-side `idle-reset` calls are supplementary; they are not sufficient for lifecycle correctness.
+3. **Keep cleanup scheduling and persistence coupled.** If a session can still accept messages, the persistence path must be able to keep it alive.
+4. **Write a regression test** proving persisted messages move `cleanupAt` forward for a scheduled session.
+
 ## Adding New Features
 
 1. Check if types need to be added to `packages/shared`

--- a/apps/api/src/durable-objects/project-data/index.ts
+++ b/apps/api/src/durable-objects/project-data/index.ts
@@ -91,6 +91,10 @@ export class ProjectData extends DurableObject<Env> {
 
   async persistMessage(sessionId: string, role: string, content: string, toolMetadata: string | null): Promise<string> {
     const result = messages.persistMessage(this.sql, this.env, sessionId, role, content, toolMetadata);
+    const idleReset = idleCleanup.resetIdleCleanup(this.sql, this.env, sessionId);
+    if (idleReset.cleanupAt > 0) {
+      await this.recalculateAlarm();
+    }
     if (result.workspaceId) activity.updateMessageActivity(this.sql, result.workspaceId, sessionId);
     this.scheduleSummarySync();
     let parsedToolMetadata: unknown = null;
@@ -111,6 +115,10 @@ export class ProjectData extends DurableObject<Env> {
   ): Promise<{ persisted: number; duplicates: number }> {
     const result = messages.persistMessageBatch(this.sql, this.env, sessionId, batchMessages);
     if (result.persisted > 0) {
+      const idleReset = idleCleanup.resetIdleCleanup(this.sql, this.env, sessionId);
+      if (idleReset.cleanupAt > 0) {
+        await this.recalculateAlarm();
+      }
       if (result.workspaceId) activity.updateMessageActivity(this.sql, result.workspaceId, sessionId);
       this.scheduleSummarySync();
       this.broadcastEvent('messages.batch', { sessionId, messages: result.persistedMessages, count: result.persisted }, sessionId);

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -8,7 +8,7 @@
  */
 import type { ChatSessionTaskEmbed } from '@simple-agent-manager/shared';
 import { isTaskExecutionStep } from '@simple-agent-manager/shared';
-import { and, desc,eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/d1';
 import { Hono } from 'hono';
 
@@ -167,33 +167,32 @@ chatRoutes.get('/:sessionId', async (c) => {
     }
   }
 
-  // Look up the most recent agent session ID (ULID) from D1 so the UI can
-  // route ACP WebSocket to the correct VM agent session instead of creating a
-  // duplicate.  We intentionally do NOT filter by status='running' — the
-  // agent session may be suspended (idle timeout) or briefly in another
-  // transient state.  The VM agent auto-resumes suspended sessions on
-  // WebSocket attach (agent_ws.go:96-117), so the browser should always
-  // reconnect with the original agent session ID to preserve conversation
-  // context.  Filtering by status caused the UI to fall back to the chat
-  // session ID, which created a new SessionHost on the VM and wiped the
-  // conversation history.
+  // Resolve the ACP session from the ProjectData DO's canonical chatSessionId
+  // mapping rather than inferring it from the workspace. A workspace can host
+  // multiple agent sessions over time, so "latest agent session in workspace"
+  // is not a safe proxy for "agent session for this chat session".
+  //
+  // We intentionally do NOT filter by ACP status='running' — the agent session
+  // may be suspended (idle timeout) or briefly in another transient state. The
+  // VM agent auto-resumes suspended sessions on WebSocket attach
+  // (agent_ws.go:96-117), so the browser should always reconnect with the
+  // original ACP session ID linked to this chat session to preserve
+  // conversation context.
   let agentSessionId: string | null = null;
-  const workspaceId = (session as Record<string, unknown>).workspaceId as string | null;
-  if (workspaceId) {
-    try {
-      const [agentRow] = await db
-        .select({ id: schema.agentSessions.id })
-        .from(schema.agentSessions)
-        .where(eq(schema.agentSessions.workspaceId, workspaceId))
-        .orderBy(desc(schema.agentSessions.createdAt))
-        .limit(1);
-      if (agentRow) {
-        agentSessionId = agentRow.id;
-      }
-    } catch (err) {
-      // D1 lookup failure is non-fatal — UI falls back to chat session ID
-      log.warn('chat.agent_session_id_lookup_failed', { workspaceId, error: err instanceof Error ? err.message : String(err) });
-    }
+  try {
+    const acpSessions = await projectDataService.listAcpSessions(c.env, projectId, {
+      chatSessionId: sessionId,
+      limit: 1,
+    });
+    agentSessionId = acpSessions.sessions[0]?.id ?? null;
+  } catch (err) {
+    // ACP session lookup failure is non-fatal — UI falls back to the chat
+    // session ID and can still load persisted history from the DO.
+    log.warn('chat.agent_session_id_lookup_failed', {
+      projectId,
+      sessionId,
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 
   return c.json({

--- a/apps/api/tests/unit/routes/chat-session-agent-routing.test.ts
+++ b/apps/api/tests/unit/routes/chat-session-agent-routing.test.ts
@@ -1,0 +1,164 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Env } from '../../../src/env';
+import { chatRoutes } from '../../../src/routes/chat';
+
+const mocks = vi.hoisted(() => ({
+  drizzle: vi.fn(),
+  requireOwnedProject: vi.fn(),
+  getSession: vi.fn(),
+  getMessages: vi.fn(),
+  listAcpSessions: vi.fn(),
+}));
+
+vi.mock('drizzle-orm/d1', () => ({
+  drizzle: mocks.drizzle,
+}));
+
+vi.mock('@simple-agent-manager/shared', () => ({
+  DEFAULT_WORKSPACE_PROFILE: 'full',
+  isTaskExecutionStep: () => true,
+}));
+
+vi.mock('../../../src/middleware/auth', () => ({
+  requireAuth: () => vi.fn((c: unknown, next: () => Promise<void>) => next()),
+  requireApproved: () => vi.fn((c: unknown, next: () => Promise<void>) => next()),
+  getUserId: () => 'user-1',
+}));
+
+vi.mock('../../../src/middleware/project-auth', () => ({
+  requireOwnedProject: mocks.requireOwnedProject,
+}));
+
+vi.mock('../../../src/services/project-data', () => ({
+  listSessions: vi.fn(),
+  createSession: vi.fn(),
+  forwardWebSocket: vi.fn(),
+  getSession: mocks.getSession,
+  getMessages: mocks.getMessages,
+  resetIdleCleanup: vi.fn(),
+  listAcpSessions: mocks.listAcpSessions,
+  stopSession: vi.fn(),
+  linkSessionIdea: vi.fn(),
+  unlinkSessionIdea: vi.fn(),
+}));
+
+vi.mock('../../../src/schemas', () => ({
+  CreateChatSessionSchema: {},
+  LinkTaskToChatSchema: {},
+  SendChatMessageSchema: {},
+  parseOptionalBody: vi.fn(),
+}));
+
+describe('chatRoutes agent session routing', () => {
+  let app: Hono<{ Bindings: Env }>;
+  let orderBySpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    orderBySpy = vi.fn(() => ({
+      limit: vi.fn().mockResolvedValue([]),
+    }));
+
+    const queryBuilder = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([]),
+      orderBy: orderBySpy,
+    };
+
+    mocks.drizzle.mockReturnValue({
+      select: vi.fn().mockReturnValue(queryBuilder),
+    });
+
+    mocks.requireOwnedProject.mockResolvedValue({
+      id: 'proj-1',
+      userId: 'user-1',
+    });
+
+    mocks.getSession.mockResolvedValue({
+      id: 'chat-1',
+      workspaceId: 'ws-1',
+      taskId: null,
+      topic: 'Investigate routing',
+      status: 'active',
+      messageCount: 2,
+      startedAt: 1,
+      endedAt: null,
+      createdAt: 1,
+    });
+
+    mocks.getMessages.mockResolvedValue({
+      messages: [
+        {
+          id: 'msg-1',
+          sessionId: 'chat-1',
+          role: 'assistant',
+          content: 'Persisted output',
+          toolMetadata: null,
+          createdAt: 1,
+          sequence: 1,
+        },
+      ],
+      hasMore: false,
+    });
+
+    app = new Hono<{ Bindings: Env }>();
+    app.onError((err, c) => {
+      const appError = err as { statusCode?: number; error?: string; message?: string };
+      if (typeof appError.statusCode === 'number' && typeof appError.error === 'string') {
+        return c.json({ error: appError.error, message: appError.message }, appError.statusCode);
+      }
+      return c.json({ error: 'INTERNAL_ERROR', message: err.message }, 500);
+    });
+    app.route('/api/projects/:projectId/sessions', chatRoutes);
+  });
+
+  it('resolves agentSessionId from the ACP session linked to the chat session', async () => {
+    mocks.listAcpSessions.mockResolvedValue({
+      sessions: [
+        {
+          id: 'acp-chat-1',
+          chatSessionId: 'chat-1',
+          status: 'completed',
+        },
+      ],
+      total: 1,
+    });
+
+    const response = await app.request(
+      '/api/projects/proj-1/sessions/chat-1',
+      { method: 'GET' },
+      { DATABASE: {} as D1Database } as Env,
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.session.agentSessionId).toBe('acp-chat-1');
+    expect(mocks.listAcpSessions).toHaveBeenCalledWith(
+      expect.anything(),
+      'proj-1',
+      { chatSessionId: 'chat-1', limit: 1 },
+    );
+    expect(orderBySpy).not.toHaveBeenCalled();
+  });
+
+  it('returns a null agentSessionId when no ACP session is linked to the chat session', async () => {
+    mocks.listAcpSessions.mockResolvedValue({
+      sessions: [],
+      total: 0,
+    });
+
+    const response = await app.request(
+      '/api/projects/proj-1/sessions/chat-1',
+      { method: 'GET' },
+      { DATABASE: {} as D1Database } as Env,
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.session.agentSessionId).toBeNull();
+  });
+});

--- a/apps/api/tests/workers/project-data-do.test.ts
+++ b/apps/api/tests/workers/project-data-do.test.ts
@@ -1246,6 +1246,28 @@ describe('ProjectData Durable Object', () => {
       expect(session!.messageCount).toBe(2);
     });
 
+    it('message persistence extends scheduled idle cleanup', async () => {
+      const stub = getStub('project-msg-activity-idle-reset');
+      const sessionId = await stub.createSession('ws-msg-idle', 'Message idle reset test');
+
+      const { cleanupAt: firstCleanupAt } = await stub.scheduleIdleCleanup(sessionId, 'ws-msg-idle', null);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+
+      await stub.persistMessageBatch(sessionId, [
+        {
+          messageId: crypto.randomUUID(),
+          role: 'assistant',
+          content: 'Still working',
+          toolMetadata: null,
+          timestamp: new Date().toISOString(),
+        },
+      ]);
+
+      const secondCleanupAt = await stub.getCleanupAt(sessionId);
+      expect(secondCleanupAt).not.toBeNull();
+      expect(secondCleanupAt!).toBeGreaterThan(firstCleanupAt);
+    });
+
     it('terminal activity works without a session id', async () => {
       const stub = getStub('project-terminal-no-session');
       // Create a session to ensure the DO is initialized

--- a/docs/notes/2026-04-22-chat-agent-session-routing-postmortem.md
+++ b/docs/notes/2026-04-22-chat-agent-session-routing-postmortem.md
@@ -1,0 +1,35 @@
+# Post-Mortem: Chat Session Routed to the Wrong Agent Session
+
+## What Broke
+
+On chat reload, recent assistant responses could appear briefly and then disappear once the UI attached to the live workspace connection. Persisted history existed, but the live chat session sometimes reconnected to the wrong underlying agent session.
+
+## Root Cause
+
+Commit `6fcb08f8` (`fix: resolve session ID mismatch in project chat (#354)`) introduced a heuristic in `apps/api/src/routes/chat.ts` that derived `agentSessionId` by selecting the most recent D1 `agent_sessions` row for the workspace. That was meant to avoid falling back to the chat session ID, but it used the wrong identity boundary: the canonical mapping is `acp_sessions.chat_session_id` inside the ProjectData Durable Object, not "latest session in this workspace."
+
+Once a workspace had more than one agent session over time, `GET /api/projects/:projectId/sessions/:sessionId` could return an `agentSessionId` belonging to a different chat. The browser then merged persisted history for one chat session with live ACP state from another one.
+
+## Timeline
+
+- **2026-03-13**: `6fcb08f8` adds workspace-scoped D1 lookup for `agentSessionId`
+- **2026-03-14**: `caa76524` keeps the same lookup but removes the status filter, preserving the workspace-scoped heuristic
+- **2026-04-22**: User reports chat history appearing after refresh, then disappearing once the live connection settles
+
+## Why It Wasn't Caught
+
+1. The route logic was validated by code inspection, not a route-level regression test.
+2. The fix that introduced the heuristic was solving a real bug, which made the workspace-scoped lookup look like a harmless implementation detail instead of a new identity contract.
+3. The existing test note in `apps/api/tests/workers/route-auth-validation.test.ts` documented "do not filter by status" but not the more important invariant: agent-session lookup must remain chat-scoped.
+
+## Class of Bug
+
+**Wrong identity boundary**: a route resolved live state using a broader workspace-scoped heuristic instead of the narrower canonical chat-scoped identifier. This is a session-routing bug, not a storage bug.
+
+## Process Fix
+
+Add an explicit rule that whenever the UI bridges persisted chat history to live agent state, the handoff must use the canonical session-to-session mapping (`chatSessionId -> ACP session`) rather than a workspace-level proxy like "latest session on this workspace." Route-level tests should assert both the positive mapping and the absence of the broader heuristic.
+
+## Fix
+
+Update `apps/api/src/routes/chat.ts` to resolve `agentSessionId` via `projectDataService.listAcpSessions({ chatSessionId })` and add a regression test that fails if the route falls back to the old workspace-level D1 lookup.

--- a/docs/notes/2026-04-22-chat-idle-cleanup-message-activity-postmortem.md
+++ b/docs/notes/2026-04-22-chat-idle-cleanup-message-activity-postmortem.md
@@ -1,0 +1,59 @@
+# Postmortem: Idle Cleanup Could Stop A Chat Session While Fresh Agent Output Was Still Arriving
+
+Date: 2026-04-22
+
+## Summary
+
+A chat session could be auto-stopped by the ProjectData idle-cleanup timer even though the VM agent was still persisting fresh assistant messages. Once that happened, the workspace-side message reporter hit permanent `400` responses and discarded those messages, so the UI could briefly show live agent output and then fall back to older durable history after a refresh.
+
+## Impact
+
+- Fresh assistant replies could disappear from persisted chat history.
+- The VM agent deleted message outbox rows after the control plane returned permanent client errors.
+- A workspace could remain running while its linked chat session had already been stopped, creating inconsistent live-vs-persisted chat state.
+
+## Root Cause
+
+The system armed idle cleanup when a task entered `awaiting_followup`, but the server did not extend that cleanup deadline when later messages were actually persisted.
+
+Before the fix:
+
+- Idle cleanup was scheduled from [tasks/crud.ts](/workspaces/simple-agent-manager/apps/api/src/routes/tasks/crud.ts:535)
+- The browser could explicitly reset the deadline via [chat.ts](/workspaces/simple-agent-manager/apps/api/src/routes/chat.ts:223)
+- But ProjectData persistence did **not** extend the deadline inside [project-data/index.ts](/workspaces/simple-agent-manager/apps/api/src/durable-objects/project-data/index.ts:92) or [project-data/index.ts](/workspaces/simple-agent-manager/apps/api/src/durable-objects/project-data/index.ts:108)
+- Once the session was stopped, [messages.ts](/workspaces/simple-agent-manager/apps/api/src/durable-objects/project-data/messages.ts:125) rejected further batch writes
+- The API surfaced that as a permanent `400` from [runtime.ts](/workspaces/simple-agent-manager/apps/api/src/routes/workspaces/runtime.ts:592)
+
+This made session liveness depend too heavily on the browser calling `idle-reset` at the right time, instead of on authoritative persisted activity.
+
+## Trigger Conditions
+
+The regression required:
+
+- A session with an active idle-cleanup schedule
+- Later agent output reaching the ProjectData persistence path
+- No server-side extension of the cleanup deadline before it expired
+
+At that point the session could be stopped even though fresh output was still in flight.
+
+## Fix
+
+The ProjectData DO now extends any existing idle-cleanup schedule whenever it successfully persists messages through:
+
+- `persistMessage()`
+- `persistMessageBatch()`
+
+Updated code:
+
+- [project-data/index.ts](/workspaces/simple-agent-manager/apps/api/src/durable-objects/project-data/index.ts:92)
+- [project-data/index.ts](/workspaces/simple-agent-manager/apps/api/src/durable-objects/project-data/index.ts:108)
+
+Regression coverage:
+
+- [project-data-do.test.ts](/workspaces/simple-agent-manager/apps/api/tests/workers/project-data-do.test.ts:1245)
+
+## Prevention
+
+- Server-side lifecycle timers must be refreshed from authoritative persisted activity.
+- Client-side timer resets should be treated as hints, not correctness boundaries.
+- Idle-cleanup changes must include a regression test proving that fresh persisted output extends the cleanup deadline.


### PR DESCRIPTION
## Summary
- resolve `agentSessionId` for chat sessions from the ProjectData DO's canonical `chatSessionId -> ACP session` mapping instead of inferring from the latest workspace agent session
- extend scheduled session idle cleanup whenever authoritative message persistence succeeds, so active agent output cannot race a stale idle timer and get rejected as a stopped session
- add regression coverage, postmortems, and a process rule for both failure modes uncovered during investigation

## What this addresses
The uploaded debug package showed two concrete problems behind the disappearing-agent-messages symptom:
1. chat reconnects could attach the UI to the wrong live ACP session for older/reused workspaces
2. `POST /api/workspaces/:id/messages` could start returning permanent `400` errors after ProjectData idle cleanup stopped an otherwise active chat session while the VM agent was still reporting messages

This PR fixes both of those control-plane issues.

## Verification
- `pnpm --filter @simple-agent-manager/api test -- tests/unit/routes/chat-session-agent-routing.test.ts`
- worker regression test added for idle-cleanup reset-on-persist in `apps/api/tests/workers/project-data-do.test.ts`
- local `test:workers` execution is currently blocked by `workerd`/Miniflare instability in this workspace (`worker exited unexpectedly` / segfault), so I could not get a clean local pass for that suite here

## Follow-up still open
The debug package also showed repeated VM-agent `session/update` marshal failures (`acp.ContentBlock: unexpected end of JSON input`) and some callback `401`s. Those appear to be separate issues and are not fixed in this PR.