### PR TITLE
ci: trigger CodeRabbit reviews through human PAT

### DIFF
--- a/.claude/rules/25-review-merge-gate.md
+++ b/.claude/rules/25-review-merge-gate.md
@@ -6,9 +6,17 @@ If you run specialist local subagents during Phase 5 of the `/do` workflow, **ev
 
 ## Rule: CodeRabbit Must Agree Before Agent Merge
 
-For `/do` workflow PRs, once CI and every non-CodeRabbit gate are green, the agent MUST apply the `coderabbit-review` label with `gh pr edit <pr-number> --add-label coderabbit-review`. The PR is not merge-ready until all CodeRabbit feedback is implemented or explicitly reviewed and closed/resolved, and the latest CodeRabbit review has no unresolved feedback.
+For `/do` workflow PRs, once CI and every non-CodeRabbit gate are green, the agent MUST apply the `coderabbit-review` label with `gh pr edit <pr-number> --add-label coderabbit-review`. The label invokes `.github/workflows/coderabbit-bot-review.yml`, which posts the CodeRabbit command through the repository's human-scoped `CODERABBIT_REVIEW_PAT`. The PR is not merge-ready until all CodeRabbit feedback is implemented or explicitly reviewed and closed/resolved, and the latest CodeRabbit review has no unresolved feedback.
 
-This is an iterative gate: keep the `coderabbit-review` label on the PR so CodeRabbit performs incremental reviews for subsequent commits, then repeat until the agent and CodeRabbit agree there is no unresolved feedback. Do not use `@coderabbitai review` comments as the trigger for SAM bot-authored PRs. If CodeRabbit is unavailable, does not respond, or the agent cannot inspect whether feedback remains unresolved, add `needs-human-review` and do not self-merge.
+If the label-triggered workflow did not run, needs to be retried, or a fresh explicit review is required after fixes, agents MAY dispatch the same trusted workflow directly:
+
+```bash
+gh workflow run coderabbit-bot-review.yml --ref main -f pr_number=<pr-number>
+```
+
+Always dispatch the workflow from `main`; do not execute a workflow definition from the PR branch. Agents MUST NOT post `@coderabbitai review` directly with their own GitHub App token: CodeRabbit ignores bot-authored review commands. The workflow is the human-identity bridge.
+
+This is an iterative gate: keep the `coderabbit-review` label on the PR so CodeRabbit can perform incremental reviews for subsequent commits, and manually dispatch the workflow when an explicit fresh review is needed. Repeat until the agent and CodeRabbit agree there is no unresolved feedback. If CodeRabbit is unavailable, does not respond, or the agent cannot inspect whether feedback remains unresolved, add `needs-human-review` and do not self-merge.
 
 ### Why This Rule Exists
 

--- a/.github/workflows/coderabbit-bot-review.yml
+++ b/.github/workflows/coderabbit-bot-review.yml
@@ -6,27 +6,59 @@ on:
       - labeled
       - ready_for_review
       - reopened
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to request a CodeRabbit review for
+        required: true
+        type: number
 
 permissions: {}
 
 concurrency:
-  group: coderabbit-bot-review-${{ github.event.pull_request.number }}
+  group: coderabbit-review-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   request-review:
     name: Request CodeRabbit review
     if: >-
-      github.event.pull_request.user.login == 'simple-agent-manager[bot]' &&
-      github.event.pull_request.draft == false &&
-      contains(github.event.pull_request.labels.*.name, 'coderabbit-review') &&
-      (github.event.action != 'labeled' || github.event.label.name == 'coderabbit-review')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.user.login == 'simple-agent-manager[bot]' &&
+       github.event.pull_request.draft == false &&
+       contains(github.event.pull_request.labels.*.name, 'coderabbit-review') &&
+       (github.event.action != 'labeled' || github.event.label.name == 'coderabbit-review'))
     runs-on: ubuntu-24.04
-    permissions:
-      pull-requests: write
     steps:
-      - name: Ask CodeRabbit to review
+      - name: Resolve pull request
+        id: pr
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr comment "$PR_URL" --body '@coderabbitai review'
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            pr_number="$INPUT_PR_NUMBER"
+          else
+            pr_number="$EVENT_PR_NUMBER"
+          fi
+
+          gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json number,state --jq '
+            if .state != "OPEN" then error("PR is not open") else .number end
+          ' >/dev/null
+          echo "number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Ask CodeRabbit to review as Raphaël
+        env:
+          # Fine-grained PAT scoped to this repository. The PAT's human identity is
+          # intentional: CodeRabbit ignores review commands authored by GitHub Apps.
+          GH_TOKEN: ${{ secrets.CODERABBIT_REVIEW_PAT }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::error::CODERABBIT_REVIEW_PAT is not configured"
+            exit 1
+          fi
+
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body '@coderabbitai review'


### PR DESCRIPTION
## Summary

Fix the CodeRabbit bridge after PR #2064 proved that `github-actions[bot]` is still treated as a bot and its `@coderabbitai review` command is ignored.

- Post the CodeRabbit review command using `secrets.CODERABBIT_REVIEW_PAT`, so GitHub attributes the comment to Raphaël's human account.
- Keep the existing `coderabbit-review` label automation for SAM bot-authored PRs.
- Add `workflow_dispatch` with a required `pr_number` input so agents can explicitly request/retry a review.
- Update rule 25 so `/do` agents know how to invoke the trusted workflow instead of posting a bot-authored CodeRabbit command directly.

## Agent usage

```bash
gh workflow run coderabbit-bot-review.yml --ref main -f pr_number=<pr-number>
```

The `--ref main` requirement is intentional: the workflow containing the PAT must always execute the trusted definition from `main`, never a PR-controlled workflow definition.

## Required repository secret

Configure `CODERABBIT_REVIEW_PAT` as a fine-grained PAT owned by `raphaeltm`, restricted to `raphaeltm/simple-agent-manager`, with the minimum repository permission needed to comment on pull requests.

## Safety

- No checkout.
- No PR-controlled code is executed.
- The review body is fixed (`@coderabbitai review`); callers cannot supply arbitrary comment text.
- Manual dispatch accepts only a PR number.
- The PR is resolved and checked to be open before the PAT is used.
- Automatic dispatch remains restricted to non-draft PRs authored by `simple-agent-manager[bot]` carrying `coderabbit-review`.
- Workflow-level `GITHUB_TOKEN` permissions remain empty; the built-in token is used only for the read-only PR lookup.

## Validation / rollout

This cannot prove the PAT-authored CodeRabbit interaction until the workflow is on `main` and `CODERABBIT_REVIEW_PAT` is configured. After merge, a useful smoke test is:

```bash
gh workflow run coderabbit-bot-review.yml --ref main -f pr_number=2064
```

The resulting `@coderabbitai review` comment should be authored by `raphaeltm`, not `github-actions[bot]`.