### PR TITLE
fix(api): prevent platform credential injection into tenant workspaces

### DIFF
--- a/apps/api/src/routes/workspaces/runtime.ts
+++ b/apps/api/src/routes/workspaces/runtime.ts
@@ -60,6 +60,14 @@ runtimeRoutes.post('/:id/agent-key', jsonValidator(AgentTypeBodySchema), async (
     workspace.projectId
   );
 
+  // SECURITY: Never return raw platform-managed credentials to tenant workspaces.
+  // Platform credentials are control-plane secrets and must only be used via
+  // SAM-mediated proxy flows (callback-token auth), not injected into tenant
+  // containers as env vars or auth files.
+  if (credentialData?.credentialSource === 'platform') {
+    credentialData = null;
+  }
+
   // Cloud provider credential fallback: if no dedicated agent key, check if the agent
   // definition specifies a cloud provider whose credential can be used instead.
   // Currently applies to OpenCode, which shares SCW_SECRET_KEY with Scaleway cloud.


### PR DESCRIPTION
### Motivation
- Close a privilege-separation bug where admin-managed platform agent credentials could be returned to the VM agent and injected into tenant devcontainers, allowing tenants to read/exfiltrate platform secrets.

### Description
- In `apps/api/src/routes/workspaces/runtime.ts` added a guard that nulls `credentialData` when `credentialSource === platform` to ensure raw platform-managed credentials are never returned to tenant workspaces.
- Added an explicit in-code security comment explaining that platform credentials are control-plane secrets and must be delivered only via SAM-mediated proxy flows (callback-token auth), not as environment variables or auth files in tenant containers.
- Preserved existing user credential behavior and existing AI-proxy/platform-proxy fallback flows so platform access remains available only via proxying rather than raw secret injection.

### Testing
- CI lint, type check, build, test, code quality, SonarCloud, and VM agent smoke checks passed on PR 1098.
- Reviewed git history for the credential path: PR #672 introduced platform credential fallback for zero-config onboarding; PR #695 added platform proxy fallback; PR #1073 added explicit SAM provider opt-in for Claude/Codex. This PR closes the remaining raw platform credential return path.

<!-- AGENT_PREFLIGHT_START -->
- [x] Preflight completed before code changes

### Classification
- [ ] external-api-change
- [ ] cross-component-change
- [x] business-logic-change
- [ ] public-surface-change
- [ ] docs-sync-change
- [x] security-sensitive-change
- [ ] ui-change
- [ ] infra-change

### External References
N/A: No external API or documentation behavior changed; review used local git history, PR diff, and existing credential flow code.

### Codebase Impact Analysis
Reviewed `apps/api/src/routes/workspaces/runtime.ts`, `apps/api/src/routes/credentials.ts`, and related credential fallback history. The change is limited to tenant-facing runtime agent credential delivery and preserves user/project credential injection plus callback-token platform proxy flows.

### Documentation & Specs
N/A: This is a narrow security fix to credential delivery behavior with no user-facing API or documentation contract change.

### Constitution & Risk Check
Checked credential isolation and no-hardcoded-values risk. The change removes raw platform secret exposure from tenant workspace delivery without adding new constants, secrets, URLs, or configuration values.
<!-- AGENT_PREFLIGHT_END -->

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f55d33404832c8e01041ba6693747)