### PR TITLE
Show infrastructure nav to all users

### DIFF
--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -87,14 +87,13 @@ export function AppShell({ children }: AppShellProps) {
   }, [isSuperadmin]);
 
   const mobileInfraSection = useMemo(() => {
-    if (!isSuperadmin) return undefined;
     return {
       items: [
         { label: 'Nodes', path: '/nodes', icon: <Server size={18} /> },
         { label: 'Workspaces', path: '/workspaces', icon: <Monitor size={18} /> },
       ],
     };
-  }, [isSuperadmin]);
+  }, []);
 
   const handleProjectNavigate = useCallback(
     (path: string) => {

--- a/apps/web/src/components/NavSidebar.tsx
+++ b/apps/web/src/components/NavSidebar.tsx
@@ -189,45 +189,42 @@ export function NavSidebar({ className, projectName, showGlobalNav, onToggleGlob
               );
             })}
 
-            {/* Infrastructure section — superadmin only */}
-            {isSuperadmin && (
-              <div className="mt-2">
-                <button
-                  onClick={() => setInfraOpen(!infraOpen)}
-                  className={`flex items-center gap-2 w-full px-3 py-2 rounded-sm bg-transparent border-none text-xs font-semibold text-fg-muted uppercase tracking-wider cursor-pointer hover:text-fg-primary hover:bg-surface-hover transition-all duration-150 ${FOCUS_RING}`}
-                  aria-expanded={infraOpen}
-                  aria-controls="infra-nav-panel"
-                >
-                  {infraOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-                  Infrastructure
-                </button>
-                {infraOpen && (
-                  <div id="infra-nav-panel" className="flex flex-col gap-1">
-                    {[
-                      { label: 'Nodes', path: '/nodes', icon: <Server size={18} /> },
-                      { label: 'Workspaces', path: '/workspaces', icon: <Monitor size={18} /> },
-                    ].map((item) => {
-                      const active = isActive(item.path, location.pathname);
-                      return (
-                        <Link
-                          key={item.path}
-                          to={item.path}
-                          aria-current={active ? 'page' : undefined}
-                          className={`flex items-center gap-3 px-3 py-2 ml-2 rounded-sm no-underline text-sm font-medium transition-all duration-150 ${FOCUS_RING} ${
-                            active
-                              ? 'text-accent bg-surface-hover'
-                              : 'text-fg-muted hover:text-fg-primary hover:bg-surface-hover'
-                          }`}
-                        >
-                          {item.icon}
-                          {item.label}
-                        </Link>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-            )}
+            <div className="mt-2">
+              <button
+                onClick={() => setInfraOpen(!infraOpen)}
+                className={`flex items-center gap-2 w-full px-3 py-2 rounded-sm bg-transparent border-none text-xs font-semibold text-fg-muted uppercase tracking-wider cursor-pointer hover:text-fg-primary hover:bg-surface-hover transition-all duration-150 ${FOCUS_RING}`}
+                aria-expanded={infraOpen}
+                aria-controls="infra-nav-panel"
+              >
+                {infraOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                Infrastructure
+              </button>
+              {infraOpen && (
+                <div id="infra-nav-panel" className="flex flex-col gap-1">
+                  {[
+                    { label: 'Nodes', path: '/nodes', icon: <Server size={18} /> },
+                    { label: 'Workspaces', path: '/workspaces', icon: <Monitor size={18} /> },
+                  ].map((item) => {
+                    const active = isActive(item.path, location.pathname);
+                    return (
+                      <Link
+                        key={item.path}
+                        to={item.path}
+                        aria-current={active ? 'page' : undefined}
+                        className={`flex items-center gap-3 px-3 py-2 ml-2 rounded-sm no-underline text-sm font-medium transition-all duration-150 ${FOCUS_RING} ${
+                          active
+                            ? 'text-accent bg-surface-hover'
+                            : 'text-fg-muted hover:text-fg-primary hover:bg-surface-hover'
+                        }`}
+                      >
+                        {item.icon}
+                        {item.label}
+                      </Link>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
 
             {/* Project list — in global panel within project context */}
             {projectListSection}
@@ -263,45 +260,42 @@ export function NavSidebar({ className, projectName, showGlobalNav, onToggleGlob
         );
       })}
 
-      {/* Infrastructure section — superadmin only */}
-      {isSuperadmin && (
-        <div className="mt-2">
-          <button
-            onClick={() => setInfraOpen(!infraOpen)}
-            className={`flex items-center gap-2 w-full px-3 py-2 rounded-sm bg-transparent border-none text-xs font-semibold text-fg-muted uppercase tracking-wider cursor-pointer hover:text-fg-primary hover:bg-surface-hover transition-all duration-150 ${FOCUS_RING}`}
-            aria-expanded={infraOpen}
-            aria-controls="infra-nav-panel"
-          >
-            {infraOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-            Infrastructure
-          </button>
-          {infraOpen && (
-            <div id="infra-nav-panel" className="flex flex-col gap-1">
-              {[
-                { label: 'Nodes', path: '/nodes', icon: <Server size={18} /> },
-                { label: 'Workspaces', path: '/workspaces', icon: <Monitor size={18} /> },
-              ].map((item) => {
-                const active = isActive(item.path, location.pathname);
-                return (
-                  <Link
-                    key={item.path}
-                    to={item.path}
-                    aria-current={active ? 'page' : undefined}
-                    className={`flex items-center gap-3 px-3 py-2 ml-2 rounded-sm no-underline text-sm font-medium transition-all duration-150 ${FOCUS_RING} ${
-                      active
-                        ? 'text-accent bg-surface-hover'
-                        : 'text-fg-muted hover:text-fg-primary hover:bg-surface-hover'
-                    }`}
-                  >
-                    {item.icon}
-                    {item.label}
-                  </Link>
-                );
-              })}
-            </div>
-          )}
-        </div>
-      )}
+      <div className="mt-2">
+        <button
+          onClick={() => setInfraOpen(!infraOpen)}
+          className={`flex items-center gap-2 w-full px-3 py-2 rounded-sm bg-transparent border-none text-xs font-semibold text-fg-muted uppercase tracking-wider cursor-pointer hover:text-fg-primary hover:bg-surface-hover transition-all duration-150 ${FOCUS_RING}`}
+          aria-expanded={infraOpen}
+          aria-controls="infra-nav-panel"
+        >
+          {infraOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+          Infrastructure
+        </button>
+        {infraOpen && (
+          <div id="infra-nav-panel" className="flex flex-col gap-1">
+            {[
+              { label: 'Nodes', path: '/nodes', icon: <Server size={18} /> },
+              { label: 'Workspaces', path: '/workspaces', icon: <Monitor size={18} /> },
+            ].map((item) => {
+              const active = isActive(item.path, location.pathname);
+              return (
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  aria-current={active ? 'page' : undefined}
+                  className={`flex items-center gap-3 px-3 py-2 ml-2 rounded-sm no-underline text-sm font-medium transition-all duration-150 ${FOCUS_RING} ${
+                    active
+                      ? 'text-accent bg-surface-hover'
+                      : 'text-fg-muted hover:text-fg-primary hover:bg-surface-hover'
+                  }`}
+                >
+                  {item.icon}
+                  {item.label}
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </div>
 
       {/* Project list — in standalone global nav */}
       {projectListSection}

--- a/apps/web/tests/unit/AppShell.test.tsx
+++ b/apps/web/tests/unit/AppShell.test.tsx
@@ -77,16 +77,16 @@ describe('AppShell (global context)', () => {
     expect(screen.getByText('Settings')).toBeInTheDocument();
   });
 
-  it('does not show Nodes or Workspaces in primary nav for non-superadmins', () => {
-    renderAppShell();
-    expect(screen.queryByText('Nodes')).not.toBeInTheDocument();
-    expect(screen.queryByText('Workspaces')).not.toBeInTheDocument();
-  });
-
-  it('shows Infrastructure section for superadmins', () => {
-    mockAuthState = { ...mockAuthState, isSuperadmin: true };
+  it('shows Infrastructure section for non-superadmins', () => {
     renderAppShell();
     expect(screen.getByText('Infrastructure')).toBeInTheDocument();
+  });
+
+  it('expands Infrastructure to show Nodes and Workspaces in primary nav', () => {
+    renderAppShell();
+    fireEvent.click(screen.getByText('Infrastructure'));
+    expect(screen.getByText('Nodes')).toBeInTheDocument();
+    expect(screen.getByText('Workspaces')).toBeInTheDocument();
   });
 
   it('renders SAM branding', () => {
@@ -291,8 +291,7 @@ describe('AppShell (mobile)', () => {
     expect(within(drawer).getByText('Project')).toBeInTheDocument();
   });
 
-  it('shows Infrastructure section in mobile drawer for superadmins', () => {
-    mockAuthState = { ...mockAuthState, isSuperadmin: true };
+  it('shows Infrastructure section in mobile drawer for non-superadmins', () => {
     renderAppShell();
 
     fireEvent.click(screen.getByLabelText('Open navigation menu'));
@@ -301,7 +300,6 @@ describe('AppShell (mobile)', () => {
   });
 
   it('expands Infrastructure to show Nodes and Workspaces in mobile drawer', () => {
-    mockAuthState = { ...mockAuthState, isSuperadmin: true };
     renderAppShell();
 
     fireEvent.click(screen.getByLabelText('Open navigation menu'));
@@ -309,15 +307,6 @@ describe('AppShell (mobile)', () => {
 
     expect(screen.getByRole('button', { name: 'Nodes' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Workspaces' })).toBeInTheDocument();
-  });
-
-  it('does not show Infrastructure in mobile drawer for non-superadmins', () => {
-    mockAuthState = { ...mockAuthState, isSuperadmin: false };
-    renderAppShell();
-
-    fireEvent.click(screen.getByLabelText('Open navigation menu'));
-
-    expect(screen.queryByText('Infrastructure')).not.toBeInTheDocument();
   });
 
   it('renders sign out with icon in mobile drawer', () => {
@@ -351,16 +340,13 @@ describe('AppShell (mobile)', () => {
     expect(screen.queryByRole('dialog', { name: 'Navigation menu' })).not.toBeInTheDocument();
   });
 
-  it('shows Infrastructure in toggled global view when superadmin is inside a project', () => {
-    mockAuthState = { ...mockAuthState, isSuperadmin: true };
+  it('shows Infrastructure in toggled global view when non-superadmin is inside a project', () => {
     renderAppShell('/projects/proj-123/chat');
 
     fireEvent.click(screen.getByLabelText('Open navigation menu'));
+    fireEvent.click(screen.getByTestId('mobile-nav-toggle'));
 
-    // Infrastructure is in the global nav panel (hidden by default)
-    // It becomes visible when the user toggles to global nav
-    const toggleBtn = screen.getByTestId('mobile-nav-toggle');
-    expect(toggleBtn).toBeInTheDocument();
+    expect(screen.getByText('Infrastructure')).toBeInTheDocument();
   });
 
   it('closes the drawer when backdrop is clicked', () => {


### PR DESCRIPTION
## Summary
- Show the Infrastructure navigation section to all authenticated users on desktop and mobile
- Keep Admin navigation entries superadmin-only
- Update AppShell unit tests for the new non-superadmin visibility behavior

## Verification
- `git diff --check`
- Focused local test was attempted with `pnpm --filter @simple-agent-manager/web test -- AppShell.test.tsx`, but this workspace has no `node_modules` and `vitest` is unavailable. CI should run with dependencies installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Infrastructure navigation section with Nodes and Workspaces menu items is now universally accessible to all users
  * Available across both desktop sidebar and mobile menu layouts in all application contexts
  * Includes consistent access in project-level and global views for infrastructure management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/raphaeltm/simple-agent-manager/pull/994)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->