### PR TITLE
fix(ci): derive RESOURCE_PREFIX from BASE_DOMAIN in DO wall-time check

### DIFF
--- a/.github/workflows/do-wall-time.yml
+++ b/.github/workflows/do-wall-time.yml
@@ -44,6 +44,7 @@ jobs:
           CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
           TARGET_ENVIRONMENT: ${{ inputs.environment || 'production' }}
           RESOURCE_PREFIX: ${{ vars.RESOURCE_PREFIX }}
+          BASE_DOMAIN: ${{ vars.BASE_DOMAIN }}
           DO_WALL_TIME_SCRIPT_NAMES: ${{ vars.DO_WALL_TIME_SCRIPT_NAMES }}
           DO_WALL_TIME_NAMESPACE_IDS: ${{ vars.DO_WALL_TIME_NAMESPACE_IDS }}
           DO_WALL_TIME_OBJECT_NAMES: ${{ vars.DO_WALL_TIME_OBJECT_NAMES }}
@@ -67,8 +68,15 @@ jobs:
             *) echo "Unsupported target environment: $TARGET_ENVIRONMENT" >&2; exit 2 ;;
           esac
           if [ -z "$RESOURCE_PREFIX" ]; then
-            echo "RESOURCE_PREFIX GitHub Environment variable is required" >&2
-            exit 2
+            if [ -z "$BASE_DOMAIN" ]; then
+              echo "RESOURCE_PREFIX or BASE_DOMAIN GitHub Environment variable is required" >&2
+              exit 2
+            fi
+            # Derive from BASE_DOMAIN: 's' + first 6 hex chars of sha256.
+            # Must match infra/resources/config.ts derivePrefix() and the
+            # Compute Resource Prefix step in deploy-reusable.yml.
+            RESOURCE_PREFIX="s$(printf %s "$BASE_DOMAIN" | sha256sum | cut -c1-6)"
+            echo "Resource prefix (derived from $BASE_DOMAIN): $RESOURCE_PREFIX"
           fi
           if [ -z "$DO_WALL_TIME_SCRIPT_NAMES" ]; then
             export DO_WALL_TIME_SCRIPT_NAMES="${RESOURCE_PREFIX}-api-${TARGET_STACK}"


### PR DESCRIPTION
## Summary

- Fixes the Durable Object Wall-Time workflow so `RESOURCE_PREFIX` remains optional when `BASE_DOMAIN` is configured.
- Keeps existing explicit-prefix behavior: if `RESOURCE_PREFIX` is set, the workflow uses it unchanged.
- When `RESOURCE_PREFIX` is unset, derives the prefix from `BASE_DOMAIN` using SAM's deployment formula: `s` + first 6 lowercase hex chars of `sha256(BASE_DOMAIN)`.
- Source PR from external contributor defangdevs: https://github.com/raphaeltm/simple-agent-manager/pull/1825

Original contributor context: the nightly DO wall-time check previously hard-required `RESOURCE_PREFIX`, while deployment derives it from `BASE_DOMAIN` in `.github/workflows/deploy-reusable.yml` and `infra/resources/config.ts`.

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] Additional validation run: local shell/hash comparison confirmed `deploy-reusable.yml`, this workflow change, and `infra/resources/config.ts:derivePrefix()` all derive `sf209b3` for `BASE_DOMAIN=defanglabs.ca`.
- [x] Additional validation run: reviewed DefangLabs scheduled workflow failures. Run `31788941468` shows the missing-`RESOURCE_PREFIX` failure mode; run `31877008341` had `RESOURCE_PREFIX=sf209b3` and failed later on cron liveness, so the specific cited example is not itself a missing-prefix failure.
- [x] Additional validation run: local PR body evidence checks passed before pushing the refresh commit.
- [ ] If this PR changes candidate selection for a sweep/cron/alarm loop (WHERE clause, status set, join, or equivalent), expected candidate volume and worst-case per-candidate cost are stated in the summary or validation notes (see `.claude/rules/47-control-loop-io-budget.md`)

Candidate-selection note: N/A, this only resolves the target Worker script name used by the workflow when no explicit script-name override is configured.

## Staging Verification (REQUIRED for all code changes — merge-blocking)

All checkboxes below are mandatory for any PR that changes runtime code (`.ts`, `.tsx`, `.go`, etc.). Write `N/A: docs-only` ONLY if the PR contains zero runtime code changes. See `.claude/rules/13-staging-verification.md`.

- [ ] **Staging deployment green** — `Deploy Staging` workflow triggered manually and passed for this branch
- [ ] **Live app verified via Playwright** — logged into `app.sammy.party` (staging) using test credentials and actively tested the application
- [ ] **Existing workflows confirmed working** — navigated dashboard, projects, and settings; confirmed no regressions in core flows (pages load, data displays, navigation works, no new console errors)
- [ ] **New feature/fix verified on staging** — the specific changes in this PR work correctly on the live staging environment (describe what was tested below)
- [ ] Infrastructure verification completed — VM provisioned and heartbeat confirmed (required for changes to cloud-init, VM agent, DNS, TLS, scripts/deploy). Write `N/A: no infra changes` ONLY if the PR does not touch any infrastructure paths.
- [ ] Mobile and desktop verification notes added for UI changes

