### PR TITLE
Audit website claims against current capabilities

### DIFF
--- a/apps/www/src/components/Comparison.astro
+++ b/apps/www/src/components/Comparison.astro
@@ -23,14 +23,14 @@ const rows = [
   },
   {
     label: 'Control plane',
-    sam: 'Free (Cloudflare Workers)',
+    sam: 'Workers Paid base plan',
     managed: 'Bundled into pricing',
     selfHosted: 'You host it (K8s / Docker)',
     samWins: true,
   },
   {
     label: 'Infrastructure cost',
-    sam: '~$4–15/mo (direct to provider)',
+    sam: 'Cloud bill direct to provider',
     managed: 'From $20/mo (compute + inference)',
     selfHosted: 'Your cloud bill + license fees',
     samWins: true,

--- a/apps/www/src/content/docs/docs/concepts.mdx
+++ b/apps/www/src/content/docs/docs/concepts.mdx
@@ -10,6 +10,7 @@ import { Aside } from '@astrojs/starlight/components';
 A **workspace** is an AI coding environment: a Docker container running inside a VM, with your repository cloned and a devcontainer configured.
 
 Each workspace has:
+
 - A unique subdomain (`ws-{id}.example.com`)
 - A browser-based terminal (xterm.js over WebSocket)
 - An agent chat interface (via ACP — Agent Communication Protocol)
@@ -22,10 +23,10 @@ Workspaces are **ephemeral** — they're meant to be created for a coding sessio
 
 SAM supports two workspace profiles:
 
-| Profile | Startup Time | Description |
-|---------|-------------|-------------|
-| **Full** (default) | 2-3 minutes | Standard devcontainer build from your project's `.devcontainer` config |
-| **Lightweight** | 30-120 seconds faster | Skips devcontainer build, uses a minimal base image |
+| Profile            | Startup Time          | Description                                                            |
+| ------------------ | --------------------- | ---------------------------------------------------------------------- |
+| **Full** (default) | 2-3 minutes           | Standard devcontainer build from your project's `.devcontainer` config |
+| **Lightweight**    | 30-120 seconds faster | Skips devcontainer build, uses a minimal base image                    |
 
 Lightweight workspaces are ideal for quick conversations that don't need custom build steps. You can select the profile when starting an idea or creating a workspace.
 
@@ -38,6 +39,7 @@ https://ws-{workspaceId}--{port}.{baseDomain}
 ```
 
 For example, if your dev server starts on port 3000 in workspace `abc123`:
+
 ```
 https://ws-abc123--3000.example.com
 ```
@@ -49,6 +51,7 @@ The port scanner polls `/proc/net/tcp` inside the container every 5 seconds and 
 A **node** is a cloud VM that hosts one or more workspaces. When you create a workspace, SAM either assigns it to an existing healthy node or provisions a new one.
 
 Nodes have their own lifecycle:
+
 - `pending` → `creating` → `running` → `stopping` → `stopped`
 - Health is tracked via heartbeats from the VM Agent
 
@@ -63,7 +66,8 @@ SAM uses a three-layer defense against orphaned warm nodes:
 3. **Max lifetime** — absolute limit of 4 hours (configurable via `MAX_AUTO_NODE_LIFETIME_MS`) for auto-provisioned nodes
 
 <Aside type="tip">
-Warm node pooling only applies to nodes that were auto-provisioned for idea execution. Manually created nodes are not affected.
+  Warm node pooling only applies to nodes that were auto-provisioned for idea execution. Manually
+  created nodes are not affected.
 </Aside>
 
 ## Providers
@@ -72,48 +76,50 @@ A **provider** is a cloud infrastructure abstraction. SAM currently supports thr
 
 ### Hetzner Cloud
 
-| Size | Server Type | Specs | Monthly Cost |
-|------|------------|-------|-------------|
-| Small | CX23 | 2 vCPU, 4GB RAM, 40GB disk | ~$4/mo |
-| Medium | CX33 | 4 vCPU, 8GB RAM, 80GB disk | ~$7.50/mo |
-| Large | CX43 | 8 vCPU, 16GB RAM, 160GB disk | ~$14.50/mo |
+| Size   | Server Type | Specs                        | Monthly Cost |
+| ------ | ----------- | ---------------------------- | ------------ |
+| Small  | CX23        | 2 vCPU, 4GB RAM, 40GB disk   | ~$4/mo       |
+| Medium | CX33        | 4 vCPU, 8GB RAM, 80GB disk   | ~$7.50/mo    |
+| Large  | CX43        | 8 vCPU, 16GB RAM, 160GB disk | ~$14.50/mo   |
 
 **Locations**: Falkenstein (DE), Nuremberg (DE), Helsinki (FI), Ashburn (US), Hillsboro (US)
 
 ### Scaleway
 
-| Size | Server Type | Specs | Hourly Cost |
-|------|------------|-------|-------------|
-| Small | DEV1-M | 3 vCPU, 4GB RAM, 40GB disk | ~$0.024/hr |
-| Medium | DEV1-XL | 4 vCPU, 12GB RAM, 120GB disk | ~$0.048/hr |
-| Large | GP1-S | 8 vCPU, 32GB RAM, 600GB disk | ~$0.084/hr |
+| Size   | Server Type | Specs                        | Hourly Cost |
+| ------ | ----------- | ---------------------------- | ----------- |
+| Small  | DEV1-M      | 3 vCPU, 4GB RAM, 40GB disk   | ~$0.024/hr  |
+| Medium | DEV1-XL     | 4 vCPU, 12GB RAM, 120GB disk | ~$0.048/hr  |
+| Large  | GP1-S       | 8 vCPU, 32GB RAM, 600GB disk | ~$0.084/hr  |
 
 **Locations**: Paris (3 zones), Amsterdam (3 zones), Warsaw (2 zones)
 
 ### Google Cloud Platform (GCP)
 
-| Size | Machine Type | Specs | Monthly Cost |
-|------|------------|-------|-------------|
-| Small | e2-medium | 1 vCPU, 4GB RAM, 50GB disk | ~$25/mo |
-| Medium | e2-standard-2 | 2 vCPU, 8GB RAM, 50GB disk | ~$49/mo |
-| Large | e2-standard-4 | 4 vCPU, 16GB RAM, 50GB disk | ~$97/mo |
+| Size   | Machine Type  | Specs                       | Monthly Cost |
+| ------ | ------------- | --------------------------- | ------------ |
+| Small  | e2-medium     | 1 vCPU, 4GB RAM, 50GB disk  | ~$25/mo      |
+| Medium | e2-standard-2 | 2 vCPU, 8GB RAM, 50GB disk  | ~$49/mo      |
+| Large  | e2-standard-4 | 4 vCPU, 16GB RAM, 50GB disk | ~$97/mo      |
 
 **Locations**: Iowa (US), South Carolina (US), Oregon (US), Belgium (EU), Frankfurt (DE), London (GB), Singapore, Tokyo (JP)
 
 ### Provider Selection
 
-SAM follows a **Bring Your Own Cloud (BYOC)** model: you provide your own cloud provider API tokens through the Settings UI. The platform never stores cloud credentials as environment variables — all VM costs are billed directly to your account.
+SAM follows a **Bring Your Own Cloud (BYOC)** model: you provide your own cloud provider credentials through the Settings UI. The platform never stores cloud credentials as environment variables. When SAM uses your own cloud credential, VM costs are billed directly to your account.
 
 You can set a **default provider** per project. When executing an idea, the provider is selected in this order:
+
 1. Explicit override on submission
 2. Project default provider
-3. First available credential
+3. First available user or platform credential
 
 ## Projects
 
 A **project** links a GitHub repository to its workspaces, chat sessions, ideas, and activity. Projects are the primary organizational unit in SAM.
 
 Each project has:
+
 - A **chat-first interface** — the project page is a conversation view
 - An **Ideas board** — for tracking and organizing work
 - A **default VM size** and **default provider** for new workspaces
@@ -121,7 +127,8 @@ Each project has:
 - **Runtime configuration** — environment variables and files injected into workspaces
 
 <Aside type="note">
-Every ACP (agent) session must belong to a project. Workspaces without a project can only use PTY terminal sessions, not agent chat.
+  Every ACP (agent) session must belong to a project. Workspaces without a project can only use PTY
+  terminal sessions, not agent chat.
 </Aside>
 
 ## Ideas
@@ -130,17 +137,18 @@ An **idea** is how you describe work you want an AI agent to do. Ideas are the p
 
 Ideas progress through these stages:
 
-| Stage | Description |
-|-------|-------------|
-| **Exploring** | You're brainstorming — the idea is a draft |
-| **Ready** | The idea is defined and ready to execute |
-| **Executing** | An agent is actively working on it |
-| **Done** | The agent finished and created a PR |
-| **Parked** | The idea was cancelled or the execution failed |
+| Stage         | Description                                    |
+| ------------- | ---------------------------------------------- |
+| **Exploring** | You're brainstorming — the idea is a draft     |
+| **Ready**     | The idea is defined and ready to execute       |
+| **Executing** | An agent is actively working on it             |
+| **Done**      | The agent finished and created a PR            |
+| **Parked**    | The idea was cancelled or the execution failed |
 
 ### How Execution Works
 
 When you execute an idea from the chat interface:
+
 1. SAM generates a concise title from your message (via Workers AI)
 2. A descriptive branch name is created (`sam/...`)
 3. The runner selects or provisions a node (reusing warm nodes when available)
@@ -165,16 +173,17 @@ An **agent session** is an AI coding agent conversation running inside a workspa
 
 SAM supports six AI coding agents:
 
-| Agent | Provider | API Key Variable |
-|-------|----------|-----------------|
-| **Claude Code** | Anthropic | `ANTHROPIC_API_KEY` |
-| **OpenAI Codex** | OpenAI | `OPENAI_API_KEY` |
-| **Google Gemini** | Google | `GEMINI_API_KEY` |
-| **Mistral Vibe** | Mistral | `MISTRAL_API_KEY` |
-| **OpenCode** | Multiple inference providers | Varies by provider |
-| **Amp** | Sourcegraph | `AMP_API_KEY` |
+| Agent             | Provider                   | API Key Variable    |
+| ----------------- | -------------------------- | ------------------- |
+| **Claude Code**   | Anthropic                  | `ANTHROPIC_API_KEY` |
+| **OpenAI Codex**  | OpenAI                     | `OPENAI_API_KEY`    |
+| **Google Gemini** | Google                     | `GEMINI_API_KEY`    |
+| **Mistral Vibe**  | Mistral                    | `MISTRAL_API_KEY`   |
+| **OpenCode**      | OpenCode managed inference | `OPENCODE_API_KEY`  |
+| **Amp**           | Sourcegraph                | `AMP_API_KEY`       |
 
 Sessions support:
+
 - Streaming responses (real-time output as the agent works)
 - Multiple concurrent sessions per workspace (each in its own terminal tab)
 - Persistence across page refreshes (tabs restored from VM Agent SQLite)
@@ -189,24 +198,27 @@ See the [AI Agents guide](/docs/guides/agents/) and [Chat Features guide](/docs/
 
 SAM includes an in-app notification system with real-time delivery via WebSocket:
 
-| Type | Urgency | Trigger |
-|------|---------|---------|
-| `task_complete` | Medium | An idea finishes executing successfully |
-| `needs_input` | High | Agent is blocked and needs your decision |
-| `error` | High | Execution fails |
-| `progress` | Low | Agent reports incremental progress |
-| `session_ended` | Medium | Agent conversation turn completes |
-| `pr_created` | Medium | Agent creates a pull request |
+| Type            | Urgency | Trigger                                  |
+| --------------- | ------- | ---------------------------------------- |
+| `task_complete` | Medium  | An idea finishes executing successfully  |
+| `needs_input`   | High    | Agent is blocked and needs your decision |
+| `error`         | High    | Execution fails                          |
+| `progress`      | Low     | Agent reports incremental progress       |
+| `session_ended` | Medium  | Agent conversation turn completes        |
+| `pr_created`    | Medium  | Agent creates a pull request             |
 
 See the [Notifications guide](/docs/guides/notifications/) for full details.
 
 ## Authentication
 
 SAM uses a **GitHub App** for both OAuth login and repository access. The app needs:
+
 - **OAuth** — for user sign-in (BetterAuth handles session management)
 - **Contents: Read and write** — for cloning repos and pushing changes
 - **Email addresses: Read-only** — for user profile information
 
 <Aside type="caution">
-User credentials (cloud provider tokens, agent API keys) are encrypted at rest using AES-256-GCM. The encryption key is a platform secret managed by Pulumi — never share it or store it in source control.
+  User credentials (cloud provider credentials and agent credentials) are encrypted at rest using
+  AES-256-GCM. The encryption key is a platform secret managed by Pulumi — never share it or store
+  it in source control.
 </Aside>

--- a/apps/www/src/content/docs/docs/overview.mdx
+++ b/apps/www/src/content/docs/docs/overview.mdx
@@ -13,8 +13,9 @@ AI coding agents need real development environments — not sandboxes. SAM gives
 
 <CardGrid>
   <Card title="Bring Your Own Cloud" icon="cloud">
-    You provide your Hetzner, Scaleway, or GCP API token. VMs run on your infrastructure, billed to
-    your account. The platform never stores your cloud credentials as environment variables.
+    You connect Hetzner, Scaleway, or GCP cloud credentials. When you bring your own cloud, VMs run
+    on your infrastructure and are billed to your account. The platform never stores your cloud
+    credentials as environment variables.
   </Card>
   <Card title="Serverless Control Plane" icon="rocket">
     The API runs on Cloudflare Workers — zero infrastructure to manage. D1 for storage, KV for
@@ -33,8 +34,8 @@ AI coding agents need real development environments — not sandboxes. SAM gives
 ## How It Works
 
 1. **Sign in** with GitHub via the web UI
-2. **Add your cloud provider token** in Settings (Hetzner, Scaleway, or GCP)
-3. **Configure agent credentials** — add API keys for your preferred AI coding agents
+2. **Add your cloud provider credentials** in Settings (Hetzner, Scaleway, or GCP)
+3. **Configure agent credentials** for your preferred AI coding agents
 4. **Install the GitHub App** on your repositories
 5. **Create a project** — link a GitHub repo to start working
 6. **Describe your idea** — tell SAM what you want done; it provisions a VM, creates a workspace, and runs the agent autonomously


### PR DESCRIPTION
@raphaeltm weekly website claims audit is ready for review.

## Summary

| Area checked | Evidence | Result |
| --- | --- | --- |
| Supported agents | Compared homepage/docs agent lists against `packages/shared/src/agents.ts` and `/api/agents` catalog route | Confirmed six agents remain supported; updated OpenCode docs row to match `OPENCODE_API_KEY` and managed inference wording |
| Supported providers | Compared provider claims against `packages/shared/src/types/user.ts`, `packages/shared/src/constants/providers.ts`, `packages/providers/src/index.ts`, and `/api/providers/catalog` | Confirmed Hetzner, Scaleway, and GCP remain the supported compute providers; changed GCP-inclusive docs from token language to cloud credentials |
| Feature claims | Checked chat/task/workspace/deployment claims against task submission, provider resolution, notifications, TTS, file library, and deployment routes/services | Confirmed major claims remain accurate; clarified platform credential fallback in provider selection |
| Comparison table | Checked Cloudflare plan claim against self-hosting docs and current Worker config; checked managed-platform starting price against current Devin/Ona pricing pages | Removed Free-plan implication and fixed the provider-cost row so it no longer excludes GCP pricing |
| Roadmap | Compared complete/planned items against implementation areas for agents, providers, orchestration, CLI, and app deployments | No roadmap status changes needed |
| How It Works | Compared described flow against auth, credential setup, project/task submission, and PR workflow code | Updated credential wording; flow still matches current journey |

## Changes

- `apps/www/src/components/Comparison.astro`: replaced `Free (Cloudflare Workers)` with `Workers Paid base plan`, and removed the narrow `~$4-15/mo` infrastructure range.
- `apps/www/src/content/docs/docs/overview.mdx`: changed GCP-inclusive cloud setup wording from token/API-key wording to credentials.
- `apps/www/src/content/docs/docs/concepts.mdx`: aligned BYOC/provider selection wording with platform credential fallback and updated OpenCode credential details.

## Verification

- `pnpm --filter @simple-agent-manager/www build` passed.
- `pnpm exec prettier --check --parser mdx apps/www/src/content/docs/docs/overview.mdx apps/www/src/content/docs/docs/concepts.mdx` passed.
- `git diff --check` passed for the edited source files.

Note: local `git push` returned 403 for the available bot token, so I pushed the branch content through the GitHub connector contents API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified core concept docs around cloud credentials, provider selection, billing wording, agent setup, and authentication guidance.
  * Improved table formatting across several documentation sections for easier reading.
  * Updated the product overview to use clearer “cloud credentials” and “agent credentials” language in the setup flow.

* **Bug Fixes**
  * Refined comparison copy to better reflect current plan and infrastructure cost wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->