### PR TITLE
ci: trigger CodeRabbit reviews for SAM bot PRs

### DIFF
--- a/.github/workflows/coderabbit-bot-review.yml
+++ b/.github/workflows/coderabbit-bot-review.yml
@@ -1,0 +1,32 @@
+name: CodeRabbit Bot PR Review
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - ready_for_review
+      - reopened
+
+permissions: {}
+
+concurrency:
+  group: coderabbit-bot-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  request-review:
+    name: Request CodeRabbit review
+    if: >-
+      github.event.pull_request.user.login == 'simple-agent-manager[bot]' &&
+      github.event.pull_request.draft == false &&
+      contains(github.event.pull_request.labels.*.name, 'coderabbit-review') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'coderabbit-review')
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Ask CodeRabbit to review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr comment "$PR_URL" --body '@coderabbitai review'


### PR DESCRIPTION
## Summary

Add a small `pull_request_target` workflow that bridges SAM bot-authored PRs to CodeRabbit through `github-actions[bot]`.

SAM already opts PRs into review by applying the `coderabbit-review` label after CI is green, but CodeRabbit skips `simple-agent-manager[bot]` as an ineligible bot author and ignores review commands posted by that bot. This workflow listens for the existing opt-in label and posts a fixed `@coderabbitai review` comment using the built-in `GITHUB_TOKEN`, so the command is authored by `github-actions[bot]` instead.

## Safety

- Does not check out PR code.
- Does not execute any PR-controlled content.
- Uses `pull_request_target` only to inspect event metadata and post a fixed comment.
- Repository-level permissions default to none; the job gets only `pull-requests: write`.
- Restricted to PRs authored by `simple-agent-manager[bot]` that already carry `coderabbit-review` and are not drafts.
- Does not trigger on every push; CodeRabbit's existing incremental-review setting remains responsible for follow-up commits.

## Validation

- Workflow YAML reviewed against the existing `.coderabbit.yaml` label-based opt-in flow.
- Existing `/do` behavior remains unchanged: it still applies `coderabbit-review` only after CI/non-CodeRabbit gates are satisfied.

## Rollout note

Because `pull_request_target` workflows execute from the base branch, this workflow cannot trigger itself until it is merged. The first meaningful test is the next SAM bot-authored PR (or an existing one after this lands and the label is re-applied).
