### PR TITLE
fix(git-token): scope by repository name for legacy projects without repo id

### DIFF
--- a/apps/api/src/routes/workspaces/runtime.ts
+++ b/apps/api/src/routes/workspaces/runtime.ts
@@ -661,12 +661,14 @@ runtimeRoutes.post('/:id/git-token', async (c) => {
   let repoProvider = 'github';
   let artifactsRepoId: string | null = null;
   let githubRepoId: number | null = null;
+  let repositoryName: string | null = null;
   if (workspace.projectId) {
     const projectRows = await db
       .select({
         repoProvider: schema.projects.repoProvider,
         artifactsRepoId: schema.projects.artifactsRepoId,
         githubRepoId: schema.projects.githubRepoId,
+        repository: schema.projects.repository,
       })
       .from(schema.projects)
       .where(eq(schema.projects.id, workspace.projectId))
@@ -677,6 +679,7 @@ runtimeRoutes.post('/:id/git-token', async (c) => {
       repoProvider = project.repoProvider || 'github';
       artifactsRepoId = project.artifactsRepoId;
       githubRepoId = project.githubRepoId;
+      repositoryName = project.repository;
     }
   }
 
@@ -709,8 +712,16 @@ runtimeRoutes.post('/:id/git-token', async (c) => {
   if (!workspace.installationId) {
     throw errors.notFound('Workspace has no GitHub installation');
   }
-  if (!githubRepoId) {
-    throw errors.forbidden('GitHub repository ID is not verified for this workspace');
+  // Scope the token to a single repo. Prefer the verified numeric repo ID; fall
+  // back to the repository name for legacy projects created before github_repo_id
+  // was backfilled (PR #1236). Both paths scope to exactly one repository, so the
+  // personal-installation leak fix is preserved.
+  const repoShortName =
+    repositoryName && repositoryName.includes('/')
+      ? repositoryName.split('/').pop() ?? null
+      : repositoryName;
+  if (!githubRepoId && !repoShortName) {
+    throw errors.forbidden('GitHub repository is not verified for this workspace');
   }
 
   const installations = await db
@@ -742,7 +753,9 @@ runtimeRoutes.post('/:id/git-token', async (c) => {
   }
   const scopedTokenOptions = {
     ...(tokenOptions ?? {}),
-    repositoryIds: [githubRepoId],
+    ...(githubRepoId
+      ? { repositoryIds: [githubRepoId] }
+      : { repositories: [repoShortName as string] }),
   };
   const token = await getInstallationToken(
     getExternalInstallationId(installation),

--- a/apps/api/tests/unit/routes/workspace-git-token.test.ts
+++ b/apps/api/tests/unit/routes/workspace-git-token.test.ts
@@ -75,10 +75,29 @@ describe('workspace git-token GitHub scoping', () => {
     app.route('/ws', runtimeRoutes);
   });
 
-  it('rejects legacy GitHub workspaces without a verified repository id', async () => {
+  it('falls back to repository-name scoping for legacy projects without a repo id', async () => {
     limitResponses.push(
       [{ id: 'ws-1', installationId: 'inst-row-111', projectId: 'proj-1', userId: 'user-1' }],
-      [{ repoProvider: 'github', artifactsRepoId: null, githubRepoId: null }]
+      [{ repoProvider: 'github', artifactsRepoId: null, githubRepoId: null, repository: 'raph/sam' }],
+      [{ installationId: 'user-1:120081765', externalInstallationId: '120081765' }]
+    );
+
+    const res = await app.request('/ws/ws-1/git-token', { method: 'POST' }, mockEnv);
+
+    expect(res.status).toBe(200);
+    expect(getInstallationToken).toHaveBeenCalledWith('120081765', mockEnv, {
+      repositories: ['sam'],
+    });
+    await expect(res.json()).resolves.toEqual({
+      token: 'github-installation-token',
+      expiresAt: '2026-06-06T19:00:00.000Z',
+    });
+  });
+
+  it('rejects GitHub workspaces with neither a repo id nor a repository name', async () => {
+    limitResponses.push(
+      [{ id: 'ws-1', installationId: 'inst-row-111', projectId: 'proj-1', userId: 'user-1' }],
+      [{ repoProvider: 'github', artifactsRepoId: null, githubRepoId: null, repository: null }]
     );
 
     const res = await app.request('/ws/ws-1/git-token', { method: 'POST' }, mockEnv);
@@ -86,7 +105,7 @@ describe('workspace git-token GitHub scoping', () => {
     expect(res.status).toBe(403);
     await expect(res.json()).resolves.toEqual({
       error: 'FORBIDDEN',
-      message: 'GitHub repository ID is not verified for this workspace',
+      message: 'GitHub repository is not verified for this workspace',
     });
     expect(getInstallationToken).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
PR #1236 hardened the workspace git-token endpoint to scope GitHub
installation tokens to a verified numeric repository ID, fixing a leak
where personal installations could mint tokens for every repo in the
installation. But it hard-rejected (403) any project whose
github_repo_id was never backfilled, breaking gh/git push for every
legacy workspace.

Fall back to scoping by repository name when the numeric ID is absent.
getInstallationToken already supports the `repositories` (by-name)
option, and GitHub scopes a by-name token to exactly one repo within the
installation account, so the leak fix is fully preserved — only the
key changes (name vs id). No DB backfill required.

The previously-passing test that asserted the 403 is updated to assert
the name-scoping fallback; a new test covers the both-missing 403 guard.

https://claude.ai/code/session_0162H9RiM492Nf8Qwde126Ap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added fallback support for GitHub token scoping in legacy projects without repository IDs, improving compatibility for older workspace configurations.
  * Improved error messaging for GitHub workspace token verification failures for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->