### Staging Verification Evidence

N/A: CI-workflow-only change with no runtime application surface. No staging deployment was run per maintainer instruction for this scoped PR-backlog task.

## UI Compliance Checklist (Required for UI changes)

- [ ] Mobile-first layout verified
- [ ] Accessibility checks completed
- [ ] Shared UI components used or exception documented
- [ ] Playwright visual audit run locally — mock data scenarios (normal, long text, empty, many items, error, special chars) tested at mobile (375x667) and desktop (1280x800); no horizontal overflow; screenshots in `.codex/tmp/playwright-screenshots/` (see `.claude/rules/17-ui-visual-testing.md`)

N/A: no UI files or user-facing UI behavior changed.

## End-to-End Verification (Required for multi-component changes)

- [ ] Data flow traced from user input to final outcome with code path citations (see `.claude/rules/10-e2e-verification.md`)
- [ ] Capability test exercises the complete happy path across system boundaries
- [ ] All spec/doc assumptions about existing behavior verified against code (not just "read the code")
- [ ] If any gap exists between automated test coverage and full E2E, manual verification steps documented below

### Data Flow Trace

N/A: single GitHub Actions workflow change. The relevant flow is: `.github/workflows/do-wall-time.yml` reads GitHub Environment variables, prefers `vars.RESOURCE_PREFIX`, otherwise hashes `vars.BASE_DOMAIN`, then builds `${RESOURCE_PREFIX}-api-${TARGET_STACK}` for the DO wall-time checker.

### Untested Gaps

N/A: no live staging run by explicit maintainer instruction. Validation is by source comparison, shell derivation checks, existing CI on the PR, and local evidence-check execution.

## Post-Mortem (Required for bug fix PRs)

### What broke

The DO Wall-Time workflow could fail before running the checker when `RESOURCE_PREFIX` was unset, even though normal deployments can derive the same identity from `BASE_DOMAIN`.

### Root cause

`.github/workflows/do-wall-time.yml` independently required `vars.RESOURCE_PREFIX` instead of reusing the deployment identity fallback already present in `.github/workflows/deploy-reusable.yml` and `infra/resources/config.ts`.

### Class of bug

Configuration contract drift between deployment workflows and operational check workflows.

### Why it wasn't caught

The wall-time workflow's environment validation was stricter than deployment validation, and the previous workflow did not have a local check covering the `BASE_DOMAIN` fallback path.

### Process fix included in this PR

N/A: scoped external contributor workflow fix. Existing repo preflight evidence checks caught the missing PR-template evidence before merge.

### Post-mortem file

N/A: no separate post-mortem file for this workflow-only external PR.

## Specialist Review Evidence (Required for agent-authored PRs)

N/A: external contributor PR; no local subagents were used for this scoped maintainer evidence update.

| Reviewer | Status | Outcome |
|----------|--------|---------|

## Exceptions (If any)

- Scope: CI workflow-only change.
- Rationale: Staging deployment is not useful for a GitHub Actions shell fallback and was explicitly not requested.
- Expiration: Applies only to PR #1825.

<!-- AGENT_PREFLIGHT_START -->

## Agent Preflight (Required)

- [x] Preflight completed before code changes

### Classification

- [ ] external-api-change
- [ ] cross-component-change
- [ ] business-logic-change
- [ ] public-surface-change
- [ ] docs-sync-change
- [ ] security-sensitive-change
- [ ] ui-change
- [x] infra-change

### External References

N/A: no external API behavior changed. Validation used local repo sources: `.github/workflows/deploy-reusable.yml` Compute Resource Prefix step, `infra/resources/config.ts:derivePrefix()`, `.github/workflows/do-wall-time.yml`, and DefangLabs workflow logs for runs `31788941468` and `31877008341`.

### Codebase Impact Analysis

Only `.github/workflows/do-wall-time.yml` changes. The workflow now accepts `vars.BASE_DOMAIN`, derives `RESOURCE_PREFIX` only when the explicit variable is empty, and still lets `DO_WALL_TIME_SCRIPT_NAMES` / `DO_CRON_LIVENESS_SCRIPT_NAMES` override script-name targeting.

### Documentation & Specs

N/A: CI workflow-only fix. No public docs or specs needed because the deployment identity contract already exists in the deploy workflow and infra helper.

### Constitution & Risk Check

Checked Principle XI / no hardcoded values. The change avoids adding a new required hardcoded prefix and keeps deployment identity derived from configured `BASE_DOMAIN`; main risk is divergence from deploy derivation, which was checked for hash input, lowercase hex output, `s` prefix, six-character length, and explicit `RESOURCE_PREFIX` precedence.

<!-- AGENT_PREFLIGHT_END -->
