### PR TITLE
Fix migrated cloud credential provider hydration

### DIFF
--- a/apps/api/src/services/composable-credentials/snapshot.ts
+++ b/apps/api/src/services/composable-credentials/snapshot.ts
@@ -90,6 +90,55 @@ function rowToConsumer(row: { consumerKind: string; consumerTarget: string }): C
     : { kind: 'compute', provider: row.consumerTarget };
 }
 
+function buildCloudProviderHints(configurations: CCConfiguration[]): Map<string, string> {
+  const providersByCredential = new Map<string, Set<string>>();
+
+  for (const configuration of configurations) {
+    if (configuration.consumer.kind !== 'compute' || !configuration.credentialId) continue;
+
+    const providers = providersByCredential.get(configuration.credentialId) ?? new Set<string>();
+    providers.add(configuration.consumer.provider);
+    providersByCredential.set(configuration.credentialId, providers);
+  }
+
+  const hints = new Map<string, string>();
+  for (const [credentialId, providers] of providersByCredential) {
+    if (providers.size === 1) {
+      const [provider] = providers;
+      if (provider) hints.set(credentialId, provider);
+    }
+  }
+
+  return hints;
+}
+
+/**
+ * Raw migrated Hetzner credentials carry no embedded provider in the encrypted
+ * token body. The provider identity lives on the compute configuration produced
+ * by legacy backfill, so recover it there when it is unambiguous.
+ */
+export function hydrateMissingCloudProviderSecretProviders(
+  credentials: CCCredential[],
+  configurations: CCConfiguration[],
+): CCCredential[] {
+  const providerHints = buildCloudProviderHints(configurations);
+
+  return credentials.map((credential) => {
+    const secret = credential.secret;
+    if (secret.kind !== 'cloud-provider' || secret.provider) {
+      return credential;
+    }
+
+    const provider = providerHints.get(credential.id);
+    if (!provider) return credential;
+
+    return {
+      ...credential,
+      secret: { ...secret, provider },
+    };
+  });
+}
+
 /**
  * Build a CompositionSnapshot for a user, optionally scoped to a project.
  * Decrypts all credential secrets.
@@ -140,7 +189,7 @@ export async function buildSnapshot(
       }
     }),
   );
-  const credentials: CCCredential[] = credentialResults.filter(
+  const parsedCredentials: CCCredential[] = credentialResults.filter(
     (c): c is CCCredential => c !== null,
   );
 
@@ -154,6 +203,11 @@ export async function buildSnapshot(
     settings: row.settingsJson ? safeParseJson(row.settingsJson, row.id) : {},
     isActive: row.isActive,
   }));
+
+  const credentials = hydrateMissingCloudProviderSecretProviders(
+    parsedCredentials,
+    configurations,
+  );
 
   // Map attachments
   const attachments: CCAttachment[] = attachRows.map((row) => ({

--- a/apps/api/tests/unit/composable-credentials-snapshot.test.ts
+++ b/apps/api/tests/unit/composable-credentials-snapshot.test.ts
@@ -1,0 +1,80 @@
+import type { CCConfiguration, CCCredential } from '@simple-agent-manager/shared';
+import { describe, expect, it } from 'vitest';
+
+import { hydrateMissingCloudProviderSecretProviders } from '../../src/services/composable-credentials/snapshot';
+
+function cloudCredential(overrides: Partial<CCCredential> = {}): CCCredential {
+  return {
+    id: 'cred-cloud',
+    ownerId: 'user-1',
+    name: 'Hetzner migrated',
+    kind: 'cloud-provider',
+    secret: { kind: 'cloud-provider', provider: '', token: 'raw-hetzner-token' },
+    isActive: true,
+    ...overrides,
+  };
+}
+
+function computeConfiguration(overrides: Partial<CCConfiguration> = {}): CCConfiguration {
+  return {
+    id: 'cfg-hetzner',
+    ownerId: 'user-1',
+    name: 'Hetzner compute',
+    consumer: { kind: 'compute', provider: 'hetzner' },
+    credentialId: 'cred-cloud',
+    settings: {},
+    isActive: true,
+    ...overrides,
+  };
+}
+
+describe('hydrateMissingCloudProviderSecretProviders', () => {
+  it('hydrates a raw migrated cloud-provider credential from its compute configuration', () => {
+    const [credential] = hydrateMissingCloudProviderSecretProviders(
+      [cloudCredential()],
+      [computeConfiguration()],
+    );
+
+    expect(credential.secret).toEqual({
+      kind: 'cloud-provider',
+      provider: 'hetzner',
+      token: 'raw-hetzner-token',
+    });
+  });
+
+  it('does not override an explicit provider from the decrypted secret', () => {
+    const [credential] = hydrateMissingCloudProviderSecretProviders(
+      [
+        cloudCredential({
+          secret: { kind: 'cloud-provider', provider: 'scaleway', token: 'scw-token' },
+        }),
+      ],
+      [computeConfiguration()],
+    );
+
+    expect(credential.secret).toEqual({
+      kind: 'cloud-provider',
+      provider: 'scaleway',
+      token: 'scw-token',
+    });
+  });
+
+  it('leaves the provider empty when one credential is referenced by multiple compute providers', () => {
+    const [credential] = hydrateMissingCloudProviderSecretProviders(
+      [cloudCredential()],
+      [
+        computeConfiguration(),
+        computeConfiguration({
+          id: 'cfg-scaleway',
+          consumer: { kind: 'compute', provider: 'scaleway' },
+        }),
+      ],
+    );
+
+    expect(credential.secret).toEqual({
+      kind: 'cloud-provider',
+      provider: '',
+      token: 'raw-hetzner-token',
+    });
+  });
+});

--- a/apps/api/tests/workers/composable-credentials-snapshot-resilience.test.ts
+++ b/apps/api/tests/workers/composable-credentials-snapshot-resilience.test.ts
@@ -25,6 +25,7 @@ import { encrypt } from '../../src/services/encryption';
 
 const TEST_PREFIX = `cc-snap-${Date.now()}`;
 const USER = `${TEST_PREFIX}-user`;
+const USER_RAW_HETZNER = `${TEST_PREFIX}-user-raw-hetzner`;
 const ADMIN = `${TEST_PREFIX}-admin`;
 const ENCRYPTION_KEY = 'SK4ihJazAK3GIWUQcM6nZ1odR6KQHrqRAVSp6HdPxrg=';
 const AGENT_SECRET = 'sk-test-anthropic-key-resilience';
@@ -34,7 +35,7 @@ let db: ReturnType<typeof drizzle>;
 beforeAll(async () => {
   db = drizzle(env.DATABASE, { schema });
 
-  for (const userId of [USER, ADMIN]) {
+  for (const userId of [USER, USER_RAW_HETZNER, ADMIN]) {
     await env.DATABASE.prepare(
       `INSERT OR IGNORE INTO users (id, github_id, email, name, created_at, updated_at)
        VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
@@ -74,6 +75,22 @@ async function seedPlatformCloudProvider(opts: {
     .run();
 }
 
+async function seedLegacyCloudProvider(opts: {
+  id: string;
+  userId: string;
+  provider: string;
+  secret: string;
+}) {
+  const { ciphertext, iv } = await encrypt(opts.secret, ENCRYPTION_KEY);
+  await env.DATABASE.prepare(
+    `INSERT OR IGNORE INTO credentials
+     (id, user_id, project_id, credential_type, credential_kind, agent_type, provider, encrypted_token, iv, is_active, created_at, updated_at)
+     VALUES (?, ?, NULL, 'cloud-provider', 'api-key', NULL, ?, ?, ?, 1, datetime('now'), datetime('now'))`,
+  )
+    .bind(opts.id, opts.userId, opts.provider, ciphertext, iv)
+    .run();
+}
+
 describe('snapshot resilience to raw cloud-provider platform defaults', () => {
   it('raw (non-JSON) hetzner platform token does not crash the snapshot', async () => {
     // Hetzner tokens are stored raw — not JSON. This is the exact row that
@@ -103,6 +120,53 @@ describe('snapshot resilience to raw cloud-provider platform defaults', () => {
       // provider never reaches the compute assembler (which throws on '').
       expect(hetznerDefault.credential.secret.provider).toBe('hetzner');
     }
+  });
+
+  it('raw migrated user Hetzner token hydrates provider from its compute configuration', async () => {
+    await seedLegacyCloudProvider({
+      id: `${TEST_PREFIX}-cred-user-raw-hetzner`,
+      userId: USER_RAW_HETZNER,
+      provider: 'hetzner',
+      secret: 'raw-user-hetzner-token-not-json-1234567890abcdef',
+    });
+
+    const { runBackfill } = await import(
+      '../../src/services/composable-credentials/backfill-service'
+    );
+    await runBackfill(db, { userId: USER_RAW_HETZNER });
+
+    const { buildSnapshot } = await import(
+      '../../src/services/composable-credentials/snapshot'
+    );
+    const snapshot = await buildSnapshot(db, USER_RAW_HETZNER, ENCRYPTION_KEY);
+    const computeConfig = snapshot.configurations.find(
+      (configuration) =>
+        configuration.consumer.kind === 'compute' &&
+        configuration.consumer.provider === 'hetzner',
+    );
+    expect(computeConfig).toBeDefined();
+
+    const credential = snapshot.credentials.find(
+      (candidate) => candidate.id === computeConfig?.credentialId,
+    );
+    expect(credential?.secret.kind).toBe('cloud-provider');
+    if (credential?.secret.kind === 'cloud-provider') {
+      expect(credential.secret.provider).toBe('hetzner');
+      expect(credential.secret.token).toBe(
+        'raw-user-hetzner-token-not-json-1234567890abcdef',
+      );
+    }
+
+    const { resolveComputeConfig } = await import(
+      '../../src/services/composable-credentials/resolve'
+    );
+    await expect(
+      resolveComputeConfig(db, USER_RAW_HETZNER, ENCRYPTION_KEY, 'hetzner'),
+    ).resolves.toMatchObject({
+      provider: 'hetzner',
+      token: 'raw-user-hetzner-token-not-json-1234567890abcdef',
+      isPlatform: false,
+    });
   });
 
   it('agent resolution still succeeds despite the raw cloud-provider default', async () => {


### PR DESCRIPTION
## Summary

Fixes the production `node_provisioning` failure:

```text
compute provider mismatch: requested hetzner, credential is 
```

Production evidence showed the legacy `credentials` rows were intact and all still had `provider = hetzner`, but the lazily backfilled `cc_credentials` row had no provider column. For raw/non-JSON Hetzner tokens, `buildSnapshot()` parsed the decrypted credential as `secret.provider = ""`, and the strict provider mismatch guard added in `01bd70da` rejected the credential before any Hetzner API call.

This change hydrates missing `cloud-provider` secret provider metadata from the unambiguous compute configuration that references the credential. Explicit embedded providers are not overridden, so real mismatches like Hetzner config + Scaleway secret remain rejected.

## Validation

Passed locally:

- `pnpm --filter @simple-agent-manager/api test -- composable-credentials-snapshot.test.ts composable-credentials-resolver.test.ts`
- `pnpm --filter @simple-agent-manager/api typecheck`
- `pnpm --filter @simple-agent-manager/api lint` (passes with existing warnings)
- `git diff --check`

Attempted Worker/D1 regression:

- Built missing local package deps: `pnpm --filter @simple-agent-manager/providers build`, `pnpm --filter @simple-agent-manager/cloud-init build`
- `pnpm --filter @simple-agent-manager/api exec vitest run --config vitest.workers.config.ts tests/workers/composable-credentials-snapshot-resilience.test.ts` reached `workerd` startup but failed with a local `workerd` signal 11 segmentation fault before executing tests. The D1-backed regression is included for CI.

## Production Impact

No evidence of DB data loss. The encrypted legacy and CC credential material remains present; this was provider metadata loss during snapshot materialization. Failed provisioning rows had no provider instance ID/IP, so no VM was created for those failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of migrated cloud-provider credentials so missing provider names are restored when the source is clear.
  * Preserved existing provider values and left ambiguous cases unchanged to avoid incorrect resolution.
  * Expanded support for legacy Hetzner credentials so snapshots now include the expected provider information and token data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->