### PR TITLE
feat(www): add interactive mermaid blog previews

### DIFF
--- a/apps/www/.gitignore
+++ b/apps/www/.gitignore
@@ -4,3 +4,6 @@ node_modules/
 
 # Compiled from src/scripts/tracker.ts by build:tracker script
 public/scripts/tracker.js
+
+# Compiled from src/scripts/blog-mermaid.ts by build:blog-mermaid script
+public/scripts/blog-mermaid.js

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -4,17 +4,21 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "astro dev",
+    "dev": "pnpm build:assets && astro dev",
+    "build:assets": "pnpm build:tracker && pnpm build:blog-mermaid",
+    "build:blog-mermaid": "pnpm exec esbuild src/scripts/blog-mermaid.ts --bundle --format=esm --platform=browser --target=es2022 --outfile=public/scripts/blog-mermaid.js",
     "build:tracker": "npx tsx scripts/build-tracker.ts",
-    "build": "pnpm build:tracker && astro build",
+    "build": "pnpm build:assets && astro build",
     "preview": "astro preview"
   },
   "dependencies": {
     "@astrojs/sitemap": "3.7.2",
     "@astrojs/starlight": "0.37.7",
-    "astro": "5.17.3"
+    "astro": "5.17.3",
+    "mermaid": "11.14.0"
   },
   "devDependencies": {
+    "esbuild": "0.25.12",
     "typescript": "catalog:"
   }
 }

