### PR TITLE
fix: use Node 22 devcontainer image as default for lightweight workspaces

### DIFF
--- a/packages/vm-agent/internal/bootstrap/bootstrap_test.go
+++ b/packages/vm-agent/internal/bootstrap/bootstrap_test.go
@@ -872,7 +872,7 @@ func TestWriteDefaultDevcontainerConfigForLightweightModeOmitsFeatures(t *testin
 
 	configPath := filepath.Join(t.TempDir(), "default-devcontainer.json")
 	cfg := &config.Config{
-		DefaultDevcontainerImage:      "mcr.microsoft.com/devcontainers/base:ubuntu",
+		DefaultDevcontainerImage:      config.DefaultDevcontainerImage,
 		DefaultDevcontainerConfigPath: configPath,
 	}
 
@@ -895,8 +895,8 @@ func TestWriteDefaultDevcontainerConfigForLightweightModeOmitsFeatures(t *testin
 	if updateRemoteUserUID, ok := parsed["updateRemoteUserUID"].(bool); !ok || updateRemoteUserUID {
 		t.Fatalf("expected lightweight fallback config to disable updateRemoteUserUID, got:\n%s", string(data))
 	}
-	if img, _ := parsed["image"].(string); img != "mcr.microsoft.com/devcontainers/base:ubuntu" {
-		t.Errorf("expected image %q, got %q", "mcr.microsoft.com/devcontainers/base:ubuntu", img)
+	if img, _ := parsed["image"].(string); img != config.DefaultDevcontainerImage {
+		t.Errorf("expected image %q, got %q", config.DefaultDevcontainerImage, img)
 	}
 }
 

--- a/packages/vm-agent/internal/config/config.go
+++ b/packages/vm-agent/internal/config/config.go
@@ -27,9 +27,9 @@ const (
 )
 
 // DefaultDevcontainerImage is the default container image used when a repo has no devcontainer config.
-// Uses a lighter base image so fallback workspaces bootstrap quickly on modest nodes.
-// Override via DEFAULT_DEVCONTAINER_IMAGE env var.
-const DefaultDevcontainerImage = "mcr.microsoft.com/devcontainers/base:ubuntu"
+// Uses the Node 22 devcontainer image so lightweight workspaces have a compatible Node.js runtime
+// without a slow apt-get install step. Override via DEFAULT_DEVCONTAINER_IMAGE env var.
+const DefaultDevcontainerImage = "mcr.microsoft.com/devcontainers/typescript-node:22-bookworm"
 
 // DefaultDevcontainerConfigPath is where the VM agent writes the default devcontainer.json
 // when a repo has no devcontainer config. Override via DEFAULT_DEVCONTAINER_CONFIG_PATH env var.

--- a/packages/vm-agent/internal/provision/provision.go
+++ b/packages/vm-agent/internal/provision/provision.go
@@ -418,7 +418,7 @@ func installDevcontainerCLI(ctx context.Context) error {
 }
 
 func pullBaseImage(ctx context.Context) error {
-	return runShell(ctx, "docker pull mcr.microsoft.com/devcontainers/base:ubuntu")
+	return runShell(ctx, "docker pull "+config.DefaultDevcontainerImage)
 }
 
 func restartJournald() error {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Root cause:** `DefaultDevcontainerImage` was `mcr.microsoft.com/devcontainers/base:ubuntu`, which ships with no Node.js runtime. Lightweight/fallback workspaces (no repo devcontainer) triggered a slow `apt-get install nodejs npm` path that wedged sessions before Claude Code / Codex ACP adapters could connect.
- **Fix:** Change `DefaultDevcontainerImage` to `mcr.microsoft.com/devcontainers/typescript-node:22-bookworm`, which ships Node 22 out of the box.
- **Aligned pre-pull:** `pullBaseImage()` was hardcoding the old ubuntu image; it now references `config.DefaultDevcontainerImage` so nodes pre-cache the image they will actually use.
- **Test update:** `TestWriteDefaultDevcontainerConfigForLightweightModeOmitsFeatures` now sets and asserts against `config.DefaultDevcontainerImage` rather than the old hardcoded string, so it stays correct if the default changes again.

The `DEFAULT_DEVCONTAINER_IMAGE` env-var override is unchanged — operators who need a different image are unaffected.

## Files changed

| File | Change |
|------|--------|
| `packages/vm-agent/internal/config/config.go` | `DefaultDevcontainerImage` const → `typescript-node:22-bookworm` |
| `packages/vm-agent/internal/provision/provision.go` | `pullBaseImage()` uses `config.DefaultDevcontainerImage` instead of hardcoded string |
| `packages/vm-agent/internal/bootstrap/bootstrap_test.go` | Lightweight mode test uses constant, not hardcoded ubuntu string |

## Immediate mitigation (already possible without deploying)

Set `DEFAULT_DEVCONTAINER_IMAGE=mcr.microsoft.com/devcontainers/typescript-node:22-bookworm` in the deployed VM agent environment to stop new lightweight workspaces from hitting the broken apt path before this PR lands.

## Test plan

- [x] `go test ./internal/bootstrap/... -run TestWriteDefaultDevcontainerConfig` — all 8 sub-tests pass
- [x] `go build ./...` — no compile errors
- [ ] Deploy to staging with fresh nodes (delete existing nodes first per rule 27) and verify a lightweight workspace (no devcontainer in repo) boots and the agent connects successfully

## Agent preflight

**Change class:** `infra-change`, `business-logic-change`  
**Impact:** Lightweight workspace boot path. Node 22 image is a superset of the ubuntu base (adds Node.js/npm/TypeScript toolchain). No API surface changes. Existing workspaces that specify their own devcontainer are unaffected.  
**Constitution Principle XI:** `DefaultDevcontainerImage` is already overridable via `DEFAULT_DEVCONTAINER_IMAGE` env var — no hardcoded value violation introduced.

https://claude.ai/code/session_01FHE9rs3XkBSKFE5CM1hAxd
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHE9rs3XkBSKFE5CM1hAxd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default development container image to include Node.js 22 runtime, replacing the lightweight base image with a more feature-rich development environment.
  * Aligned configuration and provisioning workflows to consistently reference the updated default container image.
  * Updated tests for compatibility with the new default image configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->