### PR TITLE
fix: prevent false stale node readiness gating

### DIFF
--- a/apps/api/src/durable-objects/task-runner/readiness.ts
+++ b/apps/api/src/durable-objects/task-runner/readiness.ts
@@ -24,5 +24,22 @@ export function isNodeAgentReadyForWorkspaceDispatch(
   }
 
   const freshnessFloor = waitStartedAtMs - freshnessSkewMs;
-  return heartbeatTime > freshnessFloor && readyTime > freshnessFloor;
+
+  // `/ready` is emitted once during VM agent startup, while heartbeats continue
+  // every few seconds after boot. In real provisioning flows, task-runner may
+  // enter `node_agent_ready` after `/ready` has already fired (for example, if
+  // post-provision bookkeeping or retries delay the poll loop). Gating strictly
+  // on a *fresh* `/ready` timestamp causes false negatives where the node is
+  // actually healthy and actively heartbeating.
+  //
+  // Readiness criteria:
+  // 1) heartbeat must be fresh relative to this task-runner wait window, and
+  // 2) `/ready` must exist and not be implausibly newer than heartbeat.
+  //
+  // Rule (2) preserves protection against mixed-cycle timestamps while allowing
+  // valid startup sequences where `/ready` is older than recent heartbeats.
+  const heartbeatIsFresh = heartbeatTime > freshnessFloor;
+  const readyNotAheadOfHeartbeat = readyTime <= heartbeatTime + freshnessSkewMs;
+
+  return heartbeatIsFresh && readyNotAheadOfHeartbeat;
 }

--- a/apps/api/tests/unit/durable-objects/task-runner-readiness.test.ts
+++ b/apps/api/tests/unit/durable-objects/task-runner-readiness.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { isNodeAgentReadyForWorkspaceDispatch } from '../../../src/durable-objects/task-runner/readiness';
+
+describe('isNodeAgentReadyForWorkspaceDispatch', () => {
+  it('accepts a fresh heartbeat even when /ready happened before the poll window', () => {
+    const waitStartedAt = Date.parse('2026-05-21T10:00:00.000Z');
+
+    const ready = isNodeAgentReadyForWorkspaceDispatch(
+      {
+        status: 'running',
+        health_status: 'healthy',
+        // /ready is sent once during VM agent startup and may predate the
+        // task-runner poll window if provisioning bookkeeping takes time.
+        agent_ready_at: '2026-05-21T09:58:10.000Z',
+        // Heartbeat is fresh relative to this task's wait start.
+        last_heartbeat_at: '2026-05-21T10:00:05.000Z',
+      },
+      waitStartedAt,
+    );
+
+    expect(ready).toBe(true);
+  });
+
+  it('rejects when heartbeat is stale even if /ready exists', () => {
+    const waitStartedAt = Date.parse('2026-05-21T10:00:00.000Z');
+
+    const ready = isNodeAgentReadyForWorkspaceDispatch(
+      {
+        status: 'running',
+        health_status: 'healthy',
+        agent_ready_at: '2026-05-21T09:50:00.000Z',
+        last_heartbeat_at: '2026-05-21T09:58:00.000Z',
+      },
+      waitStartedAt,
+    );
+
+    expect(ready).toBe(false);
+  });
+
+  it('rejects when /ready timestamp is ahead of heartbeat by more than skew budget', () => {
+    const waitStartedAt = Date.parse('2026-05-21T10:00:00.000Z');
+
+    const ready = isNodeAgentReadyForWorkspaceDispatch(
+      {
+        status: 'running',
+        health_status: 'healthy',
+        // Impossible ordering suggests mixed/stale timestamps from different cycles.
+        agent_ready_at: '2026-05-21T10:01:00.000Z',
+        last_heartbeat_at: '2026-05-21T10:00:05.000Z',
+      },
+      waitStartedAt,
+    );
+
+    expect(ready).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Tasks provisioning nodes intermittently stalled because readiness gating required a *fresh* `/ready` timestamp inside the task-runner poll window even though `/ready` is a one-time startup signal that can legitimately predate polling.
- This caused nodes to appear created in Hetzner but remain "stale"/stuck in `node_agent_ready` until timeout.

### Description
- Change readiness logic in `apps/api/src/durable-objects/task-runner/readiness.ts` to require a fresh heartbeat plus a sanity check that `/ready` is not implausibly ahead of the heartbeat, instead of requiring both timestamps to be fresh relative to the poll window.
- Add explanatory comments to `readiness.ts` documenting the race/timing rationale and the new readiness criteria.
- Add focused unit tests in `apps/api/tests/unit/durable-objects/task-runner-readiness.test.ts` that cover a fresh heartbeat with an older `/ready`, stale heartbeat rejection, and impossible `/ready`-ahead-of-heartbeat ordering.

### Testing
- Ran `pnpm --filter @simple-agent-manager/api test -- --run tests/unit/durable-objects/task-runner-readiness.test.ts`, and the new unit tests passed (3 tests, all green).
- Ran `pnpm --filter @simple-agent-manager/api lint`, which completed successfully (ESLint reported repository-wide warnings but no errors).
- Attempted `pnpm --filter @simple-agent-manager/api build`, which failed in this isolated workspace due to unresolved monorepo dependency/type resolution (e.g., `@simple-agent-manager/shared` missing), unrelated to the change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f182f200c832c801bc505e742b83a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved agent readiness determination logic to more accurately validate agent availability for task dispatch by better handling heartbeat timing and status updates
  * Added timing validation safeguards to detect inconsistent state ordering

* **Tests**
  * Added unit test coverage for agent readiness checks, including edge cases for stale heartbeats and timing anomalies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/raphaeltm/simple-agent-manager/pull/1092?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->