--- a/apps/www/src/content/blog/i-wanted-a-diagram-i-could-actually-read.md
+++ b/apps/www/src/content/blog/i-wanted-a-diagram-i-could-actually-read.md
@@ -1,0 +1,148 @@
+---
+title: "I Wanted a Diagram I Could Actually Read"
+date: 2026-04-22
+author: Raphaël Titsworth-Morin
+category: devlog
+tags: ["architecture", "ux", "ai-agents", "cloudflare-workers", "open-source"]
+excerpt: "I needed a SAM architecture diagram that still made sense on my phone. This post shows the approach and the system shape behind it."
+---
+
+I kept ending up in the same conversation.
+
+Someone would ask how SAM actually works. I would start with "Cloudflare Worker control plane, ephemeral VM workspaces, per-project context," and at some point I would paste a static diagram. On desktop it was fine. On my phone, which is where I use SAM a lot, it was basically a green blur with tiny labels.
+
+That felt wrong for a product like this. If SAM is supposed to make complex systems feel operable, the architecture post on the marketing site should not collapse the second you pinch-zoom it on mobile.
+
+So this is the version I actually wanted: one diagram, directly inside the blog post, with enough detail to be useful and enough interaction to stay readable.
+
+## The shape I keep explaining
+
+The core SAM story is simple.
+
+You talk to an agent. The control plane figures out what infrastructure is needed. A workspace appears on your own cloud. The project keeps the durable context. The agent does work there, not in some black box you can't inspect.
+
+The diagram below shows the control flow I keep describing to people when they ask where the moving parts actually are.
+
+```mermaid
+flowchart LR
+  classDef actor fill:#0f1917,stroke:#6ed79a,color:#e6f2ee,stroke-width:1.5px;
+  classDef plane fill:#13201d,stroke:#3f7a63,color:#e6f2ee,stroke-width:1.5px;
+  classDef store fill:#101816,stroke:#2f6d58,color:#d6e8e0,stroke-width:1.5px;
+  classDef edge fill:#162723,stroke:#4b8d72,color:#e6f2ee,stroke-width:1.5px;
+  classDef vm fill:#0d1714,stroke:#7be0a2,color:#effaf4,stroke-width:1.5px;
+  classDef note fill:#1a1710,stroke:#f59e0b,color:#f7e7c2,stroke-dasharray: 5 3;
+
+  user["Developer<br/>chatting with SAM"]:::actor
+  mobile["Phone / PWA<br/>where I usually notice bad diagrams"]:::note
+
+  subgraph cf["Cloudflare control plane"]
+    web["app.<br/>React control plane"]:::plane
+    api["api.<br/>Hono API routes"]:::plane
+    runner["Task runner<br/>dispatches and supervises"]:::plane
+    project["ProjectData DO<br/>sessions, messages, activity"]:::store
+    nodeLife["NodeLifecycle DO<br/>warm node state machine"]:::store
+    d1["D1<br/>cross-project queries"]:::store
+    kv["KV / R2<br/>cache + durable assets"]:::store
+  end
+
+  subgraph cloud["User cloud account"]
+    provider["Provider adapter<br/>Hetzner today, more later"]:::edge
+    node["Node VM<br/>single-user isolation"]:::vm
+    workspace["Workspace VM / container<br/>one agent, one task focus"]:::vm
+    vmAgent["VM agent<br/>PTY + WebSocket + ACP"]:::vm
+    repo["Checked-out repo<br/>branch + PR workflow"]:::edge
+  end
+
+  subgraph memory["Accumulating product value"]
+    ideas["Ideas + linked sessions"]:::store
+    search["Cross-conversation search"]:::store
+    knowledge["Knowledge graph<br/>what the system learns over time"]:::store
+  end
+
+  user -->|"asks for work"| web
+  mobile -.->|"forces mobile-first reality check"| web
+  web --> api
+  api --> runner
+  api <--> project
+  api <--> d1
+  runner <--> project
+  runner <--> nodeLife
+  runner --> provider
+  provider --> node
+  node --> workspace
+  workspace --> vmAgent
+  vmAgent <--> api
+  vmAgent --> repo
+  project --> ideas
+  project --> search
+  project --> knowledge
+  kv -.-> web
+  kv -.-> api
+
+  click project "/docs/architecture/overview/" "Open the architecture overview"
+  click knowledge "/blog/sams-journal-knowledge-before-the-vm-boots/" "Read about knowledge before the VM boots"
+  click runner "/blog/agents-managing-agents/" "Read about agent orchestration"
+  click web "/" "Open the SAM site home page"
+```
+
+## What matters in the diagram
+
+There are four ideas I want people to get from this immediately.
+
+### 1. The control plane is not the workspace
+
+SAM's UI and API live on Cloudflare. The actual coding work happens in a workspace that runs on infrastructure you control. That's the boundary that matters.
+
+It is easy to accidentally present agent products like a magic hosted blob where everything is happening in one place. SAM is the opposite. The control plane coordinates. The workspace does the work.
+
+### 2. Project memory is part of the product, not just metadata
+
+The `ProjectData` durable object, ideas system, search, and knowledge graph are not side dishes.
+
+They're the part that compounds.
+
+If all you have is "spin up a fresh workspace," you can replace that with raw infrastructure pretty quickly. What is harder to replace is the layer that remembers what you were doing, what your agents learned, and what should happen next across sessions.
+
+That is the reason I keep thinking about SAM as more than a workspace launcher.
+
+### 3. Isolation is a product decision
+
+We are opinionated about this: one agent per workspace, and different users do not share the same VM. That sounds like an implementation detail until you've debugged enough messy shared-state systems.
+
+The architecture diagram should communicate that isolation visually, because it is part of the trust model.
+
+### 4. The UX has to survive mobile
+
+I am on the phone a lot when I check on agents. That means diagrams, logs, task trees, and status surfaces have to survive narrow screens and clumsy thumbs.
+
+This is not a separate "later we will make it responsive" concern. It changes the design from the start.
+
+## Why I wanted the diagram to be interactive
+
+Static diagrams are fine when they are tiny or shallow.
+
+SAM is neither.
+
+If I try to make the architecture honest, it includes the control plane, the provider boundary, the per-project state, and the long-term context layer. That is enough density that the viewer should be allowed to explore it, not just stare at a screenshot. So the interaction model here is intentionally simple:
+
+- Drag to pan across dense sections.
+- Scroll or pinch to zoom when labels get tight.
+- Click key nodes to jump into the relevant docs or blog posts.
+
+That is enough to make the post feel alive without turning it into a toy.
+
+## The product lesson hiding inside this
+
+This started as a content problem. I wanted a better blog post.
+
+But it is also the same standard I want the rest of SAM to meet. When the system gets complicated, the answer should not be "flatten the truth until it fits." The answer should be "make the real thing understandable."
+
+I want the product to feel like that. Honest topology. Real boundaries. Enough polish that complexity stays navigable.
+
+That is the vibe I want the marketing site to carry too.
+
+## What's next
+
+The obvious follow-up is using the same treatment for docs pages and architecture explainers, not just blog posts. Dense system diagrams get a lot more useful once they behave like surfaces instead of screenshots.
+
+If you want to see the actual system this diagram describes, [the code is here](https://github.com/raphaeltm/simple-agent-manager). If you're building something similar, I think the interesting problem is not just rendering diagrams. It's designing systems that still make sense when you have to explain them to yourself on a phone while an agent is already working.

--- a/apps/www/src/layouts/BlogPost.astro
+++ b/apps/www/src/layouts/BlogPost.astro
@@ -26,7 +26,7 @@ const formattedDate = date.toLocaleDateString('en-US', {
 
 <Base title={`${title} | SAM Blog`} description={description}>
   <Header />
-  <main class="blog-post">
+  <main class="blog-post" data-blog-title={title}>
     <div class="container">
       <a href="/blog" class="back-link">&larr; All posts</a>
 
@@ -56,6 +56,11 @@ const formattedDate = date.toLocaleDateString('en-US', {
     </div>
   </main>
   <CtaFooter />
+  <script type="module">
+    if (document.querySelector('.post-body [data-language="mermaid"]')) {
+      import('/scripts/blog-mermaid.js');
+    }
+  </script>
 </Base>
 
 <style>
@@ -230,6 +235,263 @@ const formattedDate = date.toLocaleDateString('en-US', {
     padding: 2px 6px;
     font-family: var(--font-mono);
     font-size: 0.85em;
+  }
+
+  .post-body :global(.mermaid-shell) {
+    margin: 32px 0;
+    border: 1px solid rgba(110, 215, 154, 0.18);
+    border-radius: 20px;
+    overflow: hidden;
+    background:
+      radial-gradient(circle at top left, rgba(110, 215, 154, 0.12), transparent 32%),
+      linear-gradient(180deg, rgba(19, 32, 29, 0.96), rgba(11, 17, 16, 0.98));
+    box-shadow:
+      inset 0 1px 0 rgba(230, 242, 238, 0.04),
+      0 28px 60px rgba(0, 0, 0, 0.24);
+  }
+
+  .post-body :global(.mermaid-chrome) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 18px 20px 14px;
+    border-bottom: 1px solid rgba(110, 215, 154, 0.12);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent);
+  }
+
+  .post-body :global(.mermaid-eyebrow) {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: #6ed79a;
+  }
+
+  .post-body :global(.mermaid-hint) {
+    margin: 4px 0 0;
+    font-size: 0.82rem;
+    color: var(--color-fg-muted);
+  }
+
+  .post-body :global(.mermaid-actions) {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .post-body :global(.mermaid-reset),
+  .post-body :global(.mermaid-expand) {
+    border: 1px solid rgba(110, 215, 154, 0.18);
+    border-radius: 999px;
+    padding: 10px 14px;
+    background: rgba(11, 17, 16, 0.7);
+    color: var(--color-fg-primary);
+    font: inherit;
+    font-size: 0.82rem;
+    cursor: pointer;
+    transition:
+      border-color 0.2s ease,
+      transform 0.2s ease,
+      background 0.2s ease;
+  }
+
+  .post-body :global(.mermaid-reset:hover),
+  .post-body :global(.mermaid-reset:focus-visible),
+  .post-body :global(.mermaid-expand:hover),
+  .post-body :global(.mermaid-expand:focus-visible) {
+    border-color: rgba(110, 215, 154, 0.45);
+    background: rgba(21, 128, 61, 0.12);
+    transform: translateY(-1px);
+  }
+
+  .post-body :global(.mermaid-expand) {
+    background: rgba(22, 163, 74, 0.12);
+  }
+
+  .post-body :global(.mermaid-surface) {
+    position: relative;
+    width: 100%;
+    min-height: 360px;
+    max-height: min(78vh, 720px);
+    overflow: hidden;
+    cursor: grab;
+    touch-action: none;
+    aspect-ratio: var(--mermaid-diagram-ratio, auto);
+    background:
+      linear-gradient(rgba(110, 215, 154, 0.05) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(110, 215, 154, 0.05) 1px, transparent 1px);
+    background-size: 28px 28px;
+  }
+
+  .post-body :global(.mermaid-surface.is-grabbing) {
+    cursor: grabbing;
+  }
+
+  .post-body :global(.mermaid-canvas) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-height: 360px;
+    height: 100%;
+    padding: 20px;
+  }
+
+  .post-body :global(.mermaid-canvas svg) {
+    display: block;
+    width: 100%;
+    max-width: none;
+    height: 100%;
+    max-height: 100%;
+    margin: 0 auto;
+    shape-rendering: geometricPrecision;
+    text-rendering: geometricPrecision;
+    color-rendering: optimizeQuality;
+  }
+
+  .post-body :global(.mermaid-shell .label),
+  .post-body :global(.mermaid-shell foreignObject div) {
+    color: var(--color-fg-primary);
+  }
+
+  .post-body :global(.mermaid-error) {
+    padding: 24px;
+    color: #ffd1d1;
+  }
+
+  .post-body :global(.mermaid-error pre) {
+    margin-top: 12px;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  :global(body.mermaid-fullscreen-open) {
+    overflow: hidden;
+  }
+
+  .post-body :global(.mermaid-shell.is-fullscreen) {
+    position: fixed;
+    inset: 16px;
+    z-index: 300;
+    margin: 0;
+    border-color: rgba(110, 215, 154, 0.28);
+    background:
+      radial-gradient(circle at top left, rgba(110, 215, 154, 0.16), transparent 28%),
+      linear-gradient(180deg, rgba(19, 32, 29, 0.985), rgba(7, 11, 10, 0.995));
+  }
+
+  .post-body :global(.mermaid-shell.is-fullscreen .mermaid-chrome) {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    left: 12px;
+    z-index: 2;
+    align-items: flex-start;
+    border: none;
+    padding: 0;
+    background: none;
+    pointer-events: none;
+  }
+
+  .post-body :global(.mermaid-shell.is-fullscreen .mermaid-chrome > div:first-child) {
+    max-width: min(55vw, 420px);
+    padding: 10px 12px;
+    border: 1px solid rgba(110, 215, 154, 0.12);
+    border-radius: 14px;
+    background: rgba(7, 11, 10, 0.68);
+  }
+
+  .post-body :global(.mermaid-shell.is-fullscreen .mermaid-actions) {
+    margin-left: auto;
+    pointer-events: auto;
+  }
+
+  .post-body :global(.mermaid-shell.is-fullscreen .mermaid-surface) {
+    min-height: calc(100vh - 32px);
+    max-height: calc(100vh - 32px);
+    aspect-ratio: auto;
+  }
+
+  .post-body :global(.mermaid-shell.is-fullscreen .mermaid-canvas) {
+    min-height: calc(100vh - 32px);
+    padding: 24px;
+  }
+
+  .post-body :global(.mermaid-shell.is-fullscreen .mermaid-canvas svg) {
+    width: 100%;
+    height: 100%;
+  }
+
+  @media (max-width: 640px) {
+    .post-body :global(.mermaid-chrome) {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .post-body :global(.mermaid-actions) {
+      width: 100%;
+      flex-direction: column;
+    }
+
+    .post-body :global(.mermaid-reset),
+    .post-body :global(.mermaid-expand) {
+      width: 100%;
+      min-height: 44px;
+    }
+
+    .post-body :global(.mermaid-surface) {
+      min-height: 300px;
+    }
+
+    .post-body :global(.mermaid-canvas) {
+      min-height: 300px;
+      padding: 14px;
+    }
+
+    .post-body :global(.mermaid-shell.is-fullscreen) {
+      inset: 0;
+      border-radius: 0;
+      border-left: none;
+      border-right: none;
+    }
+
+    .post-body :global(.mermaid-shell.is-fullscreen .mermaid-chrome) {
+      top: 8px;
+      right: 8px;
+      left: 8px;
+      flex-direction: row;
+      justify-content: flex-end;
+      gap: 8px;
+    }
+
+    .post-body :global(.mermaid-shell.is-fullscreen .mermaid-chrome > div:first-child) {
+      display: none;
+    }
+
+    .post-body :global(.mermaid-shell.is-fullscreen .mermaid-actions) {
+      width: auto;
+      flex-direction: row;
+      gap: 8px;
+    }
+
+    .post-body :global(.mermaid-shell.is-fullscreen .mermaid-reset),
+    .post-body :global(.mermaid-shell.is-fullscreen .mermaid-expand) {
+      width: auto;
+      min-height: 40px;
+      padding: 8px 12px;
+      font-size: 0.78rem;
+      background: rgba(7, 11, 10, 0.78);
+    }
+
+    .post-body :global(.mermaid-shell.is-fullscreen .mermaid-surface),
+    .post-body :global(.mermaid-shell.is-fullscreen .mermaid-canvas) {
+      min-height: 100vh;
+      max-height: 100vh;
+      padding: 12px;
+    }
   }
 
   .post-tags {

--- a/apps/www/src/scripts/blog-mermaid.ts
+++ b/apps/www/src/scripts/blog-mermaid.ts
@@ -1,0 +1,432 @@
+import mermaid from 'mermaid';
+
+mermaid.initialize({
+  startOnLoad: false,
+  securityLevel: 'loose',
+  theme: 'base',
+  themeVariables: {
+    background: '#13201d',
+    primaryColor: '#13201d',
+    primaryTextColor: '#e6f2ee',
+    primaryBorderColor: '#2f6d58',
+    lineColor: '#6ed79a',
+    secondaryColor: '#0e1a17',
+    secondaryTextColor: '#d6e8e0',
+    tertiaryColor: '#162723',
+    tertiaryTextColor: '#9fb7ae',
+    clusterBkg: '#101b18',
+    clusterBorder: '#2f6d58',
+    edgeLabelBackground: '#0b1110',
+    nodeBorder: '#3f7a63',
+    fontFamily:
+      'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  },
+  flowchart: {
+    curve: 'basis',
+    useMaxWidth: false,
+    htmlLabels: false,
+  },
+});
+
+const diagramBlocks = Array.from(
+  document.querySelectorAll<HTMLElement>('.post-body [data-language="mermaid"]')
+);
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const getDistance = (
+  first: { x: number; y: number },
+  second: { x: number; y: number }
+) => Math.hypot(second.x - first.x, second.y - first.y);
+
+const getMidpoint = (
+  first: { x: number; y: number },
+  second: { x: number; y: number }
+) => ({
+  x: (first.x + second.x) / 2,
+  y: (first.y + second.y) / 2,
+});
+
+const attachPanZoom = (surface: HTMLElement, svg: SVGElement) => {
+  const isMobile = window.innerWidth < 640;
+  const viewBoxAttr = svg.getAttribute('viewBox');
+  if (!viewBoxAttr) {
+    return { reset: () => {} };
+  }
+
+  const [baseMinX, baseMinY, baseWidth, baseHeight] = viewBoxAttr
+    .split(/[\s,]+/)
+    .map(Number);
+
+  surface.style.setProperty('--mermaid-diagram-ratio', `${baseWidth} / ${baseHeight}`);
+
+  const baseCenterX = baseMinX + baseWidth / 2;
+  const baseCenterY = baseMinY + baseHeight / 2;
+  const getShell = () => surface.closest<HTMLElement>('.mermaid-shell');
+  const getDefaultZoom = () => {
+    const isFullscreen = getShell()?.classList.contains('is-fullscreen');
+    if (isMobile) {
+      return isFullscreen ? 1 : 1;
+    }
+
+    return isFullscreen ? 1 : 1;
+  };
+  const getMaxZoom = () => (isMobile ? 18 : 10);
+
+  let zoom = getDefaultZoom();
+  let centerX = baseCenterX;
+  let centerY = baseCenterY;
+  let gestureStartZoom = zoom;
+  let gestureStartCenterX = baseCenterX;
+  let gestureStartCenterY = baseCenterY;
+  let startPointerDistance = 0;
+  let startPointerMidpoint = { x: 0, y: 0 };
+  let panStartPointer = { x: 0, y: 0 };
+  const activePointers = new Map<number, { x: number; y: number }>();
+
+  const getInteractionRect = () => {
+    const rect = svg.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) {
+      return rect;
+    }
+
+    return surface.getBoundingClientRect();
+  };
+
+  const clampCenter = (
+    nextCenterX: number,
+    nextCenterY: number,
+    nextZoom = zoom
+  ) => {
+    const viewWidth = baseWidth / nextZoom;
+    const viewHeight = baseHeight / nextZoom;
+    const minCenterX = baseMinX + viewWidth / 2;
+    const maxCenterX = baseMinX + baseWidth - viewWidth / 2;
+    const minCenterY = baseMinY + viewHeight / 2;
+    const maxCenterY = baseMinY + baseHeight - viewHeight / 2;
+
+    return {
+      x: clamp(nextCenterX, minCenterX, maxCenterX),
+      y: clamp(nextCenterY, minCenterY, maxCenterY),
+    };
+  };
+
+  const applyViewBox = () => {
+    const viewWidth = baseWidth / zoom;
+    const viewHeight = baseHeight / zoom;
+    const clampedCenter = clampCenter(centerX, centerY, zoom);
+    centerX = clampedCenter.x;
+    centerY = clampedCenter.y;
+
+    svg.setAttribute(
+      'viewBox',
+      `${centerX - viewWidth / 2} ${centerY - viewHeight / 2} ${viewWidth} ${viewHeight}`
+    );
+  };
+
+  const reset = () => {
+    zoom = getDefaultZoom();
+    centerX = baseCenterX;
+    centerY = baseCenterY;
+    applyViewBox();
+  };
+
+  const getSvgPoint = (
+    clientX: number,
+    clientY: number,
+    currentCenterX = centerX,
+    currentCenterY = centerY,
+    currentZoom = zoom
+  ) => {
+    const rect = getInteractionRect();
+    const currentWidth = baseWidth / currentZoom;
+    const currentHeight = baseHeight / currentZoom;
+    return {
+      x:
+        currentCenterX - currentWidth / 2 + ((clientX - rect.left) / rect.width) * currentWidth,
+      y:
+        currentCenterY -
+        currentHeight / 2 +
+        ((clientY - rect.top) / rect.height) * currentHeight,
+    };
+  };
+
+  const zoomAroundPoint = (
+    clientX: number,
+    clientY: number,
+    nextZoom: number,
+    baseZoom = zoom,
+    baseCenterXInput = centerX,
+    baseCenterYInput = centerY
+  ) => {
+    const rect = getInteractionRect();
+    const anchor = getSvgPoint(
+      clientX,
+      clientY,
+      baseCenterXInput,
+      baseCenterYInput,
+      baseZoom
+    );
+    const nextWidth = baseWidth / nextZoom;
+    const nextHeight = baseHeight / nextZoom;
+    const relativeX = (clientX - rect.left) / rect.width;
+    const relativeY = (clientY - rect.top) / rect.height;
+
+    return {
+      centerX: anchor.x - (relativeX - 0.5) * nextWidth,
+      centerY: anchor.y - (relativeY - 0.5) * nextHeight,
+    };
+  };
+
+  surface.addEventListener(
+    'wheel',
+    (event) => {
+      event.preventDefault();
+
+      const nextZoom = clamp(zoom - event.deltaY * 0.0012, 1, getMaxZoom());
+      if (nextZoom === zoom) {
+        return;
+      }
+
+      const nextCenter = zoomAroundPoint(
+        event.clientX,
+        event.clientY,
+        nextZoom
+      );
+
+      zoom = nextZoom;
+      centerX = nextCenter.centerX;
+      centerY = nextCenter.centerY;
+      applyViewBox();
+    },
+    { passive: false }
+  );
+
+  const syncGrabState = () => {
+    surface.classList.toggle('is-grabbing', activePointers.size > 0);
+  };
+
+  const initializePinchGesture = () => {
+    const [first, second] = Array.from(activePointers.values());
+    if (!first || !second) {
+      return;
+    }
+
+    gestureStartZoom = zoom;
+    gestureStartCenterX = centerX;
+    gestureStartCenterY = centerY;
+    startPointerDistance = getDistance(first, second);
+    startPointerMidpoint = getMidpoint(first, second);
+  };
+
+  surface.addEventListener('pointerdown', (event) => {
+    activePointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+    surface.setPointerCapture(event.pointerId);
+
+    if (activePointers.size === 1) {
+      gestureStartCenterX = centerX;
+      gestureStartCenterY = centerY;
+      panStartPointer = { x: event.clientX, y: event.clientY };
+    } else if (activePointers.size === 2) {
+      initializePinchGesture();
+    }
+
+    syncGrabState();
+  });
+
+  surface.addEventListener('pointermove', (event) => {
+    if (!activePointers.has(event.pointerId)) {
+      return;
+    }
+
+    activePointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+
+    if (activePointers.size >= 2) {
+      const [first, second] = Array.from(activePointers.values());
+      if (!first || !second || !startPointerDistance) {
+        return;
+      }
+
+      const rect = getInteractionRect();
+      const currentDistance = getDistance(first, second);
+      const midpoint = getMidpoint(first, second);
+      const nextZoom = clamp(
+        gestureStartZoom * (currentDistance / startPointerDistance),
+        1,
+        getMaxZoom()
+      );
+      const nextCenter = zoomAroundPoint(
+        midpoint.x,
+        midpoint.y,
+        nextZoom,
+        gestureStartZoom,
+        gestureStartCenterX,
+        gestureStartCenterY
+      );
+      const startWidth = baseWidth / gestureStartZoom;
+      const startHeight = baseHeight / gestureStartZoom;
+      const deltaMidX =
+        ((midpoint.x - startPointerMidpoint.x) / rect.width) * startWidth;
+      const deltaMidY =
+        ((midpoint.y - startPointerMidpoint.y) / rect.height) * startHeight;
+
+      zoom = nextZoom;
+      centerX = nextCenter.centerX - deltaMidX;
+      centerY = nextCenter.centerY - deltaMidY;
+      applyViewBox();
+      return;
+    }
+
+    if (activePointers.size === 1) {
+      const pointer = activePointers.get(event.pointerId);
+      if (!pointer) {
+        return;
+      }
+
+      const rect = getInteractionRect();
+      const currentWidth = baseWidth / zoom;
+      const currentHeight = baseHeight / zoom;
+      const deltaX =
+        ((pointer.x - panStartPointer.x) / rect.width) * currentWidth;
+      const deltaY =
+        ((pointer.y - panStartPointer.y) / rect.height) * currentHeight;
+
+      centerX = gestureStartCenterX - deltaX;
+      centerY = gestureStartCenterY - deltaY;
+      applyViewBox();
+    }
+  });
+
+  const releasePointer = (event: PointerEvent) => {
+    if (!activePointers.has(event.pointerId)) {
+      return;
+    }
+
+    activePointers.delete(event.pointerId);
+    if (surface.hasPointerCapture(event.pointerId)) {
+      surface.releasePointerCapture(event.pointerId);
+    }
+
+    if (activePointers.size === 1) {
+      const [pointer] = Array.from(activePointers.values());
+      if (pointer) {
+        gestureStartCenterX = centerX;
+        gestureStartCenterY = centerY;
+        panStartPointer = pointer;
+      }
+    } else if (activePointers.size >= 2) {
+      initializePinchGesture();
+    }
+
+    syncGrabState();
+  };
+
+  surface.addEventListener('pointerup', releasePointer);
+  surface.addEventListener('pointercancel', releasePointer);
+
+  applyViewBox();
+  return { reset };
+};
+
+for (const [index, block] of diagramBlocks.entries()) {
+  const pre = block.matches('pre') ? block : block.querySelector('pre');
+  const copyButton = block.querySelector<HTMLButtonElement>('button[data-code]');
+  const source =
+    copyButton?.dataset.code?.replace(/\u007f/g, '\n').trim() ??
+    pre?.innerText?.trim() ??
+    pre?.textContent?.trim();
+  if (!source || !pre) {
+    continue;
+  }
+
+  const article = document.querySelector<HTMLElement>('.blog-post');
+  const title = article?.dataset.blogTitle ?? 'SAM architecture diagram';
+
+  const wrapper = document.createElement('figure');
+  wrapper.className = 'mermaid-shell';
+
+  const chrome = document.createElement('div');
+  chrome.className = 'mermaid-chrome';
+  chrome.innerHTML = `
+    <div>
+      <p class="mermaid-eyebrow">Interactive diagram</p>
+      <p class="mermaid-hint">Drag to pan. Scroll or pinch to zoom.</p>
+    </div>
+  `;
+
+  const resetButton = document.createElement('button');
+  resetButton.className = 'mermaid-reset';
+  resetButton.type = 'button';
+  resetButton.textContent = 'Reset view';
+
+  const expandButton = document.createElement('button');
+  expandButton.className = 'mermaid-expand';
+  expandButton.type = 'button';
+  expandButton.textContent = 'Full screen';
+
+  const actions = document.createElement('div');
+  actions.className = 'mermaid-actions';
+  actions.append(expandButton, resetButton);
+  chrome.append(actions);
+
+  const surface = document.createElement('div');
+  surface.className = 'mermaid-surface';
+
+  const canvas = document.createElement('div');
+  canvas.className = 'mermaid-canvas';
+  canvas.innerHTML = `<div class="mermaid">${source}</div>`;
+  surface.append(canvas);
+
+  wrapper.append(chrome, surface);
+  block.replaceWith(wrapper);
+
+  try {
+    const { svg } = await mermaid.render(`sam-diagram-${index}`, source);
+    canvas.innerHTML = svg;
+
+    const svgElement = canvas.querySelector<SVGElement>('svg');
+    if (!svgElement) {
+      continue;
+    }
+
+    svgElement.removeAttribute('width');
+    svgElement.removeAttribute('height');
+    svgElement.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+    svgElement.setAttribute('role', 'img');
+    svgElement.setAttribute('aria-label', `Diagram for ${title}`);
+    const controls = attachPanZoom(surface, svgElement);
+    resetButton.addEventListener('click', controls.reset);
+    expandButton.addEventListener('click', () => {
+      wrapper.classList.toggle('is-fullscreen');
+      document.body.classList.toggle(
+        'mermaid-fullscreen-open',
+        wrapper.classList.contains('is-fullscreen')
+      );
+      expandButton.textContent = wrapper.classList.contains('is-fullscreen')
+        ? 'Close full screen'
+        : 'Full screen';
+      controls.reset();
+    });
+
+    wrapper.addEventListener('click', (event) => {
+      if (
+        wrapper.classList.contains('is-fullscreen') &&
+        event.target === wrapper
+      ) {
+        wrapper.classList.remove('is-fullscreen');
+        document.body.classList.remove('mermaid-fullscreen-open');
+        expandButton.textContent = 'Full screen';
+        controls.reset();
+      }
+    });
+  } catch (error) {
+    wrapper.classList.add('mermaid-shell--error');
+    surface.innerHTML = `
+      <div class="mermaid-error">
+        <strong>Mermaid failed to render.</strong>
+        <pre>${String(error)}</pre>
+      </div>
+    `;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,7 +419,13 @@ importers:
       astro:
         specifier: 5.17.3
         version: 5.17.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.56.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      mermaid:
+        specifier: 11.14.0
+        version: 11.14.0
     devDependencies:
+      esbuild:
+        specifier: 0.25.12
+        version: 0.25.12
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -6830,9 +6836,6 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
-  mlly@1.8.0:
-    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
-
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
@@ -8961,7 +8964,7 @@ snapshots:
     dependencies:
       '@astrojs/markdown-remark': 6.3.10
       '@mdx-js/mdx': 3.1.1
-      acorn: 8.15.0
+      acorn: 8.16.0
       astro: 5.17.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.56.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
@@ -9803,7 +9806,7 @@ snapshots:
       '@commitlint/types': 19.8.1
       git-raw-commits: 4.0.0
       minimist: 1.2.8
-      tinyexec: 1.0.2
+      tinyexec: 1.1.1
 
   '@commitlint/resolve-extends@19.8.1':
     dependencies:
@@ -10639,7 +10642,7 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdx': 2.0.13
-      acorn: 8.15.0
+      acorn: 8.16.0
       collapse-white-space: 2.1.0
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
@@ -10648,7 +10651,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.1(acorn@8.15.0)
+      recma-jsx: 1.0.1(acorn@8.16.0)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
       remark-mdx: 3.1.1
@@ -12289,13 +12292,13 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  acorn-import-attributes@1.9.5(acorn@8.15.0):
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
 
-  acorn-jsx@5.3.2(acorn@8.15.0):
+  acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
 
   acorn-walk@8.3.2: {}
 
@@ -13617,7 +13620,7 @@ snapshots:
   esast-util-from-js@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      acorn: 8.15.0
+      acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
@@ -13871,8 +13874,8 @@ snapshots:
 
   espree@9.6.1:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 3.4.3
 
   esprima@4.0.1: {}
@@ -13936,7 +13939,7 @@ snapshots:
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
 
   execa@5.1.1:
     dependencies:
@@ -14171,7 +14174,7 @@ snapshots:
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
       magic-string: 0.30.21
-      mlly: 1.8.0
+      mlly: 1.8.2
       rollup: 4.56.0
 
   flat-cache@3.2.0:
@@ -14709,8 +14712,8 @@ snapshots:
 
   import-in-the-middle@1.15.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-import-attributes: 1.9.5(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
       cjs-module-lexer: 1.4.3
       module-details-from-path: 1.0.4
 
@@ -15625,8 +15628,8 @@ snapshots:
 
   micromark-extension-mdxjs@3.0.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       micromark-extension-mdx-expression: 3.0.1
       micromark-extension-mdx-jsx: 3.0.2
       micromark-extension-mdx-md: 2.0.0
@@ -15881,13 +15884,6 @@ snapshots:
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.2
-
-  mlly@1.8.0:
-    dependencies:
-      acorn: 8.15.0
-      pathe: 2.0.3
-      pkg-types: 1.3.1
-      ufo: 1.6.3
 
   mlly@1.8.2:
     dependencies:
@@ -16294,7 +16290,7 @@ snapshots:
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
-      mlly: 1.8.0
+      mlly: 1.8.2
       pathe: 2.0.3
 
   playwright-core@1.59.1: {}
@@ -16560,10 +16556,10 @@ snapshots:
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  recma-jsx@1.0.1(acorn@8.15.0):
+  recma-jsx@1.0.1(acorn@8.16.0):
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0


### PR DESCRIPTION
## Summary
- restore the marketing-site mermaid preview work from the earlier session and add a sample architecture post
- render blog mermaid fences into an interactive shell with pan, zoom, reset, and full-screen controls
- fix the clipped inline viewport issue by sizing the interaction surface to the shell width and anchoring pan/zoom math to the rendered SVG bounds
- bundle the browser enhancer into `public/scripts/blog-mermaid.js` during website builds and load it only on posts that actually contain mermaid blocks

## Validation
- `pnpm --filter @simple-agent-manager/www build`
- Playwright screenshot audit against the local preview build at mobile `375x667` and desktop `1280x800`
- verified no horizontal overflow in either viewport
- screenshots saved in `.codex/tmp/playwright-screenshots/`

## Notes
- the fullscreen canvas still has unavoidable vertical empty space on portrait mobile because the architecture diagram is very wide; the main inline clipping/viewport bug is fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive Mermaid diagrams in blog posts with pan, zoom, and fullscreen capabilities.
  * "Reset view" and "Full screen" controls for diagram navigation.

* **Documentation**
  * New blog post describing the system architecture with an interactive flowchart visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->